### PR TITLE
Support archivable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # jats-dtd-entity-resolver-lib
 Journal Article Tag Suite Journal Publishing XML DTD library. A cache of the DTD files of various versions situated at https://jats.nlm.nih.gov/publishing/
 
-Includes the files for the Journal Article Tag Suite Journal Publishing DTD, and exposes an `EntityResolver` class for
+Includes the files for the Journal Article Tag Suite Journal Publishing DTD, Journal Archiving and Interchange Tag Set, and exposes an `EntityResolver` class for
 quick access to these resources without accessing the internet.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # jats-dtd-entity-resolver-lib
-Journal Article Tag Suite Journal Publishing XML DTD library. A cache of the DTD files of various versions situated at https://jats.nlm.nih.gov/publishing/
+Journal Article Tag Suite Journal Publishing/Archiving XML DTD library. A cache of the DTD files of various versions situated at https://jats.nlm.nih.gov/publishing/ and https://jats.nlm.nih.gov/archiving/
 
 Includes the files for the Journal Article Tag Suite Journal Publishing DTD, Journal Archiving and Interchange Tag Set, and exposes an `EntityResolver` class for
 quick access to these resources without accessing the internet.

--- a/src/main/java/no/universitetsforlaget/juridika/libraries/jats/dtd/entityresolver/JatsEntityResolver.java
+++ b/src/main/java/no/universitetsforlaget/juridika/libraries/jats/dtd/entityresolver/JatsEntityResolver.java
@@ -10,14 +10,21 @@ import org.xml.sax.SAXException;
 
 public class JatsEntityResolver implements EntityResolver {
   private static final String DTD_ENTRYPOINT = "JATS-journalpublishing1.dtd";
+  private static final String DTD_ARCHIVING_ENTRYPOINT_V1_2 = "JATS-archivearticle1.dtd";
 
   private static final String JATS_V1_1D1_PATH = "/dtd/niso-jats/1.1d1/";
   private static final String JATS_V1_1_PATH = "/dtd/niso-jats/1.1/";
+  private static final String JATS_ARCHIVING_V1_2_PATH = "/dtd/archiving/1.2/";
 
   private static final String JATS_V1_1D1_DTD_SYSTEM_ID =
       "http://jats.nlm.nih.gov/publishing/1.1d1/" + DTD_ENTRYPOINT;
   private static final String JATS_V1_1_DTD_SYSTEM_ID =
       "http://jats.nlm.nih.gov/publishing/1.1/" + DTD_ENTRYPOINT;
+  private static final String JATS_ARCHIVING_SYSTEM_ID =
+      "http://jats.nlm.nih.gov/archiving/1.2/";
+
+  private static final String JATS_ARCHIVING_PUBLIC_ID =
+      "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2 20190208//EN";
 
   public JatsEntityResolver() {
   }
@@ -30,7 +37,11 @@ public class JatsEntityResolver implements EntityResolver {
     } else if (JATS_V1_1_DTD_SYSTEM_ID.equals(systemId)) {
       final URL url = getClass().getResource(JATS_V1_1_PATH + DTD_ENTRYPOINT);
       return loadResource(url);
-    } else if (systemId.startsWith("file:/")) {
+    } else if (JATS_ARCHIVING_SYSTEM_ID.equals(systemId) || JATS_ARCHIVING_PUBLIC_ID.equals(publicId)) {
+      final URL url = getClass().getResource(JATS_ARCHIVING_V1_2_PATH + DTD_ARCHIVING_ENTRYPOINT_V1_2);
+      return loadResource(url);
+    }
+    else if (systemId.startsWith("file:/")) {
       return loadResource(new URL(systemId));
     } else {
       return StandardEntityResolver.getInstance().resolveEntity(publicId, systemId);

--- a/src/main/java/no/universitetsforlaget/juridika/libraries/jats/dtd/entityresolver/JatsEntityResolver.java
+++ b/src/main/java/no/universitetsforlaget/juridika/libraries/jats/dtd/entityresolver/JatsEntityResolver.java
@@ -9,21 +9,24 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 public class JatsEntityResolver implements EntityResolver {
-  private static final String DTD_ENTRYPOINT = "JATS-journalpublishing1.dtd";
-  private static final String DTD_ARCHIVING_ENTRYPOINT_V1_2 = "JATS-archivearticle1.dtd";
+  private static final String DTD_PUBLISHING_ENTRYPOINT = "JATS-journalpublishing1.dtd";
+  private static final String DTD_ARCHIVING_ENTRYPOINT = "JATS-archivearticle1.dtd";
 
-  private static final String JATS_V1_1D1_PATH = "/dtd/niso-jats/1.1d1/";
-  private static final String JATS_V1_1_PATH = "/dtd/niso-jats/1.1/";
+  private static final String JATS_PUBLISHING_V1_1D1_PATH = "/dtd/niso-jats/1.1d1/";
+  private static final String JATS_PUBLISHING_V1_1_PATH = "/dtd/niso-jats/1.1/";
   private static final String JATS_ARCHIVING_V1_2_PATH = "/dtd/archiving/1.2/";
 
-  private static final String JATS_V1_1D1_DTD_SYSTEM_ID =
-      "http://jats.nlm.nih.gov/publishing/1.1d1/" + DTD_ENTRYPOINT;
-  private static final String JATS_V1_1_DTD_SYSTEM_ID =
-      "http://jats.nlm.nih.gov/publishing/1.1/" + DTD_ENTRYPOINT;
-  private static final String JATS_ARCHIVING_SYSTEM_ID =
-      "http://jats.nlm.nih.gov/archiving/1.2/";
+  // `d` stands for draft, so 1.1d1 refers to a draft version
+  private static final String JATS_PUBLISHING_V1_1D1_DTD_SYSTEM_ID =
+      "http://jats.nlm.nih.gov/publishing/1.1d1/" + DTD_PUBLISHING_ENTRYPOINT;
+  private static final String JATS_PUBLISHING_V1_1_DTD_SYSTEM_ID =
+      "http://jats.nlm.nih.gov/publishing/1.1/" + DTD_PUBLISHING_ENTRYPOINT;
+  private static final String JATS_ARCHIVING_V1_2_SYSTEM_ID =
+      "http://jats.nlm.nih.gov/archiving/1.2/" + DTD_ARCHIVING_ENTRYPOINT;
 
-  private static final String JATS_ARCHIVING_PUBLIC_ID =
+  private static final String JATS_PUBLISHING_V1_1_PUBLIC_ID =
+      "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN";
+  private static final String JATS_ARCHIVING_V1_2_PUBLIC_ID =
       "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2 20190208//EN";
 
   public JatsEntityResolver() {
@@ -31,14 +34,14 @@ public class JatsEntityResolver implements EntityResolver {
 
   public InputSource resolveEntity(String publicId, String systemId)
       throws SAXException, IOException {
-    if (JATS_V1_1D1_DTD_SYSTEM_ID.equals(systemId)) {
-      final URL url = getClass().getResource(JATS_V1_1D1_PATH + DTD_ENTRYPOINT);
+    if (JATS_PUBLISHING_V1_1D1_DTD_SYSTEM_ID.equals(systemId)) {
+      final URL url = getClass().getResource(JATS_PUBLISHING_V1_1D1_PATH + DTD_PUBLISHING_ENTRYPOINT);
       return loadResource(url);
-    } else if (JATS_V1_1_DTD_SYSTEM_ID.equals(systemId)) {
-      final URL url = getClass().getResource(JATS_V1_1_PATH + DTD_ENTRYPOINT);
+    } else if (JATS_PUBLISHING_V1_1_DTD_SYSTEM_ID.equals(systemId) || JATS_PUBLISHING_V1_1_PUBLIC_ID.equals(publicId)) {
+      final URL url = getClass().getResource(JATS_PUBLISHING_V1_1_PATH + DTD_PUBLISHING_ENTRYPOINT);
       return loadResource(url);
-    } else if (JATS_ARCHIVING_SYSTEM_ID.equals(systemId) || JATS_ARCHIVING_PUBLIC_ID.equals(publicId)) {
-      final URL url = getClass().getResource(JATS_ARCHIVING_V1_2_PATH + DTD_ARCHIVING_ENTRYPOINT_V1_2);
+    } else if (JATS_ARCHIVING_V1_2_SYSTEM_ID.equals(systemId) || JATS_ARCHIVING_V1_2_PUBLIC_ID.equals(publicId)) {
+      final URL url = getClass().getResource(JATS_ARCHIVING_V1_2_PATH + DTD_ARCHIVING_ENTRYPOINT);
       return loadResource(url);
     }
     else if (systemId.startsWith("file:/")) {

--- a/src/main/resources/dtd/archiving/1.2/BITS-embedded-index2.ent
+++ b/src/main/resources/dtd/archiving/1.2/BITS-embedded-index2.ent
@@ -1,0 +1,323 @@
+<!-- ============================================================= -->
+<!--  MODULE:    BITS Embedded Index Element Module                -->
+<!--  VERSION:   BITS 2.1                                          -->
+<!--  DATE:      April 2018                                        -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD BITS Embedded Index Element Module v2.1 20180401//EN"
+Delivered as file "BITS-embedded-index2.ent"                       -->
+<!-- ============================================================= -->
+
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     Book Interchange Tag Suite                        -->
+<!--                                                               -->
+<!-- PURPOSE:    Defines the index terms to be embedded into the   -->
+<!--             narrative of a document so that an Index can be   -->
+<!--             created programmatically.                         -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This DTD was created as a superset customization  -->
+<!--             of the ANSI/NISO JATS Z39.96-2012 Version 1.0     -->
+<!--             Journal Article Tag Set.                          -->
+<!--                                                               -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of books or book-like        -->
+<!--             material for archiving and transferring           -->
+<!--             such material between archives or they may create -->
+<!--             a custom XML DTD from the BITS Suite for          -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and new DTD-specific customization   -->
+<!--             modules to redefine the many Parameter Entities.  -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the BITS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the Book Interchange Tag Suite (BITS).     -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the Book Interchange Tag Suite       -->
+<!--                    (BITS)."                                   -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             April 2012                                        -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the National      -->
+<!--             National Center for Biotechnology Information     -->
+<!--             (NCBI), a center of the US National Library of    -->
+<!--             Medicine (NLM).                                   -->
+<!--                                                               -->
+<!--             The BITS Book Interchange DTD is built from the   -->
+<!--             Journal Archiving and Interchange DTD of the      -->
+<!--             ANSI/NISO Journal Article Tag Suite (JATS)        -->
+<!--             Version 1.1d1 (Z39.96-2015).                      -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 bits@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+
+  4. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.     =============================================================
+     BITS Version 2.0                (DAL/BTU) v2.0  (2015-12-25)
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, and BITS modified to use
+     the most recent version. No other changes to BITS were made.
+ 
+  3. BITS remained version "2.0" but became "v2.0 20151225"
+     JATS became version "1.1" and "v1.1 20151215"
+
+    =============================================================
+     BITS Version 2.0                (DAL/BTU) v2.0  (2015-03-15)
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-03-01)
+
+     BITS was modified, based on user feedback collected in 2014 
+     and January/February 2015, according to the decisions
+     made by the BITS Working Group. This DTD represents current 
+     BITS and an interim version of the non-normative JATS DTD 
+     Suite (version 1.1), as an indication to JATS users of 
+     the decisions that have been made by the JATS Standing
+     Committee. 
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+
+  2. BITS became version "2.0" and   "v2.0 20150630"
+     JATS became version "1.1" and "v1.1 20150301"
+
+     =============================================================
+     BITS Version 1.1                (DAL/BTU) v1.1    (2014-09-30)
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2  (2014-09-30)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  1. BITS became version "1.1" and   "v1.1 20140930//EN"
+     JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+     =============================================================
+                                                                   -->
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    INDEX-TERM ATTRIBUTES                      -->
+<!--                    Attribute list for <index-term> element.
+                        Names the specific indexes in which this term
+                        should be used. Contains an index name or
+                        series of index names for an embedded
+                        index.                                     -->
+<!ENTITY % index-term-atts
+           "%jats-common-atts;
+             index-type NMTOKENS                          #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    INDEX-TERM RANGE END ATTRIBUTES            -->
+<!--                    Attribute list for <index-term-range-end>
+                        element.                                   -->
+<!ENTITY % index-term-range-end-atts
+           "%jats-common-atts;
+             rid        IDREF                             #REQUIRED" >
+
+
+<!--                    SEE ATTRIBUTES                             -->
+<!--                    Attribute list for <see> element.          -->
+<!ENTITY % see-atts
+           "%jats-common-atts;
+             rid        IDREFS                            #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SEE-ALSO ATTRIBUTES                        -->
+<!--                    Attribute list for <see-also> element.     -->
+<!ENTITY % see-also-atts
+           "%jats-common-atts;
+             rid        IDREFS                            #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    INDEX ELEMENTS                             -->
+<!-- ============================================================= -->
+
+
+<!--                    INDEX TERM MODEL                           -->
+<!--                    Content model for the embedded index term
+                        <index-term> element.                      -->
+<!ENTITY % index-term-model
+                        "(term,
+                          (index-term | (see | see-also)* ) )"       >
+
+
+<!--                    INDEX TERM                                 -->
+<!--                    The index term to be embedded into the
+                        narrative of a document so that an Index
+                        can be created programmatically. An
+                        <index-term> is either a single target point
+                        or the start of an index range. When it is the
+                        start of a range, an @id attribute is
+                        required, so that the <index-term-range-end>
+                        element can point to the start of the range.
+                        Details at:
+                        http://jats.nlm.nih.gov/extensions/bits/2.1/index.html?elem=index-term
+                                                                   -->
+<!ELEMENT index-term    %index-term-model;                           >
+<!ATTLIST index-term
+            %index-term-atts;                                        >
+
+
+<!--                    INDEX TERM RANGE END MODEL                 -->
+<!--                    Content model for the embedded index term
+                        <index-term> element.                      -->
+<!ENTITY % index-term-range-end-model
+                        "EMPTY"                                      >
+
+
+<!--                    INDEX TERM RANGE END                       -->
+<!--                    An index term embedded into the narrative
+                        of a document may be either a single point
+                        target or the start of a range. When the
+                        <index-term> is the start of a range, the
+                        @rid attribute of an <index-term-range-end>
+                        must point to the @id of the <index-term>.
+                        Remarks: This is an EMPTY element, since all
+                        the information naming the index term is
+                        already present in the <index-term> element
+                        to which this element points.
+                        Details at:
+                        http://jats.nlm.nih.gov/extensions/bits/2.1/index.html?elem=index-term-range-end
+                                                                   -->
+<!ELEMENT index-term-range-end
+                        %index-term-range-end-model;                 >
+<!ATTLIST index-term-range-end
+            %index-term-range-end-atts;                              >
+
+
+<!--                    SEE ELEMENTS                               -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <see> element.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % see-elements
+                        "%simple-phrase; | %block-math.class; |
+                         %simple-display-noalt.class;"               >
+
+
+<!--                    SEE                                        -->
+<!--                    Used in an embedded index entry to hold
+                        preferred terms that make "See" references
+                        in a generated index.
+                        Details at:
+                        http://jats.nlm.nih.gov/extensions/bits/2.1/index.html?elem=see
+                                                                   -->
+<!ELEMENT see           (#PCDATA %see-elements;)*                    >
+<!ATTLIST see
+            %see-atts;                                               >
+
+
+<!--                    SEE-ALSO ELEMENTS                          -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <see-also> element.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % see-also-elements
+                        "%simple-phrase; | %block-math.class; |
+                         %simple-display-noalt.class;"               >
+
+
+<!--                    SEE-ALSO TERM                              -->
+<!--                    Used in an embedded index entry to hold
+                        preferred terms that make "See Also"
+                        references in a generated index.
+                        Details at:
+                        http://jats.nlm.nih.gov/extensions/bits/2.1/index.html?elem=see-also
+                                                                   -->
+<!ELEMENT see-also      (#PCDATA %see-also-elements;)*               >
+<!ATTLIST see-also
+            %see-also-atts;                                          >
+
+
+<!-- ================== End BITS Embedded Index Elements ========= -->
+

--- a/src/main/resources/dtd/archiving/1.2/JATS-XHTMLtablesetup1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-XHTMLtablesetup1.ent
@@ -1,0 +1,587 @@
+<!-- ============================================================= -->
+<!--  MODULE:    XHTML Table Setup Module                          -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          --> 
+<!--  DATE:      February 2019                                     --> 
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite XHTML Table Setup Module v1.2 20190208//EN"
+     Delivered as file "JATS-XHTMLtablesetup1.ent"                 -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Provides the organization for using the XHTML 1.1 -->
+<!--             table model                                       -->
+<!--                                                               -->
+<!-- CONTAINS:   1) Invokes the inline style attribute module      -->
+<!--                  to pick up the "style" attribute             -->
+<!--             2) Overrides to standard parameter entities used  -->
+<!--                in the XHTML 1.1 table model                   -->
+<!--             3) Invokes the XHTML 1.1 table model              -->
+<!--                                                               -->
+<!-- MODULES REQUIRED:                                             -->
+<!--             1) XHTML inline style module                      -->
+<!--                  (-%xhtml-inlstyle-1.mod;)                    -->
+<!--             2) XHTML 1.1 table model (-%xhtml-table-1.mod;)   -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 21. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 20. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 19. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 18. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+    
+ 17. JATS became version "1.2d1" and "v1.2d1 20170631"
+ 
+    =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 16. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 15. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 14. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 13. TABLE ATTRIBUTES
+     - Added @specific-use to the attributes for <table>,
+       primarily for use when <table> is used inside <alternatives>.
+     - This entailed creating a new PE "additional-table-atts",
+       which is defined and called AFTER the full table setup,
+       so that XML tools that do not recognize a 2nd ATTLIST for
+       an element will lose only the @specific-use. This new PE
+       could also be sued to add other attributes to an XHTML-
+       inspired <table>.
+
+ 12. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 11. CAPTION ATTRIBUTES - This module has been changed to alter
+      the mechanism by which the @style attribute is associated 
+      with the element <caption>. 
+          Previously, the <caption> element's base attributes  
+      were declared in the JATS-display.ent module and additional 
+      attributes (in the published XHTML, only @style) for it 
+      were declared in the XHTML Table Module. The @style 
+      attribute is now declared with all the other <caption>
+      attributes in the  JATS-display.ent module, and the caption 
+      attributes in the XHTML table model have been set to IGNORE. 
+      This was done to prevent duplicate (harmless but annoying)
+      attribute warning messages. 
+                        
+           CAUTION: If your XHTML customization has added attributes
+                    by redefining the parameter entity 
+                            "Core.extra.attrib"
+                    you will need to uncomment the lines in this
+                    module that add that parameter entity to the
+                    contents of the <caption> attribute list.
+                    Otherwise, your new attributes will not be
+                    added to <caption>. When you uncomment this
+                    line, you will get a duplicative attribute
+                    warning message on the @style attribute,
+                    which you may ignore.  
+                    
+ 10. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added an attribute list to the parameter entity 
+     "Common.attrib".
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  5. OASIS NAMESPACE - Added the OASIS table namespace handling,
+     which, by default, places a namespace prefix of "oasis" on
+     the OASIS CALS Exchange Table Model.
+      - Added call to JATS-oasis-namespace.ent (which sets up
+          the OASIS namespace URI and the prefix "oasis")
+      - Added  %oasis.xmlns.attrib; attribute to <article>
+      - Altered the custom classes module to use the new
+         namespaced OASIS element names for <table> and <tbody>
+         (%otable.qname; and %otbody.qname;)
+     NOTE: The XHTML table material was not removed, so both table
+     models still work (using <table> and <oasis:table> respectively.
+   
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            --> 
+
+<!-- ============================================================= -->
+<!--                    SET UP FOR THE XHTML 1.1 TABLE MODULE      -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    THE XHTML TABLE STYLE ATTRIBUTE MODULE     -->
+<!-- ============================================================= -->
+
+
+<!--                    XHTML TABLE INLINE STYLE MODULE            -->
+<!--                    This module declares the 'style' attribute,
+                        used to support inline style markup for the
+                        <td> and <tr> elements. Copyright 1998-2005
+                        W3C (MIT, ERCIM, Keio), All Rights Reserved.
+                        Revision: $Id: xhtml-inlstyle-1.mod,v 4.0
+                        2001/04/02 22:42:49 altheim Exp $
+                        PUBLIC identifier
+                        "-//W3C//ENTITIES XHTML Inline Style 1.0//EN"
+                        SYSTEM identifier
+                "http://www.w3.org/MarkUp/DTD/xhtml-inlstyle-1.mod"-->
+%xhtml-inlstyle-1.mod;
+
+
+<!-- ============================================================= -->
+<!--                    DEFAULTS FOR TABLE ELEMENT NAMES           -->
+<!-- ============================================================= -->
+
+
+<!ENTITY % table.qname  "table"                                      >
+<!ENTITY % caption.qname
+                        "caption"                                    >
+<!ENTITY % thead.qname  "thead"                                      >
+<!ENTITY % tfoot.qname  "tfoot"                                      >
+<!ENTITY % tbody.qname  "tbody"                                      >
+<!ENTITY % colgroup.qname
+                        "colgroup"                                   >
+<!ENTITY % col.qname    "col"                                        >
+<!ENTITY % tr.qname     "tr"                                         >
+<!ENTITY % th.qname     "th"                                         >
+<!ENTITY % td.qname     "td"                                         >
+
+
+<!-- ============================================================= -->
+<!--                    DEFAULTS FOR DATATYPE PARAMETER ENTITIES   -->
+<!-- ============================================================= -->
+
+
+<!ENTITY % Text.datatype
+                        "CDATA"                                      >
+
+
+<!ENTITY % Number.datatype
+                        "CDATA"                                      >
+
+
+<!ENTITY % MultiLength.datatype
+                        "CDATA"                                      >
+
+
+<!ENTITY % Length.datatype
+                        "CDATA"                                      >
+
+
+<!ENTITY % Pixels.datatype
+                        "CDATA"                                      >
+
+
+<!ENTITY % Character.datatype
+                        "CDATA"                                      >
+
+
+<!-- ============================================================= -->
+<!--                    DEFAULTS FOR ATTRIBUTE PARAMETER ENTITIES  -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON ATTRIBUTES (used all over)          -->
+<!--         style      Defined in the PE -%Core.extra.attrib; and
+                        used to support inline style markup. This
+                        attribute is defined in the XHTML Table
+                        Inline Style Module called in with the PE:
+                           -%xhtml-inlstyle-1.mod
+                        which must be invoked before the attribute
+                        PE is used. 
+                        Warning: The definitions below will lead to
+                        the element <caption> having the attributes
+                        @id and @content-type defined twice. This is
+                        just a validity warning, not an error and 
+                        should be ignored.                         -->
+<!ENTITY % Common.attrib
+            "%jats-common-atts;
+             content-type
+                        CDATA                             #IMPLIED
+             %Core.extra.attrib;"                                    >
+
+
+<!-- ============================================================= -->
+<!--                    OVER-RIDES TO REMOVE CAPTION               -->
+<!-- ============================================================= -->
+
+
+<!--                   CAPTION FOR A TABLE                         -->
+<!--                   Modification of the standard XHMTL model
+                       Removed the definition of caption, so the
+                       element would not be multiply defined       -->
+<!ENTITY % caption.element
+                       "IGNORE"                                      >
+
+
+<!ENTITY % caption.attlist  
+                       "IGNORE"                                      >
+
+
+<!--                    CAPTION ATTRIBUTES                         -->
+<!--                    Attributes for <caption> element           -->
+<!--                    In the lines directly above this declaration,
+                        the attribute list for caption, as defined
+                        in the XHTML Table Model, has been removed
+                        using the IGNORE mechanism. This was done 
+                        to prevent duplicate (harmless but annoying)
+                        attribute warning messages. 
+                        
+                        CAUTION: If your XHTML customization has
+                        redefined the parameter entity 
+                                   "Core.extra.attrib"
+                        you will need to uncomment the lines
+                        below. You will get a duplicative attribute
+                        warning message on the @style attribute,
+                        which you may ignore.                      -->
+<!--
+<!ENTITY % caption-atts
+                        "%Core.extra.attrib;                         >
+-->
+            
+            
+<!-- ============================================================= -->
+<!--                    OVER-RIDES FOR CONTENT PARAMETER ENTITIES  -->
+<!-- ============================================================= -->
+
+
+<!--                   INLINE ELEMENTS                             -->
+<!--                   Modification of the standard XHMTL model
+                       for inline elements used in the <caption>
+                       Set to the null because the <caption>
+                       element is now inside the table wrapper,
+                       not inside the table, as the original XHTML
+                       table intended                              -->
+<!ENTITY % Inline.mix  ""                                            >
+
+
+<!--                   CONTENTS OF A TABLE CELL                    -->
+<!--                   Modification of the standard XHMTL model
+                       used for the content of tables cells <th>
+                       and <td>                                    -->
+<!ENTITY % Flow.mix    "%inside-cell;"                               >
+
+
+<!--                   CONTENTS OF A TABLE                         -->
+<!--                   Modification of the standard XHMTL model
+                       This has been modified from the XHTML model
+                       to remove the <caption> element from the
+                       <table> model, since in the JATS DTD Suite 
+                       modular library, the <caption> element is part  
+                       of the Table Wrapper <table-wrap> element. 
+                       No other changes were made to the XHTML table 
+                       content model.                              -->
+<!ENTITY % table.content
+     "( ( %col.qname;* | %colgroup.qname;* ),
+        ( ( %thead.qname;?, %tfoot.qname;?, %tbody.qname;+ ) |
+          ( %tr.qname;+ )
+        )
+      )"                                                             >
+
+
+<!-- ============================================================= -->
+<!--                    THE XHTML V1.1 TABLE INVOCATION            -->
+<!-- ============================================================= -->
+
+
+<!--                    XHTML TABLE MODEL                          -->
+<!--                    This module declares element types and
+                        attributes used to provide table markup
+                        similar to HTML 4, including features that
+                        enable better accessibility for non-visual
+                        user agents. This is the XHTML reformulation
+                        of HTML as a modular XML application.
+                        Copyright 1998-2005 W3C (MIT, ERCIM, Keio),
+                        All Rights Reserved.
+                        Revision: $Id: xhtml-table-1.mod,v 4.1
+                        2001/04/10 09:42:30 altheim Exp $ SMI
+                        PUBLIC identifier
+                        "-//W3C//ELEMENTS XHTML Tables 1.0//EN"
+                        SYSTEM identifier:
+                  "http://www.w3.org/MarkUp/DTD/xhtml-table-1.mod" -->
+%xhtml-table-1.mod;
+
+<!-- ============================================================= -->
+<!--                    ADDITIONAL ATTRIBUTE(S) FOR TABLE          -->
+<!-- ============================================================= -->
+
+<!ENTITY % additional-table-atts
+            "specific-use 
+                        CDATA                              #IMPLIED" >
+
+<!ATTLIST %table.qname;
+            %additional-table-atts;                                  >
+
+<!-- ================== End XHTML Table Setup Module ============= -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-ali-namespace1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-ali-namespace1.ent
@@ -1,0 +1,240 @@
+<!-- ============================================================= -->
+<!--  MODULE:    ALI Namespace Module (NISO RP-22-2015)            -->
+<!--             NISO Access License and Indicators (ALI)          -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS ALI Namespace Module v1.2 20190208//EN"
+     Delivered as file "JATS-ali-namespace1.ent"                   -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Establish the prefix for the NISO Access and      -->
+<!--             Indicators elements (prefix "ali:").              -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             February 2015                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Journal Archiving and Interchange DTD Suite.      -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+  6. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+  5. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+  4. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed. 
+
+   =============================================================
+     JATS Version 1.2d2 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d2  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+  3. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d2" and "v1.2d2 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+  2. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+    =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  1. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+
+     Details concerning ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/
+                                                                   -->
+<!-- ============================================================= -->
+<!--                    ALI NAMESPACE SETUP                        -->
+<!-- ============================================================= -->
+
+
+<!--                    NAME ALI NAMESPACE BASE URI                -->
+<!--                    Set the ALI namespace URI,as named in
+                        NISO RP-22-2015                            -->
+<!ENTITY % ali.xmlns   
+      "http://www.niso.org/schemas/ali/1.0/"                         >
+
+
+<!--                    NAME ALI NAMESPACE PREFIX                  -->
+<!--                    Set the namespace prefix for the ALI
+                        elements to the JATS-named prefix "ali". 
+                        Implementor's Note: This parameter entity
+                        should always be set, even if you need to turn
+                        off the namespace prefix.                  -->
+<!ENTITY % ali.prefix   "ali"                                        >
+
+
+<!--                    NAME OASIS NAMESPACE PREFIX                -->
+<!--                    Construct the ALI namespace prefix to be 
+                        used in the xmlns pseudo-attribute from:
+                          - the word "xmlns", 
+                          - a colon, and 
+                          - the prefix just defined in %ali.prefix;
+                                                                   -->
+<!ENTITY % ali.xmlns.attrname
+                        "xmlns:%ali.prefix;"                         >
+
+
+<!--                    DEFAULT ALI NAMESPACE                       -->
+<!--                    The default namespace to be used when
+                        calling in the ALI elements. This is set on 
+                        the article level as well as on the ALI
+                        elements themselves.
+                        Implementor's Note: The parameter entity is
+                        constructed from the parameter entities set 
+                        above.                                     -->
+<!ENTITY % ali.xmlns.attrib
+     "%ali.xmlns.attrname; 
+                        CDATA               #FIXED '%ali.xmlns;'"    >
+
+
+<!-- ================== End ALI Namespace Setup  ================= -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-archivearticle1.dtd
+++ b/src/main/resources/dtd/archiving/1.2/JATS-archivearticle1.dtd
@@ -1,0 +1,988 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Journal Archiving and Interchange DTD (MathML 2.0)-->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2 20190208//EN"
+     Delivered as file "JATS-archivearticle1.dtd"
+     Available at:
+     http://jats.nlm.nih.gov/archiving/1.2/JATS-archivearticle1.dtd
+                                                                   -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     Journal Archiving and Interchange DTD of the      --> 
+<!--             JATS DTD Suite                                    -->         
+<!--                                                               -->
+<!-- PURPOSE:    DTD to describe a full-text journal article       -->
+<!--                                                               -->
+<!--             The Journal Archiving and Interchange DTD is an   -->
+<!--             application of the ANSI/NISO Z39.96 JATS Journal  -->
+<!--             Article Tag Set. It describes journal articles    -->
+<!--             and some non-article material such as product     -->
+<!--             and book reviews for repository or interchange    -->
+<!--             purposes. It describes both the metadata for a    -->
+<!--             journal article and the  full content of          -->
+<!--             the article.                                      -->
+<!--                                                               -->
+<!--             This DTD was constructed using the modules in the -->
+<!--             JATS DTD Suite, using almost no customization.    -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This DTD was created from the JATS DTD Suite.     -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Archiving and Interchange DTD is      -->
+<!--             built from the JATS DTD Suite.                    -->
+<!--                                                               -->
+<!--             This DTD and the Suite are a continuation of      -->
+<!--             the work done by NCBI, Mulberry Technologies,     -->
+<!--             and Inera Inc. on the NLM Journal Archiving       -->
+<!--             and Interchange DTD Suite, which was originally   -->
+<!--             released in December, 2002.                       -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 33. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+ 
+ 32. @dtd-version becomes "1.2d" from "1.2d2"
+  
+ 31. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 30. DATE-NOT-AVAILABLE - Inside <article-meta> and <front-stub>,
+     a new element <pub-date-not-available> was added as an
+     alternatives to <pub-date>. The meaning is that a 
+     publication date was (for whatever reason) not available. 
+     Presence of the element says nothing about publication 
+     status.
+
+ 29. INLINE INDEX TERMS  - Added invocation to BITS inline
+     (embedded) index term model
+ 
+ 28. @dtd-version becomes "1.2d2" from "1.2d1"
+
+ 27. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d2 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d2  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+ 26. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 25. xsi:noNamespaceSchemaLocation added to attribute list of
+     <article>. Most modern processors do not need this, but
+     a user with an older processor requested it, so the JATS
+     Standing Committee acquiesced. This pseudo-attribute
+     cannot be used with a DOCTYPE declaration.
+
+ 26. FRONT STUB MODEL
+     - ARTICLE VERSION - Added new element <article-version>
+       inside <front-stub> to hold one version number for the 
+       article. <article-version> element may repeat inside
+       <article-version-alternatives> to hold version numbers 
+       from different systems.
+ 
+     - NO DATE - <pub-date> (optional repeatable) is now
+       followed by the optional new element 
+       <pub-date-not-available>. 
+ 
+     - PUB-HISTORY - <pub-history> (optional) added to hold
+       <event>s.
+ 
+ 23. @dtd-version becomes "1.2d1" from 1.1
+ 
+ 22. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+    =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 21. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 20. ALI - Added ALI namespace for NISO Access and Indicator 
+     license reference and free to read elements.
+
+ 19. JATS became version "1.1d3" and "v1.1d3 20150301"
+ 
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 18. <VOLUME> INSIDE <ARTICLE-META> and <FRONT-STUB>
+   - Allowed <volume> to repeat inside <article-meta>, the types to 
+     be distinguished using @content-type
+   - Added new optional element <volume-issue-group> inside 
+     <article-meta) following all volume and issue elements
+     to hold volume-issue pairs (or n-tuples) when a second
+     and subsequent <volume> has its own related issue
+     information.
+   - Made <issue> repeatable, for those who choose not to use
+     the new wrapper element.
+
+ 17. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 16. DTD Version - Updated the DTD-version attribute to "1.1d1" and 
+     the formal public identifier to the date: "v1.1d1 20130915//EN".
+
+ 15. GLOBAL ATTRIBUTES - Added the new module for Common (global)
+     attributes: %JATS-common-atts.ent;, called in before the
+     customizations models module.
+
+ 14. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added a new attribute list to:
+      - back
+      - front
+      - front-stub
+                          
+ 13. ABSTRACTS AND KEYWORDS
+       Changed "abstract*" to "(%abstract.class;)*"
+       and "kwd-group*" to "(%kwd-group.class;)*" since those
+       classes now exist. Elements should have a limited number of
+       ways to be invoked.
+        - article-meta (through %article-meta-model;)
+        - front-stub (through %front-stub-model;)
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+           http://jats.nlm.nih.gov/1.1/
+ 
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+  
+ 12. RELATED OBJECT - Added <related-object> everywhere
+     <related-article> was used, including inside 
+     <front-stub> using front-stub-model.
+   
+ 11. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+ 10. Updated the DTD-version attribute to "0.4" 
+   
+  9. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  8. BODY ATTRIBUTES - Added attribute list and new PE %body-atts;
+     to the model of <body>. The only current attribute is
+     @specific-use, which indicates, for example, not a real
+     tagged XML body, but a 'bag of words" for indexing purposes.
+
+  7. KEYWORD GROUP - Made <kwd-group> repeatable inside
+     <front-stub> by modifying %front-stub-model;
+
+  6. I18N - Changed the default for @xml:lang from "en" to
+     #IMPLIED, so that the @xml:lang would inherit properly and
+     not need to be over-ridden in
+      - <sub-article> through %sub-article-atts;
+      - <response> through %response-atts;
+
+  5. AFFILIATION ALTERNATIVES - Added the element <aff-alternatives>
+     to <front-stub> through %front-stub-model;. This element
+     will hold multiple <aff>s that are a representation of a
+     single affiliation, for example, the name of an institution
+     in two languages or two scripts.
+
+  4. FRONT MATTER - Modified %front-model; to add the elements:
+        ack | bio | fn-group | glossary (via %front.class;)
+     to front matter content model.
+
+  3. LANGUAGE CODES - Codes for languages as well as variants,
+     transliterations, regions, scripts, and combinations
+     such as "Jpan"(Han + Hiragana + Katakana). These values should be
+     taken from RFC 5646/W3C/IANA Subtag Registry recommendations
+     and can be found online at:
+       http://www.iana.org/assignments/language-subtag-registry
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  2. Changed default @xml:lang from "EN" from "en" to match latest
+     RFC 4646/W3C/IANA Subtag Registry recommendations
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+-->
+
+<!-- ============================================================= -->
+<!--                    DESIGN CONSIDERATIONS                      -->
+<!-- ============================================================= -->
+
+
+<!-- MODULAR DTD LIBRARY
+                        A set of journal archiving and interchange
+                        DTD modules was written as the basis for
+                        publishing, interchange, and repository
+                        DTDs, with the intention that DTDs for
+                        specific purposes, such as this Journal
+                        Archiving and Interchange DTD, would be
+                        developed based on them.
+
+                        This archiving DTD has been designed to
+                        be descriptive, open, and inclusive to
+                        allow journal articles to be translated into
+                        this format as conveniently as possible
+                        from a wide variety of proprietary journal
+                        article DTDs (such as Blackwell, Keton, and
+                        Ovid).
+
+                        This Archiving DTD has been developed from
+                        the JATS DTD Suite modules, in the approved 
+                        manner, making changes to the declarations 
+                        in those modules by over-riding Parameter 
+                        Entity contents by redefining the entities 
+                        in the:
+                            %archivecustom-classes.ent;
+                            %archivecustom-mixes.ent;
+                            %archivecustom-models.ent;
+                        modules, which are called from this DTD file.
+                        No changes to any of the original JATS DTD
+                        Suite modules are required in order to 
+                        use this DTD.                              -->
+
+
+<!-- ============================================================= -->
+<!--                    MODULES OF MODULES INVOKED                 -->
+<!-- ============================================================= -->
+
+
+<!--                    MODULE TO NAME DTD-SPECIFIC MODULES        -->
+<!--                    Names all DTD-specific external modules    -->
+<!ENTITY % archivecustom-modules.ent 
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Journal Archiving DTD-Specific Modules v1.2 20190208//EN" 
+"JATS-archivecustom-modules1.ent"                                    >
+%archivecustom-modules.ent;
+
+
+<!--                    MODULE TO NAME THE MODULES                 -->
+<!--                    Declares all the external modules that are
+                        part of the modular JATS DTD Suite library. 
+                        Thus it does NOT declare itself; 
+                        the DTD-specific module-of-modules; 
+                        any of the DTD-specific class,
+                        mix, or model over-ride modules; or any 
+                        new content modules specific to this DTD.
+                        Those are declared in the DTD-specific
+                        module of modules.
+                           Since this module declares but does not
+                        invoke modules, this DTD then invokes any
+                        modules it uses by referencing the external
+                        Parameter Entities defined in the Module of
+                        Modules. To include a set of elements (such
+                        as all the lists or the MathML elements) this
+                        module defines the external Parameter Entity
+                        for the module(s) that contains the MathML
+                        declarations and the DTD references that
+                        entity.                                    -->
+<!ENTITY % modules.ent  PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Module of Modules v1.2 20190208//EN"
+"JATS-modules1.ent"                                                  >
+%modules.ent;
+
+<!-- ============================================================= -->
+<!--                    NISO ALI NAMESPACE SETUP                   -->
+<!-- ============================================================= -->
+
+
+<!--                    DEFINE ALI NAMESPACE ATTRIBUTE AND PREFIX  -->
+<!--                    Names the module defines the NISO Access and 
+                        Indicators Exchange Model namespace, prefix, 
+                        and pseudo-attribute @xmlns.               -->
+%JATS-ali-namespace.ent;
+                                                            
+
+<!-- ============================================================= -->
+<!--                    SET UP COMMON (ALL ELEMENT) ATTRIBUTES     -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON ATTRIBUTES MODULE                   -->
+<!--                    Set up the common attributes, those used on
+                        nearly all elements.
+                        Must be called before the custom models
+                        module.                                    -->
+%JATS-common-atts.ent;
+
+
+<!-- ============================================================= -->
+<!--                    CUSTOMIZATION MODULES INVOKED              -->
+<!--                    Note: These modules must be called after   -->
+<!--                    all Module of Modules but before any other -->
+<!--                    modules. Unlike any other grouping, order  -->
+<!--                    of these modules matters.                  -->
+<!-- ============================================================= -->
+
+
+<!--                    DTD-SPECIFIC CLASS CUSTOMIZATIONS MODULE   -->
+<!--                    Names the module that holds the DTD-specific
+                        class definitions for the Journal Archiving
+                        and Interchange DTD that over-rides the Suite
+                        defaults.
+                        (Defined in %archivecustom-modules.ent; )  -->
+%archivecustom-classes.ent;
+
+
+<!--                    DEFAULT ELEMENT CLASSES MODULE             -->
+<!--                    Names the module that holds the standard
+                        class definitions for the JATS DTD Suite.  -->
+%default-classes.ent;
+
+
+<!--                    DTD-SPECIFIC MIX CUSTOMIZATIONS MODULE     -->
+<!--                    Set up the Parameter Entities and element
+                        class definitions that will be used to
+                        over-ride some element mixes in this DTD.
+                        (Defined in %archivecustom-modules.ent; )  -->
+%archivecustom-mixes.ent;
+
+
+<!--                    DEFAULT MIX CUSTOMIZATIONS MODULE          -->
+<!--                    Names the module that holds the standard
+                        mix definitions for the JATS DTD Suite.    -->
+%default-mixes.ent;
+
+
+<!--                    DTD-SPECIFIC MODELS/ATTRIBUTES CUSTOMIZATIONS
+                        MODULE                                     -->
+<!--                    Names the module that holds the over-rides
+                        of content models, attribute lists, elements
+                        lists to be used in content models, and
+                        attribute values. These are DTD-specific.
+                        (Defined in %archivecustom-modules.ent; )  -->
+%archivecustom-models.ent;
+
+
+<!-- ============================================================= -->
+<!--                    COMMON (SHARED) ELEMENTS MODULE INVOKED    -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON (SHARED) DECLARATIONS               -->
+<!--                    Declarations for elements, attributes,
+                        entities, and Notations that are shared by
+                        more than one class module. Note: Must be
+                        called before any of the class modules.    -->
+
+%common.ent;
+
+
+<!-- ============================================================= -->
+<!--                    JOURNAL ARTICLE CLASS ELEMENTS (alpha)     -->
+<!-- ============================================================= -->
+
+<!--                    ARTICLE METADATA ELEMENTS                  -->
+%articlemeta.ent;
+
+
+<!--                    BACK MATTER ELEMENTS                       -->
+%backmatter.ent;
+
+
+<!--                    DISPLAY (GRAPHICAL) ELEMENTS               -->
+%display.ent;
+
+
+<!--                    FORMATTING ELEMENT CLASSES                 -->
+<!--                    Elements that change rendition/display.    -->
+%format.ent;
+
+
+<!--                    FUNDING ELEMENTS                           -->
+<!--                    Elements that describe the sponsorship or
+                        open access                                -->
+%funding.ent;
+
+
+<!--                    JOURNAL METADATA ELEMENTS                  -->
+%journalmeta.ent;
+
+
+<!--                    LINK CLASS ELEMENTS                        -->
+%link.ent;
+
+
+<!--                    LIST CLASS ELEMENTS                        -->
+%list.ent;
+
+
+<!--                    MATH ELEMENTS                              -->
+%math.ent;
+
+
+<!--                    NLM CITATION ELEMENT                       -->
+%nlmcitation.ent;
+
+
+<!--                    PARAGRAPH-LEVEL ELEMENTS                   -->
+%para.ent;
+
+
+<!--                    PHRASE-LEVEL ELEMENTS                      -->
+%phrase.ent;
+
+
+<!--                    BIBLIOGRAPHIC REFERENCE (CITATION)
+                        CLASS ELEMENTS                             -->
+%references.ent;
+
+
+<!--                    RELATED OBJECT ELEMENT                     -->
+<!--                    Defines the <related-object> element to
+                        describe a related object such as a
+                        related book or a dataset.                 -->
+%related-object.ent;
+
+
+<!--                    SECTION ELEMENTS                           -->
+%section.ent;
+
+
+<!-- ============================================================= -->
+<!--                    THE REST OF THE EXTERNAL MODULES INVOKED   -->
+<!-- ============================================================= -->
+
+
+<!--                    BITS EMBEDDED INDEX ELEMENTS MODULE        -->
+<!--                    Element declarations the index elements
+                        which are embedded in the article 
+                        narrative.                                 -->
+%index-term.ent;
+
+
+<!-- ============================================================= -->
+<!--                    THE REST OF THE EXTERNAL MODULES INVOKED   -->
+<!-- ============================================================= -->
+
+
+<!--                    MATHML SETUP MODULE                        -->
+<!--                    Invoke the MathML modules                  -->
+%mathmlsetup.ent;
+
+<!--                    XHTML TABLE SETUP MODULE                   -->
+<!--                    Set up the necessary Parameter Entity values
+                        and then invoke XHTML (HTML 4.0) table
+                        module                                     -->
+%XHTMLtablesetup.ent;
+
+
+<!--                    SPECIAL CHARACTERS DECLARATIONS            -->
+<!--                    Standard XML special character entities
+                        used in this DTD                           -->
+%xmlspecchars.ent;
+
+
+<!--                    CUSTOM SPECIAL CHARACTERS DECLARATIONS     -->
+<!--                    Custom special character entities created
+                        specifically for use in this DTD Suite     -->
+%chars.ent;
+
+
+<!--                    NOTATION DECLARATIONS MODULE               -->
+%notat.ent;
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    DTD VERSION                                -->
+<!--                    What version of this DTD was used to make
+                        the document instance under consideration.
+                        Note that this is a fixed value that should
+                        change every time the DTD changes versions or
+                        revisions.                                 -->
+<!ENTITY % dtd-version
+            "dtd-version
+                        CDATA                      #FIXED '1.2'"     >
+
+
+<!--                    ARTICLE ATTRIBUTES                         -->
+<!--                    Attributes for the top-level element
+                        <article>                                  -->
+<!ENTITY % article-atts
+            "%jats-common-atts;                                       
+             article-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           'en'
+             %dtd-version;
+             %XLINK.xmlns.attrib;
+             %MATHML.xmlns.attrib;
+             %ali.xmlns.attrib;
+             %Schema.xmlns.attrib;
+             %Schema.prefix;:noNamespaceSchemaLocation   
+                        CDATA          #IMPLIED"                    >
+
+
+<!--                    BACK ATTRIBUTES                            -->
+<!--                    Attributes for the <back> element          -->
+<!ENTITY % back-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    BODY ATTRIBUTES                            -->
+<!--                    Attributes for the <body> element          -->
+<!ENTITY % body-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    FRONT ATTRIBUTES                           -->
+<!--                    Attributes for the <front> element         -->
+<!ENTITY % front-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    FRONT STUB ATTRIBUTES                      -->
+<!--                    Attributes for the <front-stub> element    -->
+<!ENTITY % front-stub-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    SUB-ARTICLE ATTRIBUTES                     -->
+<!--                    Attributes for the <sub-article> element   -->
+<!ENTITY % sub-article-atts
+            "%jats-common-atts;                                       
+             article-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    RESPONSE ATTRIBUTES                        -->
+<!--                    Attributes for the <response> element      -->
+<!ENTITY % response-atts
+            "%jats-common-atts;                                       
+             response-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    JOURNAL ARTICLE ELEMENTS                   -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE MODEL (LIMITED)                    -->
+<!--                    Article-like model used for, for example,
+                        a short sub-article such as a news brief that
+                        is contained in side a journal article.    -->
+<!ENTITY % article-short-model
+                        "((front | front-stub), body?, back?,
+                          floats-group?)"                            >
+
+
+<!--                    ARTICLE MODEL WITH SUB-ARTICLE OR RESPONSE -->
+<!--                    Typical journal article model, which may
+                        contain extended components, such as
+                        sub-articles or responses,                 -->
+<!ENTITY % article-full-model
+                        "(front, body?, back?, floats-group?,
+                          (sub-article* | response*) )"              >
+
+
+<!--                    ARTICLE                                    -->
+<!--                    The complete content of a journal article.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=article
+                                                                   -->
+<!ELEMENT  article      %article-full-model;                         >
+<!ATTLIST  article
+             %article-atts;                                          >
+
+
+<!-- ============================================================= -->
+<!--                    FRONT MATTER ELEMENTS                      -->
+<!-- ============================================================= -->
+
+
+<!--                    FRONT MATTER MODEL                         -->
+<!--                    Model for the <front> matter (the header
+                        metadata) of a journal article)            -->
+<!ENTITY % front-model  "(journal-meta?, article-meta,
+                          (%list.class; | %front.class; |
+                           %front-back.class;)* )"                   >
+
+
+<!--                    FRONT MATTER                               -->
+<!--                    The metadata concerning an article, such as
+                        the name and issue of the journal in which it
+                        appears and the name and author(s) of the
+                        article.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=front
+                                                                   -->
+<!ELEMENT  front        %front-model;                                >
+<!ATTLIST  front
+             %front-atts;                                            >
+
+
+<!-- ============================================================= -->
+<!--                    BODY ELEMENTS                              -->
+<!-- ============================================================= -->
+
+
+<!--                    BODY MODEL                                 -->
+<!--                    Content model for the Body (main textual
+                        content) of a journal article.             -->
+<!ENTITY % body-model   "((%para-level;)*, (%sec-level;)*,
+                          sig-block?)"                               >
+
+
+<!--                    BODY OF THE ARTICLE                        -->
+<!--                    The main textual portion of the article that
+                        conveys the content.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=body
+                                                                   -->
+<!ELEMENT  body         %body-model;                                 >
+<!ATTLIST  body
+             %body-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    BACK MATTER ELEMENTS                       -->
+<!-- ============================================================= -->
+
+
+<!--                    BACK MATTER MODEL                          -->
+<!--                    Content model for the Back Matter (ancillary
+                        material such as appendices) of a journal
+                        article.                                   -->
+<!ENTITY % back-model   "(label?, title*,
+                          (%doc-back-matter-mix;)* )"                >
+
+
+<!--                    BACK MATTER                                -->
+<!--                    Ancillary or supporting material not included
+                        as part of the main textual content of a
+                        journal article, for example appendices and
+                        acknowledgments.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=back
+                                                                   -->
+<!ELEMENT  back         %back-model;                                 >
+<!ATTLIST  back
+             %back-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    SUB-ARTICLE                                -->
+<!-- ============================================================= -->
+
+
+<!--                    SUB-ARTICLE MODEL                          -->
+<!--                    Content model for the <sub-article> element
+                                                                   -->
+<!ENTITY % sub-article-model
+                        "( (front | front-stub), body?, back?,
+                           floats-group?,
+                           (sub-article* | response*) )"             >
+
+
+<!--                    SUB-ARTICLE                                -->
+<!--                    An article that is completely contained
+                        inside another article. Both the article and
+                        the sub-article have their own metadata.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=sub-article
+                                                                   -->
+<!ELEMENT  sub-article  %sub-article-model;                          >
+<!ATTLIST  sub-article
+             %sub-article-atts;                                      >
+
+
+<!--                    FRONT MODEL STUB                           -->
+<!--                    Content model for the <front-stub> element,
+                        a reduced metadata set for use in
+                        sub-articles and responses.                -->
+<!ENTITY % front-stub-model
+                       "(article-id*, (%article-version.class;)?,  
+                         article-categories?,
+                         title-group?,
+                         (%contrib-group.class; |
+                          %aff-alternatives.class; | %x.class;)*,
+                         author-notes?, ( (%pub-date.class;)* | 
+                           pub-date-not-available?),  
+                         volume*, volume-id*, volume-series?,
+                         issue*, issue-id*, issue-title*,
+                         issue-sponsor*, issue-part?, 
+                         volume-issue-group*, isbn*,
+                         supplement?,
+                         ( ( (fpage, lpage?)?, page-range?) |
+                           elocation-id )?,
+                         (%address-link.class; | product |
+                          supplementary-material)*,
+                         history?, pub-history?, permissions?, 
+                         self-uri*, (%related-article.class;)*, 
+                         (%abstract.class;)*,
+                         trans-abstract*, (%kwd-group.class;)*,
+                         funding-group*, support-group*,
+                         conference*, counts?,
+                         custom-meta-group?)"                        >
+
+
+<!--                    STUB FRONT METADATA                        -->
+<!--                    A reduced metadata set for use in
+                        sub-articles and responses, which will
+                        inherit metadata not defined in the stub
+                        from the enclosing article
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=front-stub
+                                                                   -->
+<!ELEMENT  front-stub   %front-stub-model;                           >
+<!ATTLIST  front-stub
+             %front-stub-atts;                                       >
+
+
+<!-- ============================================================= -->
+<!--                    RESPONSE ELEMENTS                          -->
+<!-- ============================================================= -->
+
+
+<!--                    RESPONSE                                   -->
+<!--                    Reply, response, or commentary concerning the
+                        journal article.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=response
+                                                                   -->
+<!ELEMENT  response     %article-short-model;                        >
+<!ATTLIST  response
+             %response-atts;                                         >
+
+
+<!-- ================== End Journal Archiving and Interchange DTD  -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-archivecustom-classes1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-archivecustom-classes1.ent
@@ -1,0 +1,377 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Journal Archiving DTD Customize Classes Module    -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Classes Module v1.2 20190208//EN"
+Delivered as file "JATS-archivecustom-classes1.ent"                -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     Journal Archiving and Interchange DTD of the      --> 
+<!--             JATS DTD Suite                                    -->         
+<!--                                                               -->
+<!-- PURPOSE:    To declare the Parameter Entities (PEs) used to   -->
+<!--             over-ride the JATS DTD Suite default named        -->
+<!--             element classes.                                  -->
+<!--                                                               -->
+<!--             Note: Since PEs must be declared before they      -->
+<!--             are used, this module must be called before the   -->
+<!--             content modules that declare elements, and before -->
+<!--             the default classes module.                       -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This DTD was created from the JATS DTD Suite.     -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             August 2004                                       -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Archiving and Interchange DTD is      -->
+<!--             built from the JATS DTD Suite.                    -->
+<!--                                                               -->
+<!--             This DTD and the Suite are a continuation of      -->
+<!--             the work done by NCBI, Mulberry Technologies,     -->
+<!--             and Inera Inc. on the NLM Journal Archiving       -->
+<!--             and Interchange DTD Suite, which was originally   -->
+<!--             released in December, 2002.                       -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 13. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 12. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 11. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed. 
+     
+     =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+  10. JATS "1.2d1" and "v1.2d1 20170631" became
+      JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+  9. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+    =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  8. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  6. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  5. CITATION ALTERNATIVES - Added a new element 
+     <citation-alternatives> to the citation.class. The element
+     will hold, for example, a single citation in multiple
+     languages or a single citation tagged as a <mixed-citation>
+     complete with punctuation and spacing and also as an
+     <element-citation> with all punctuation and spacing removed.
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  4. Updated the DTD-version attribute to "0.4" 
+   
+  3. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+           http://jats.nlm.nih.gov/0.4.
+
+  2. AFFILIATION ALTERNATIVES - Added the element <aff-alternatives>
+     to contrib-info.class to hold multiple <aff>s that are
+     representations of a single affiliation, for example, the name
+     of an institution in two languages or two scripts.
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    METADATA CLASSES (articlemeta.ent)         -->
+<!-- ============================================================= -->
+
+
+<!--                    CONTRIBUTOR INFORMATION CLASS              -->
+<!--                    Metadata about a contributor
+                        Added <fn>                                 -->
+<!ENTITY % contrib-info.class
+                        "address | aff | aff-alternatives |
+                         author-comment | bio | email |  etal |
+                         ext-link | fn | on-behalf-of | role |
+                         uri | xref"                                 >
+
+
+<!-- ============================================================= -->
+<!--                    CITATION CLASSES (references.ent)          -->
+<!-- ============================================================= -->
+
+
+<!--                    CITATION CLASS ELEMENTS                    -->
+<!--                    Reference to an external document, as used
+                        within, for example, the text of a
+                        paragraph                                  -->
+<!ENTITY % citation.class
+                        "citation-alternatives | element-citation | 
+                         mixed-citation | nlm-citation"              >
+
+
+<!--                    CITATION MINUS ALTERNATIVES CLASS ELEMENTS -->
+<!--                    All the citation elements except the
+                        <citation-alternatives> element.           -->
+<!ENTITY % citation-minus-alt.class
+                        "element-citation | mixed-citation | 
+                         nlm-citation"                               >
+
+
+<!--                    CITATION ADDITIONS CLASS ELEMENTS          -->
+<!--                    Elements that are not part of the broader
+                        -references.class, but that need to be part
+                        of the model for citations.                -->
+<!ENTITY % citation-additions.class
+                        "string-date"                                >
+
+
+<!-- ============================================================= -->
+<!--                    PRESENTATION INFO CLASSES                  -->
+<!-- ============================================================= -->
+
+
+<!--                    X-GENERATED PUNCTUATION CLASS              -->
+<!--                    Class containing a single element that will
+                        hold generated punctuation or other
+                        generatable text, for example, the commas or
+                        semicolons between keywords.               -->
+<!ENTITY % x.class      "x"                                          >
+
+
+<!-- ============================================================= -->
+<!--                    STRUCTURAL ELEMENT CLASSES                 -->
+<!-- ============================================================= -->
+
+
+<!--                    REST OF PARAGRAPH CLASS                    -->
+<!--                    Information for the reader that is at the
+                        same structural level as a Paragraph.      -->
+<!ENTITY % rest-of-para.class
+                        "ack | disp-quote | speech | statement |
+                         verse-group"                                >
+
+<!-- ================== End Archiving Classes Customization ====== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-archivecustom-mixes1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-archivecustom-mixes1.ent
@@ -1,0 +1,506 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Journal Archiving DTD Customize Mixes Module      -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Mixes Module v1.2 20190208//EN"
+Delivered as file "JATS-archivecustom-mixes1.ent"                  -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     Journal Archiving and Interchange DTD of the      --> 
+<!--             JATS DTD Suite                                    -->         
+<!--                                                               -->
+<!-- PURPOSE:    To declare the Parameter Entities (PEs) used to   -->
+<!--             over-ride the JATS DTD Suite default named,       -->
+<!--             general purpose mixes. (Mixes for particular      -->
+<!--             elements are declared in the Archive Custom       -->
+<!--             Models module.)                                   -->
+<!--                                                               -->
+<!--             Note: Since PEs must be declared before they      -->
+<!--             are used, this module must be called before the   -->
+<!--             default mixes modules (%default-mixes;)           -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This DTD was created from the JATS DTD Suite.     -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             August 2004                                       -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Archiving and Interchange DTD is      -->
+<!--             built from the JATS DTD Suite.                    -->
+<!--                                                               -->
+<!--             This DTD and the Suite are a continuation of      -->
+<!--             the work done by NCBI, Mulberry Technologies,     -->
+<!--             and Inera Inc. on the NLM Journal Archiving       -->
+<!--             and Interchange DTD Suite, which was originally   -->
+<!--             released in December, 2002.                       -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 14. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 13. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 12. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed. 
+     
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 11. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+ 10. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+    =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  9. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  8. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  6. PARAGRAPH IN TABLE CELL - Added <p> to the contents of
+     table cells, through %inside-cell; (using
+     %nothing-but-para.class;).
+  
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  5. RELATED OBJECT - Added <related-object> everywhere
+     <related-article> was used.
+   
+  4. PARA-LEVEL PARAMETER ENTITY CONFLICT - Changed the parameter
+     entity %para-level; to use the PE %nothing-but-para.class;,
+     removing the similar PE "just-para.class;". It is possible to 
+     add element(s) to %just-para.class;, so that the added element(s)
+     may be used everywhere <p> is used. Such elements would also be
+     named in %block-display.class;. This would lead to a conflict
+     in %para-level; if both %just-para.class; and
+     %block-display.class; named <p>. So %just-para.class; is replaced
+     here in %para-level;. This is backward compatible for all XML
+     documents. If a JATS customization has modified %just-para.class;
+     they may need to change their customization to accommodate.
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+           http://jats.nlm.nih.gov/0.4.
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    ELEMENT MIXES FOR USE IN CONTENT MODELS    -->
+<!--                    (MIXES ARE COMPOSED USING CLASSES)         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    EXCEPTION: A MIX USED IN OTHER MIXES       -->
+<!-- ============================================================= -->
+
+
+<!--                    ALL PHRASE-LEVEL ELEMENTS                  -->
+<!--                    This Parameter Entity contains all of the
+                        phrase-level elements in the entire
+                        Archival Tag Set EXCEPT THE <break> element.
+                        MAINTENANCE NOTE:
+                        Since this is used inside other mixes
+                        (like a class and unlike all other mixes)
+                        all-phrase must
+                          - be declared first in this module.
+                          - does not start with an OR bar, as all
+                            other inline mixes do                  -->
+<!ENTITY % all-phrase   "%address-link.class; | %article-link.class; |
+                         %appearance.class; | %emphasis.class;  |
+                         %inline-display.class; |
+                         %inline-math.class; | %math.class; |
+                         %phrase.class; | %simple-link.class; |
+                         %subsup.class; | %x.class;"                 >
+
+
+<!-- ============================================================= -->
+<!--                    TABLE ELEMENT MIXES                        -->
+<!-- ============================================================= -->
+
+
+<!--                    INSIDE TABLE CELL ELEMENTS                 -->
+<!--                    Mixed with #PCDATA inside a table cell, such
+                        as a <td> or <th> element in the XHTML table
+                        model, the <entry> element in the OASIS CALS
+                        table model, etc.  This PE will be used as the
+                        value of %Flow.mix;, %paracon;, etc.
+                        MAINTENANCE NOTE: Inside cell is an exception,
+                        an inline mix that does not start with an OR
+                        bar. This is because is used within the
+                        PE -%Flow.mix;, which is an inline mix
+                        defined in the course of the XHTML Table DTD,
+                        a DTD not under control of this DTD Suite. -->
+<!ENTITY % inside-cell  "%all-phrase; | %block-math.class; |
+                         %break.class; | %chem-struct-wrap.class; |
+                         %citation.class; |
+                         %list.class; | %nothing-but-para.class; |
+                         %simple-display-noalt.class;"               >
+
+
+<!-- ============================================================= -->
+<!--                    BACK MATTER ELEMENT MIXES(%backmatter.ent;)-->
+<!-- ============================================================= -->
+
+
+<!--                    DOCUMENT BACK MATTER ELEMENTS              -->
+<!--                    Back Matter Elements used by a full document
+                        such as a journal article. This is an element
+                        grouping rather than a class. These
+                        elements may also appear in the content models
+                        of structural elements, such as back matter.
+                                                                   -->
+<!ENTITY % doc-back-matter-mix
+                        "%back.class; | %front-back.class; |
+                         %sec.class;"                                >
+
+
+<!-- ============================================================= -->
+<!--                    PARAGRAPH-LEVEL ELEMENT MIXES              -->
+<!-- ============================================================= -->
+
+
+<!--                    PARAGRAPH-LEVEL ELEMENTS                   -->
+<!--                    Elements that may be used at the same
+                        structural level as a paragraph, for
+                        example inside a Section
+                        Note: There a major overlap between this
+                        parameter entity and that for the elements
+                        that are at the same level as a paragraph.
+                        Inline elements appear only inside a
+                        paragraph, but block elements such as quotes
+                        and lists may appear either within a
+                        paragraph or at the same level as a
+                        paragraph. This serves a requirement in a
+                        repository DTD, since some incoming material
+                        will have restricted such elements to only
+                        inside a paragraph,  some incoming material
+                        will have restricted them to only outside a
+                        paragraph and some may allow them in both
+                        places. Thus the DTD must allow for them to
+                        be in either or both.                      -->
+<!ENTITY % para-level   "%block-display.class; | %block-math.class; |
+                         %list.class; | %math.class; | 
+                         %nothing-but-para.class; |
+                         %related-article.class; |
+                         %rest-of-para.class; | %x.class;"           >
+
+
+<!-- ============================================================= -->
+<!--                    INLINE ELEMENT MIXES                       -->
+<!-- ============================================================= -->
+
+
+<!--                    EMPHASIS MIX ELEMENTS                      -->
+<!--                    Elements that may be used inside most of the
+                        emphasis class elements                    -->
+<!ENTITY % emphasized-text
+                        "| %all-phrase; | %break.class;"             >
+
+
+<!--                    JUST RENDITION                             -->
+<!--                    Only the simplest of the typographic
+                        emphasis elements, as well as subscript and
+                        superscript.  Usually used in a model that
+                        allows #PCDATA and this restricted mixture.
+                        This mix may be stripped down to only
+                        subscript and superscript by some, more
+                        restrictive DTDs.
+                        MAINTENANCE NOTE:  This Parameter Entity
+                        and the related PE "rendition-plus" have
+                        been put in place to restrict the amount of
+                        variability that a person modifying the DTD
+                        through PE redefinition can achieve. Some
+                        elements have been set #PCDATA plus one PE
+                        and some have been set to #PCDATA plus the
+                        other in an effort to allow designers to
+                        modify entire groups of elements, but not
+                        to change similar models individually .    -->
+<!ENTITY % just-rendition
+                        "| %all-phrase;"                             >
+
+
+<!--                    RENDITION MARKUP PLUS                      -->
+<!--                    Only the simplest of the typographic
+                        emphasis elements, as well as subscript and
+                        superscript.  Usually used in a model that
+                        allows #PCDATA and this restricted mixture.
+                        This mix may be enhanced slightly in some
+                        more permissive DTDs, and should always
+                        contain at least typographic emphasis,
+                        subscript, and superscript.
+                        MAINTENANCE NOTE: This Parameter Entity
+                        and the related PE "just-rendition" have
+                        been put in place to restrict the amount of
+                        variability that a person modifying the DTD
+                        through PE redefinition can achieve. Some
+                        elements have been set #PCDATA plus one PE
+                        and some have been set to #PCDATA plus the
+                        other in an effort to allow designers to
+                        modify entire groups of elements, but not
+                        to individually change similar models.
+                        modify entire groups of elements, but not
+                        to change similar models individually .    -->
+<!ENTITY % rendition-plus
+                        "| %all-phrase;"                             >
+
+
+<!--                    SIMPLE PHRASE-LEVEL TEXTUAL ELEMENTS       -->
+<!--                    Elements that may be used almost anywhere
+                        text is used, for example, inside a title.
+                        Simple text plus inline display and math
+                        elements.                                  -->
+<!ENTITY % simple-phrase
+                        "| %all-phrase;"                             >
+
+
+<!--                    SIMPLE TEXTUAL CONTENT                     -->
+<!--                    Elements that may be used inside elements
+                        that are really expected to be #PCDATA and
+                        not to contain any of these things.
+                        Note that in the original, this contained
+                        no math and no links, thus is was even
+                        simpler than %simple-phrase; (As of 2004,
+                        the two are the same.) s                    -->
+<!ENTITY % simple-text  "| %all-phrase;"                             >
+
+
+<!-- ================== End Archiving DTD Mixes Customization ==== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-archivecustom-models1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-archivecustom-models1.ent
@@ -1,0 +1,1483 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Journal Archiving DTD Customize Content and       -->
+<!--             Attributes Module                                 -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Content and Attributes Module v1.2 20190208//EN"
+Delivered as file "JATS-archivecustom-models1.ent"                 -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     Journal Archiving and Interchange DTD of the      --> 
+<!--             JATS DTD Suite                                    -->         
+<!--                                                               -->
+<!-- PURPOSE:    To declare the Parameter Entities (PEs) used to   -->
+<!--             over-ride the content models, parts of content    -->
+<!--             models, or attribute lists of the JATS DTD Suite  -->
+<!--                                                               -->
+<!--             Or-groups within models should use mixes or       -->
+<!--             classes rather than name elements directly.       -->
+<!--                                                               -->
+<!--             Note: Since PEs must be declared before they      -->
+<!--             are used, this module must be called before the   -->
+<!--             content modules that declare elements.            -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This DTD was created from the JATS DTD Suite.     -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             August 2004                                       -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Archiving and Interchange DTD is      -->
+<!--             built from the JATS DTD Suite.                    -->
+<!--                                                               -->
+<!--             This DTD and the Suite are a continuation of      -->
+<!--             the work done by NCBI, Mulberry Technologies,     -->
+<!--             and Inera Inc. on the NLM Journal Archiving       -->
+<!--             and Interchange DTD Suite, which was originally   -->
+<!--             released in December, 2002.                       -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 43. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 42. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 41. ASSIGNING AUTHORITY - Added @assigning-authority to the
+     following elements, so that the type-of-identifier and
+     the party-responsible-for-identifier could both be
+     recorded. Previously, these values were both assigned to
+     the attribute @pub-id-type.
+        - <article-id>
+        - Note: <pub-id> already had @assigning-authority
+
+ 40. NON-MONETARY SUPPORT - Inside <article-meta> added new
+     <support-group> to hold both funding and
+     non-monetary support descriptions. <support-group> is 
+     both a peer to <funding-group> (backward compatibility)
+     and contains <funding-group>.
+ 
+ 39. PUBLICATION DATE-NOT-AVAILABLE - Inside <article-meta>, 
+     <front-stub>, <event>, and <event-desc>
+     added new element <pub-date-not-available>, as an 
+     alternative to <pub-date>. The meaning is that a 
+     publication date was (for whatever reason) not available. 
+     Presence of the element says nothing about publication 
+     status.
+ 
+ 38. DATE IN CITATION - Superscript and subscript added to
+     <date-in-citation>.
+  
+ 37. CONFERENCE DATE - Face markup (face-markup.class) 
+     added to <conf-date>.
+
+ 36. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed. 
+     
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 35. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+ 
+ 34. X - both <inline-graphic> and <private-char> added to 
+     elements allowed in <x>.
+
+ 33. INLINE FORMULA - Added accessibility elements <alt-text> and
+     <long-desc> to the model of inline formula, by adding the 
+     access.class PE.
+
+ 32. ARTICLE META MODEL
+     - ARTICLE VERSION - Added new element <article-version>
+       inside <article-metadata> to hold one version number for  
+       the article. <article-version> element may repeat inside
+       <article-version-alternatives> to hold version numbers 
+       from different systems.
+ 
+     - NO DATE - <pub-date> (optional repeatable) is now
+       followed by the optional new element 
+       <pub-date-not-available>. 
+ 
+     - PUBLICATION HISTORY - Added new element based on BITS,
+       <pub-history>, to hold <event>s as <history> holds
+       <date>s. New internal elements: <event>, <event-desc>
+       
+ 31. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+    =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 30. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 29. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+ 
+ 28.  RUBY MODEL CHANGED TO MATCH HTML5
+      - changed the Ruby content model to allow only a single
+        Ruby annotation on a single Ruby base:
+            (rb, (rt | (rp, rt, rp)) )
+        The Ruby textual annotation may take a pair of
+        Ruby parentheses, but these are optional.
+
+ 27. ATTRIBUTES FOR PUB-ID
+   - Added the linking attributes (optional version) to <pub-id> , 
+     so that a <pub-id> that is a DOI, for example, can carry the 
+     linking attributes and be made into a live link. In this use
+     of <pub-id>, the element is acting both as an identifier
+     and as a link.
+   - Added new attribute @assigning-authority to <pub-id>, to
+     carry new values such as "CrossRef" and to take some of the
+     semantic burden off the '@pub-id-type' attribute, when
+     values are organizations such as "Genbank" or "PDB".
+
+ 26. <OBJECT-ID> INSIDE <TRANS-ABSTRACT>
+     Allowed <object-id> at the beginning of <trans-abstract>, 
+     so that abstracts could be given DOIs.
+
+ 25. <VOLUME> INSIDE <ARTICLE-META>
+   - Allowed <volume> to repeat inside <article-meta>, the types to 
+     be distinguished using @content-type
+   - Added new optional element <volume-issue-group> inside 
+     <article-meta) following all volume and issue elements
+     to hold volume-issue pairs (or n-tuples) when a second
+     and subsequent <volume> has its own related issue
+     numbers.
+ 
+ 24. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 23. NEW <era> ELEMENT
+     Added <era> through date-parts.class to:
+      - <conf-date>
+      - <date-in-citation>
+      - <pub-date>
+      - <string-date>
+      - access-date (deprecated
+      - time-stamp (deprecated)
+
+ 22. INSTITUTIONS TO STANDARDS ORGANIZATIONS
+     Added the elements <institution-wrap> to the following elements
+     through the institution-wrap.class:
+      - <copyright-holder>
+      - <std-organization>
+
+ 21. RUBY ANNOTATIONS - Overrode the default JATS inclusions, to
+     change the more restricted face-markup class to the 
+     Archive-specific all Phrase. Elements change:
+      - <rb> Ruby Base (through %rb-elements;)
+
+ 20. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+
+ 19. ABSTRACTS AND KEYWORDS ON NEW STRUCTURES
+     - Added <abstract> (through %abstract.class;) and <kwd-group> 
+       (through %kwd-group.class;) to the following elements:
+        - disp-formula (through %disp-formula-elements;)
+
+     - Changed "abstract*" to "(%abstract.class;)*"
+       and "kwd-group*" to "(%kwd-group.class;)*" since those
+       classes now exist. Elements should have a limited number of
+       ways to be invoked.
+        - article-meta (through %article-meta-model;)
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 18. RELATED OBJECT - Added <related-object> everywhere
+     <related-article> was used, including inside 
+     <article-meta> using article-meta-model.
+
+ 17. CONTRIBUTOR MODEL - Added "contrib-id.class" to the 
+     <contrib> model, to hold identifiers for people,
+     such as publishers-specific IDs,  and ORCIDs.
+   
+ 16. VERSE-LINE ELEMENTS - Added the PE %verse-line-elements to
+     this module because the default expanded, and Archiving did
+     not need to expand as it already was expanded.
+   
+ 14. DATE ATTRIBUTES - Added attributes to <date> through @date-atts: 
+       a) @iso-8601-date - ISO 8601 standard date format
+          of the publication date. Format  YYYY-MM-DDThh:mm:ss 
+       b) @calendar - Name of the calendar used (@calendar) in
+          naming this publication date (such as "Gregorian", 
+          "Japanese" (Emperor years), or "Islamic").
+       c) Added @publication-format, so that both publication
+          dates and history dates can separate the format of the
+          publication from the version/lifecycle event. Thus
+          both an "article" and a "manuscript" might be received.
+   
+ 13. STANDARDS ORGANIZATION - Added std-organization-elements
+     to increase what was allowed in the names of standards bodies.
+
+ 12. XREF REF TYPES - #9 below says "XREF ATTRIBUTES - Removed 
+     the %xref-atts PE from this module since the regular version 
+     (in xlink3.ent(?)) was equally inclusive. But it is NOT. 
+     Brought back %xref-atts;
+   
+ 11. ISSN-L ELEMENTS - Added <x> TO <issn-l> via 
+     %issn-l-elements;
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+ 10. Updated the DTD-version attribute to "0.4" 
+   
+  9. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+           http://jats.nlm.nih.gov/0.4.
+
+  7. XREF ATTRIBUTES - Removed the %xref-atts PE from this module
+     since the regular version (in xlink3.ent(?)) was equally 
+     inclusive. See #12 above.
+
+  6. ISSUE - Allowed to repeat inside <article-meta>
+
+  5. AFFILIATION ALTERNATIVES - Added the element <aff-alternatives>
+     to <article-meta> through %article meta-model;. This element
+     will hold multiple <aff>s that are a representation of a
+     single affiliation, for example, the name of an institution
+     in two languages or two scripts.
+
+  4. PERSON-GROUP - Became a mixed-content model, so the parameter
+     entity %person-group-model: was changed to
+     %person-group-elements;, which will be mixed with #PCDATA
+     as defined in references.ent. The PE person-group-model has
+     been retained in references.ent for compatibility, but has been
+     set to the mixed model using person-group-elements.
+
+  3. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to %display-atts;. Also added these attributes
+     to the following over-rides:
+      - article-id through article-id-atts (@specific-user only)
+      - award-id through award-id-atts (both)
+      - date through date-atts (@specific-use only)
+      - funding-statement through funding-statement-atts (both)
+      - pub-id through pub-id-atts (@specific-use only)
+      - trans-title through pub-id-atts (@specific-use only;
+         @xml:lang already)
+      - xref through xref-atts (both)
+
+  2. STRING-DATE - Added <string-date> back to the following
+     elements using %citation-additions.class;. It was accidentally
+     deleted during the 3.0 revision of -references.class:
+      - product         (%product-elements;)
+      - related-article (%related-article-elements;)
+      - related-object  (%related-object-elements;)
+      - funding-statement through funding-statement-atts (both)
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    INLINE MIXES TO OVER-RIDE CONTENT MODELS   -->
+<!--                    (ELEMENTS TO BE ADDED TO #PCDATA IN MODELS)-->
+<!-- ============================================================= -->
+
+
+<!--                    ABBREVIATION ELEMENTS                      -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <abbrev> element                       -->
+<!ENTITY % abbrev-elements
+                        "| %all-phrase; | %def.class;"               >
+
+
+<!--                    ACCESS DATE ELEMENTS                       -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the Access Date <access-date> element      -->
+<!ENTITY % access-date-elements
+                        "| %date-parts.class; | %x.class;"           >
+
+
+<!--                    AFFILIATION ELEMENTS                       -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <aff> element                          -->
+<!ENTITY % aff-elements "| %address.class; | %all-phrase; |
+                           %break.class; | %label.class;"            >
+
+
+<!--                    ANONYMOUS ELEMENTS                         -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        an <anonymous> element                     -->
+<!ENTITY % anonymous-elements
+                        "| %all-phrase;"                             >
+
+
+<!--                    ARTICLE TITLE ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <article-title> element.               -->
+<!ENTITY % article-title-elements
+                        "| %all-phrase; | %break.class;"             >
+
+
+<!--                    CHEMICAL STRUCTURE ELEMENTS                -->
+<!--                    Those elements that may mix with the data
+                        characters inside a Chemical Structure
+                        <chem-struct>                              -->
+<!ENTITY % chem-struct-elements
+                        "| %access.class; |  %all-phrase; |
+                         %break.class; | %id.class; |
+                         %label.class; | %list.class; |
+                         %simple-display-noalt.class;"               >
+
+
+<!--                    CITATION ELEMENTS                          -->
+<!--                    Content for both types of citation. These
+                        elements may be mixed with #PCDATA in the
+                        <mixed-citation> element (in which all
+                        punctuation and spacing are left intact), and
+                        they also constitute the choices that can be
+                        used to form the all-element-content of the
+                        <element-citation> element (in which
+                        punctuation and spacing are removed).
+                        Design Note: All inline mixes begin with an
+                        OR bar.                                    -->
+<!ENTITY % citation-elements
+                        "%article-link.class; | %appearance.class; |
+                         %citation-additions.class; |
+                         %emphasis.class;  | %inline-display.class; |
+                         %inline-math.class; | %label.class; |
+                         %math.class; |  %phrase.class; |
+                         %references.class; | %simple-link.class; |
+                         %subsup.class; |  %x.class;"                >
+
+
+<!--                    COLLABORATIVE (GROUP) AUTHOR ELEMENTS      -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <collab> element. This is essentially
+                        %all-phrase; plus contrib-info and break.
+                        All-phase is not used because of
+                        duplication clashes with the
+                        -contrib-info.class;                       -->
+<!ENTITY % collab-elements
+                        "| %article-link.class; | %address.class; |
+                         %appearance.class; | %break.class; |
+                         %contrib-group.class; |
+                         %contrib-info.class; |
+                         %emphasis.class; | %inline-display.class; |
+                         %inline-math.class; | %math.class; |
+                         %phrase.class; | %subsup.class; | %x.class;">
+
+
+<!--                    COMPOUND KEYWORD PART ELEMENTS             -->
+<!--                    Elements to be mixed with data characters
+                        inside the <compound-kwd-part> element     -->
+<!ENTITY % compound-kwd-part-elements
+                        "| %break.class; | %all-phrase;"             >
+
+
+<!--                    CONFERENCE DATE ELEMENTS                   -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <conf-date> element                    -->
+<!ENTITY % conf-date-elements
+                        "| %date-parts.class; | %face-markup.class; |
+                         %x.class;"                                  >
+
+
+<!--                    COMMENT ELEMENTS                           -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the Comment in a Citation <comment> element.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % comment-elements
+                        "| %all-phrase;"                             >
+
+
+<!--                    COPYRIGHT HOLDER ELEMENTS                  -->
+<!--                    Elements to be mixed with data characters
+                        inside the content model for the
+                        <copyright-holder> element.                -->
+<!ENTITY % copyright-holder-elements
+                        "| %institution-wrap.class; | %subsup.class; | 
+                         %x.class;"                                  >
+
+
+<!--                    COPYRIGHT STATEMENT ELEMENTS               -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <copyright-statement>                  -->
+<!ENTITY % copyright-statement-elements
+                        "| %all-phrase;"                             >
+
+
+<!--                    CORRESPONDENCE INFORMATION ELEMENTS        -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the correspondence information.            -->
+<!ENTITY % corresp-elements
+                        "| %address.class; | %all-phrase; |
+                           %break.class; | %label.class;"            >
+
+
+<!--                    COUNTRY ELEMENTS                           -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the country element.                       -->
+<!ENTITY % country-elements
+                        "| %x.class;"                                >
+
+
+<!--                    DATE IN CITATION ELEMENTS                  -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the Date Inside Citation <date-in-citation>
+                        element                                    -->
+<!ENTITY % date-in-citation-elements
+                        "| %date-parts.class; | %emphasis.class; |
+                           %subsup.class; | %x.class;"               >
+
+<!--                    FORMULA, DISPLAY ELEMENTS                  -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <disp-formula>                         -->
+<!ENTITY % disp-formula-elements
+                        "| %all-phrase; | %abstract.class; |
+                         %access.class; | %break.class; | 
+                         %display-back-matter.class; |
+                         %kwd-group.class; | %label.class; |
+                         %simple-display-noalt.class;"               >
+
+
+<!--                    EMAIL ADDRESS ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <email> element                        -->
+<!ENTITY % email-elements
+                        "| %all-phrase;"                             >
+
+
+<!--                    ET AL ELEMENTS                             -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        an <etal> element                          -->
+<!ENTITY % etal-elements
+                        "| %all-phrase;"                             >
+
+
+<!--                    EXTERNAL LINK ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        an <ext-link>                              -->
+<!ENTITY % ext-link-elements
+                        "| %all-phrase;"                             >
+
+
+<!--                    FUNDING STATEMENT ELEMENTS                 -->
+<!--                    Model for the <funding-statement> element  -->
+<!ENTITY % funding-statement-elements
+                        "| %all-phrase; | %funding.class;"           >
+
+
+<!--                    HISTORY ELEMENTS                           -->
+<!--                    Elements that may be mixed with data
+                        characters inside the model for <history>
+                        when <history> is modeled as a mixed content
+                        element.                                   -->
+<!ENTITY % history-elements
+                        "| %all-phrase; | %break.class; |
+                         %date.class;"                               >
+
+
+<!--                    FORMULA, INLINE ELEMENTS                   -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <inline-formula> element.              -->
+<!ENTITY % inline-formula-elements
+                        "| %access.class; | %all-phrase;"            >
+
+
+<!--                    INLINE SUPPLEMENTARY MATERIAL ELEMENTS     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <inline-supplementary-material> element-->
+<!ENTITY % inline-supplementary-material-elements
+                        "| %access.class; | %all-phrase;"            >
+
+
+<!--                    INSTITUTION NAME ELEMENTS                  -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <institution> element                  -->
+<!ENTITY % institution-elements
+                        "| %all-phrase; | %break.class;"             >
+
+
+<!--                    ISBN ELEMENTS                              -->
+<!--                    Elements for use with data characters inside
+                        the model for the <isbn> element           -->
+<!ENTITY % isbn-elements
+                        "| %x.class;"                                >
+
+
+<!--                    ISSN ELEMENTS                              -->
+<!--                    Elements for use with data characters inside
+                        the model for the <issn> element           -->
+<!ENTITY % issn-elements
+                        "| %x.class;"                                >
+
+
+<!--                    ISSN-L ELEMENTS                            -->
+<!--                    Elements for use with data characters inside
+                        the model for the <issn-l> element         -->
+<!ENTITY % issn-l-elements
+                        "| %x.class;"                                >
+
+
+<!--                    ISSUE TITLE ELEMENTS                       -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <issue-title> element                  -->
+<!ENTITY % issue-title-elements
+                        "| %all-phrase;"                             >
+
+
+<!--                    KEYWORD CONTENT ELEMENTS                   -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a keyword.                                 -->
+<!ENTITY % kwd-elements
+                        "| %all-phrase; | %break.class;"             >
+
+
+<!--                    LABEL ELEMENTS                             -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <label> element                        -->
+<!ENTITY % label-elements
+                        "| %all-phrase; | %break.class;"             >
+
+
+<!--                    LINK ELEMENTS                              -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        linking element such as <xref>, <target>,
+                        and <ext-link>                             -->
+<!ENTITY % link-elements
+                        "| %all-phrase; | %break.class;"             >
+
+
+<!--                    LONG DESCRIPTION ELEMENTS                  -->
+<!--                    Elements to be mixed with data characters
+                        inside the <long-desc> element             -->
+<!ENTITY % long-desc-elements
+                        "| %x.class;"                                >
+
+
+<!--                    METADATA DATA NAME ELEMENTS                -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <meta-name> element                    -->
+<!ENTITY % meta-name-elements
+                        "| %all-phrase;"                             >
+
+
+<!--                    METADATA DATA VALUE ELEMENTS               -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <meta-value> element                   -->
+<!ENTITY % meta-value-elements
+                        "| %all-phrase;"                             >
+
+
+<!--                    NAMED CONTENT ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <named-content> element                -->
+<!ENTITY % named-content-elements
+                        "| %all-phrase; |
+                         %block-display-noalt.class; |
+                         %block-math.class; | %list.class; |
+                         %rest-of-para.class;"                       >
+
+
+<!--                    PARAGRAPH ELEMENTS                         -->
+<!--                    Elements that may be used within a paragraph
+                        in a mixed content model with #PCDATA.
+                        Design Note: There is a major overlap between
+                        this parameter entity and the mix for elements
+                        that are at the same level as a paragraph.
+                        Inline elements appear only inside a
+                        paragraph, but block elements such as quotes
+                        and lists may appear either within a
+                        paragraph or at the same level as a
+                        paragraph. This serves a requirement in a
+                        repository DTD, since some incoming material
+                        will have restricted such elements to only
+                        inside a paragraph, some incoming material
+                        will have restricted them to only outside a
+                        paragraph and some may allow them in both
+                        places. Thus the DTD must allow for them to
+                        be in either or both.                      -->
+<!ENTITY % p-elements   "| %all-phrase; |
+                         %block-display-noalt.class; |
+                         %block-math.class; | %citation.class; |
+                         %funding.class; | %list.class; |
+                         %rest-of-para.class;"                       >
+
+
+<!--                    PERSON GROUP ELEMENTS                      -->
+<!--                    Elements to be mixed with #PCDATA characters
+                        within the Person Group element
+                        (name class include <string-name> in this
+                        tag set.-->
+<!ENTITY % person-group-elements
+                        "| %name.class; | %person-group-info.class; |
+                          %x.class;"                                 >
+
+
+<!--                    PREFORMATTED TEXT ELEMENTS                 -->
+<!--                    Elements that may be used, along with data
+                        characters, inside the content model for the
+                        <preformat> element, in which whitespace,
+                        such as tabs, line feeds, and spaces will
+                        be preserved.                              -->
+<!ENTITY % preformat-elements
+                        "| %access.class; | %all-phrase; |
+                         %display-back-matter.class; "               >
+
+
+<!--                    PRODUCT ELEMENTS                           -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <product> element
+                        (Note: all-phrase was replicated and not
+                        used directly because the article-link.class
+                        elements are repeated in -references.class
+                        and therefore cause duplication.           -->
+<!ENTITY % product-elements
+                        "| %article-link.class; |
+                         %appearance.class; | %break.class; |
+                         %citation-additions.class; |
+                         %emphasis.class;  |
+                         %inline-display.class; |
+                         %inline-math.class; | %label.class; |
+                         %math.class; | %phrase.class; |
+                         %price.class; | %references.class; |
+                         %simple-link.class; |
+                         %subsup.class; | %x.class;"                 >
+
+
+<!--                    PUBLISHER'S LOCATION ELEMENTS              -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <publisher-loc> element                -->
+<!ENTITY % publisher-loc-elements
+                        "| %address.class; | %all-phrase; |
+                         %break.class;"                              >
+
+
+<!--                    RELATED ARTICLE ELEMENTS                   -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <related-article> element.
+                        (Note: all-phrase was replicated and not
+                        used directly because the article-link.class
+                        elements are repeated in -references.class
+                        and therefore cause duplication.)          -->
+<!ENTITY % related-article-elements
+                        " | %article-link.class; |
+                         %appearance.class; | %break.class; |
+                         %citation-additions.class; |
+                         %emphasis.class; | %inline-display.class; |
+                         %inline-math.class; | %journal-id.class; |
+                         %label.class; | %math.class; |
+                         %phrase.class; | %references.class; |
+                         %simple-link.class; |
+                         %subsup.class; | %x.class;"                 >
+
+
+<!--                    RELATED OBJECT ELEMENTS                    -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <related-object> element.
+                        (Note: all-phrase was replicated and not
+                        used directly because the article-link.class
+                        elements are repeated in -references.class
+                        and therefore cause duplication.)          -->
+<!ENTITY % related-object-elements
+                        "| %article-link.class; |
+                         %appearance.class; | %break.class; |
+                         %citation-additions.class; |
+                         %emphasis.class;  |
+                         %inline-display.class; |
+                         %inline-math.class; | %label.class; |
+                         %math.class; | %phrase.class; |
+                         %references.class; |
+                         %simple-link.class; |
+                         %subsup.class; | %x.class;"                 >
+
+
+<!--                    ROLE ELEMENTS                              -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <role>
+                        Design Note: All inline mixes begin with an
+                        OR bar; since %rendition-plus; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % role-elements
+                        "| %all-phrase;"                             >
+
+
+<!--                    SELF-URI ELEMENTS                          -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <self-uri> element                     -->
+<!ENTITY % self-uri-elements
+                        "| %all-phrase;"                             >
+
+
+
+<!--                    SIGNATURE BLOCK ELEMENTS                   -->
+<!--                    Elements to be mixed with data characters
+                        inside the content model for the
+                        <sig-block> element.                       -->
+<!ENTITY % sig-block-elements
+                        "| %all-phrase; | %break.class; |
+                         %contrib.class; |
+                         %just-base-display-noalt.class; |
+                         %person-group-info.class; | %sig.class;"    >
+
+
+<!--                    SIGNATURE ELEMENTS                         -->
+<!--                    Elements to be mixed with data characters
+                        inside the content model for the
+                        <sig> element.                             -->
+<!ENTITY % sig-elements "| %all-phrase; | %break.class; |
+                         %just-base-display-noalt.class;"            >
+
+
+<!--                    SIZE ELEMENTS                              -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the size element.                          -->
+<!ENTITY % size-elements
+                        "| %x.class;"                                >
+
+
+<!--                    SOURCE ELEMENTS                            -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <source> element                       -->
+<!ENTITY % source-elements
+                        "| %all-phrase; | %break.class;"             >
+
+<!--                    SPEAKER ELEMENTS                           -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a speaker.                                 -->
+<!ENTITY % speaker-elements
+                        "| %all-phrase; | %person-name.class;"       >
+
+
+<!--                    STANDARDS ORGANIZATION ELEMENTS            -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <std-organization>.                        -->
+<!ENTITY % std-organization-elements 
+                        "| %all-phrase; | %institution-wrap.class; |
+                         %break.class;"                              >
+
+
+<!--                    STRING DATE ELEMENTS                       -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <string-date> element                  -->
+<!ENTITY % string-date-elements
+                        "| %all-phrase; | %date-parts.class;"        >
+
+
+<!--                    STRING NAME ELEMENTS                       -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <string-name> element                  -->
+<!ENTITY % string-name-elements
+                        "| %all-phrase; | %person-name.class;"       >
+
+
+<!--                    STRUCTURAL TITLE ELEMENTS                  -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <title> element                        -->
+<!ENTITY % struct-title-elements
+                        "| %all-phrase; | %break.class; |
+                         %citation.class;"                           >
+
+
+<!--                    STYLED CONTENT ELEMENTS                    -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <styled-content> element               -->
+<!ENTITY % styled-content-elements
+                        "| %all-phrase; |
+                         %block-display-noalt.class;|
+                         %block-math.class; | %list.class; |
+                         %rest-of-para.class;"                       >
+
+
+<!--                    SUBJECT GROUPING NAME ELEMENTS             -->
+<!--                    Elements that may be used, along with data
+                        characters inside the content model of the
+                        <subject> element                          -->
+<!ENTITY % subject-elements
+                        "| %all-phrase; | %break.class;"             >
+
+
+<!--                    DEFINITION LIST: TERM ELEMENTS             -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <term>.                                  -->
+<!ENTITY % term-elements
+                        "| %all-phrase; | %block-math.class; |
+                         %chem-struct-wrap.class; |
+                         %simple-display-noalt.class;"               >
+
+
+<!--                    TEXTUAL FORM ELEMENTS                      -->
+<!--                    Model for the <textual-form> element.
+                        Added <label>                              -->
+<!ENTITY % textual-form-elements
+                        "| %emphasis.class; |
+                         %inline-display-noalt.class; |
+                         %label.class; | %math.class; |
+                         %phrase-content.class; | %subsup.class;"    >
+
+
+<!--                    TIME STAMP ELEMENTS                        -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <time-stamp>.                            -->
+<!ENTITY % time-stamp-elements
+                        "| %date-parts.class; | %x.class;"           >
+
+
+<!--                    TITLE ELEMENTS                             -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        title elements such as <title>, <subtitle>,
+                        <trans-title>, etc.                        -->
+<!ENTITY % title-elements
+                        "| %all-phrase; | %break.class;"             >
+
+
+<!--                    VERSE-LINE ELEMENTS                        -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <verse-line>
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % verse-line-elements
+                        "%simple-text;"                              >
+
+
+<!--                    X ELEMENTS                                 -->
+<!--                    Elements for use inside the <x> element    -->
+<!ENTITY % x-elements   "| %emphasis.class; | 
+                           %inline-display-noalt.class; |
+                           %phrase-content.class; | %subsup.class; |
+                           %x.class;"                                >
+
+
+<!-- ============================================================= -->
+<!--                    RUBY MARKUP                                -->
+<!-- ============================================================= -->
+
+
+<!--                    RUBY BASE ELEMENTS                         -->
+<!--                    Those elements that may mix with the data
+                        characters inside a Ruby Base <rb> 
+                        element.                                   -->
+<!ENTITY % rb-elements  "| %all-phrase;"                             >
+
+
+<!-- ============================================================= -->
+<!--                    DUPLICATES NEEDED FOR OVER-RIDES           -->
+<!--                    (models unchanged from common.ent but      -->
+<!--                     needed below)                             -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON ATTRIBUTES                          -->
+<!--                    These lists of attributes will be added to 
+                        nearly every element, in both the document 
+                        metadata and the document body, of the entire 
+                        Tag Set:
+                          - including table elements for both the 
+                              XHTML-inspired and OASIS-inspired
+                              table model elements
+                          - excluding only <mml:math> and 
+                              <xi:include> (whose namespaces JATS
+                              does not control).
+                           Great care should be taken to use these
+                        attributes judiciously, not as a shortcut to
+                        thinking through where an attribute should be
+                        used. Potential use cases include adding
+                        @xml:lang or some RDFa attribute to every 
+                        elements.                                  -->
+
+
+<!--                    JATS BASE ATTRIBUTES                       -->
+<!--                    Holds all the common attributes except @id.
+                        Used to keep the two common attribute lists 
+                        in sync. To add a global attribute, modify
+                        this list.                                 -->
+<!ENTITY % jats-base-atts
+            "xml:base   CDATA                             #IMPLIED"  >
+
+
+<!--                    JATS COMMON ATTRIBUTES                     -->
+<!--                    Holds all the common attributes, as defined in
+                        the base attribute parameter entity, plus an
+                        optional @id.                              -->
+<!ENTITY % jats-common-atts
+            "id         ID                                #IMPLIED 
+             %jats-base-atts;"                                       >
+
+
+<!--                    JATS COMMON ATTRIBUTES (ID REQUIRED)       -->
+<!--                    Holds all the common attributes, as defined in
+                        the base attribute parameter entity, plus a 
+                        required @id.                              -->
+<!ENTITY % jats-common-atts-id-required
+            "id         ID                                #REQUIRED
+             %jats-base-atts;"                                       >
+
+
+<!--                    MIGHT LINK XLINK ATTRIBUTES                -->
+<!--                    Used for elements which may need to link to
+                        external sources or other objects within
+                        the document, but may not necessarily act
+                        as a link at all.  The attribute
+                        "xlink:href" identifies the object to which
+                        the link points.                           -->
+<!ENTITY % might-link-atts
+            "xmlns:xlink CDATA                             #IMPLIED
+             xlink:type  (simple)                          #IMPLIED
+             xlink:href  CDATA                             #IMPLIED
+             xlink:role  CDATA                             #IMPLIED
+             xlink:title CDATA                             #IMPLIED
+             xlink:show  (embed | new | none | other | replace)
+                                                           #IMPLIED
+             xlink:actuate
+                         (none | onLoad | onRequest | other)
+                                                           #IMPLIED" >
+
+
+<!-- ============================================================= -->
+<!--                    SECTION OPTIONAL TITLE MODEL               -->
+<!-- ============================================================= -->
+
+
+<!--                    CONTENT MODEL FOR AN UNTITLED SECTION      -->
+<!--                    The model for a section-like structure that
+                        may or may not have an initial title       -->
+<!ENTITY % sec-opt-title-model
+                        "(sec-meta?, label?, title?, (%para-level;)*,
+                          (%sec-level;)*,
+                          (%sec-back-matter-mix;)* )"                >
+
+
+<!-- ============================================================= -->
+<!--                    OVER-RIDES OF CONTENT MODELS (FULL MODELS) -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE METADATA MODEL                     -->
+<!--                    Content model for the metadata that is
+                        specific to the article.                   -->
+<!ENTITY % article-meta-model
+                       "(article-id*, (%article-version.class;)?,
+                         article-categories?, title-group?,
+                         (%contrib-group.class; |
+                          %aff-alternatives.class; | %x.class;)*,
+                         author-notes?,  ( (%pub-date.class;)* | 
+                          pub-date-not-available?), 
+                         volume*, volume-id*, volume-series?,
+                         issue*, issue-id*, issue-title*,
+                         issue-sponsor*, issue-part?, 
+                         volume-issue-group*, isbn*,
+                         supplement?,
+                         ( ( (fpage, lpage?)?, page-range?) |
+                           elocation-id )?,
+                         (%address-link.class; | product |
+                          supplementary-material)*,
+                         history?, pub-history?,
+                         permissions?, self-uri*,
+                         (%related-article.class;)*, 
+                         (%abstract.class;)*, trans-abstract*, 
+                         (%kwd-group.class;)*, 
+                         funding-group*, support-group*,                      
+                         conference*, counts?, custom-meta-group?)"  >
+
+
+<!--                    ADDRESS MODEL                              -->
+<!--                    Content model for the <address> element    -->
+<!ENTITY % address-model
+                        "(%address.class; | %address-link.class; |
+                          %label.class; | %x.class;)*"               >
+
+
+<!--                    APPENDIX MODEL                             -->
+<!--                    Content model for the <app> element. The
+                        section model already contains parentheses.
+                        Made initial <title> optional.             -->
+<!ENTITY % app-model    "(%sec-opt-title-model;, permissions?)"      >
+
+
+<!--                    AUTHOR NOTES MODEL                         -->
+<!--                    Content model for an <author-notes> element.
+                                                                   -->
+<!ENTITY % author-notes-model
+                        "(label?, title?,
+                          (%corresp.class; | %fn-link.class; |
+                           %just-para.class; | %x.class;)+ )"        >
+
+
+<!--                    CONFERENCE MODEL                           -->
+<!--                    Content model for the <conference> element -->
+<!ENTITY % conference-model
+                        "(%conference.class; | %x.class;)*"          >
+
+
+<!--                    CONTRIBUTOR GROUP MODEL                    -->
+<!--                    Content model for the <title-group> element-->
+<!ENTITY % contrib-group-model
+                        "(%contrib.class; | %contrib-info.class; |
+                          %x.class;)+"                               >
+
+
+<!--                    CONTRIBUTOR MODEL                          -->
+<!--                    Content model for the <contrib> element    -->
+<!ENTITY % contrib-model
+                        "(%contrib-id.class; | %name.class; |  
+                          %degree.class; | %contrib-info.class; |  
+                          %x.class;)* "                              >
+
+
+<!--                    DEFINITION LIST: DEFINITION ITEM MODEL     -->
+<!--                    Content model of a <def-item>              -->
+<!ENTITY % def-item-model
+                        "(label?, term*, (%def.class; | %x.class;)* )"
+                                                                     >
+
+<!--                    DEFINITION LIST MODEL                      -->
+<!--                    Content model for the <def-list> element   -->
+<!ENTITY % def-list-model
+                        "(label?, title?, term-head?, def-head?,
+                          (%def-item.class; | %x.class;)*, 
+                          (%def-list.class;)* )"                     >
+
+
+<!--                    FOOTNOTE GROUP MODEL                       -->
+<!--                    Content model for the <fn-group> element
+                        Added an <x> as alternative to <fn>.       -->
+<!ENTITY % fn-group-model
+                        "(label?, title?,
+                          (%fn-link.class; | %x.class;)+ )"          >
+
+
+<!--                    HISTORY MODEL                              -->
+<!--                    Content model for the <history> element    -->
+<!ENTITY % history-model
+                        "(#PCDATA %history-elements;)*"              >
+
+
+<!--                    KEYWORD GROUP MODEL                        -->
+<!--                    Content model for a <kwd-group> element    -->
+<!ENTITY % kwd-group-model
+                        "(label?, title?,
+                          ((%kwd.class; | %x.class;)+ |
+                           (%unstructured-kwd-group.class;)* ) )"    >
+
+
+<!--                    LIST MODEL                                 -->
+<!--                    Content model for the <list> element       -->
+<!ENTITY % list-model   "(label?, title?,
+                          (%list-item.class; | %x.class;)+ )"        >
+
+
+<!--                    PUBLICATION DATE MODEL                     -->
+<!--                    Content model for the element <pub-date>   -->
+<!ENTITY % pub-date-model
+                        "(%date-parts.class; | %string-date.class; |
+                          %x.class;)*"                               >
+
+
+<!--                    REFERENCE ITEM MODEL                       -->
+<!--                    Content model for the <ref> element        -->
+<!ENTITY % ref-model    "(label?, (%citation.class; | %note.class; |
+                          %x.class;)+ )"                             >
+
+
+<!--                    REFERENCE LIST MODEL                       -->
+<!--                    Content model for the <ref-list> element   -->
+<!ENTITY % ref-list-model
+                        "(label?, title?, 
+                          (%para-level; | %ref.class;)*,
+                          (%ref-list.class;)* )"                     >
+                          
+                          
+<!--                    RUBY WRAPPER Model                         -->
+<!--                    Content model for the <ruby> element       -->
+<!ENTITY % ruby-model   "(rb, (rt | (rp, rt, rp)) )"                 >
+
+
+<!--                    CONTENT MODEL FOR A STRUCTURAL SECTION     -->
+<!--                    The model for a Section <sec>              -->
+<!ENTITY % sec-model    "(sec-meta?, label?, title?,
+                          (%para-level;)*, (%sec-level;)*,
+                          (%sec-back-matter-mix;)* )"                >
+
+
+<!--                    TABLE WRAP FOOTER MODEL                    -->
+<!--                    Content model for the <table-wrap-foot>
+                        element                                    -->
+<!ENTITY % table-wrap-foot-model
+                        "(label?, title?,
+                          (%just-para.class; |  %fn-group.class; |
+                           %fn-link.class; |
+                           %display-back-matter.class; |
+                           %x.class;)+ )"                            >
+
+
+<!--                    TRANSLATED ABSTRACT MODEL                  -->
+<!--                    Content model for an <trans-abstract> element.
+                                                                   -->
+<!ENTITY % trans-abstract-model
+                        "((%id.class;)*, %sec-opt-title-model;)"     >
+
+
+<!-- ============================================================= -->
+<!--                    OVER-RIDES OF ATTRIBUTE LISTS              -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE IDENTIFIER ATTRIBUTES              -->
+<!--                    Attributes for the <article-id> element    -->
+<!ENTITY % article-id-atts
+            "%jats-common-atts;                                       
+             pub-id-type                
+                        CDATA                             #IMPLIED
+             assigning-authority                
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    AWARD IDENTIFIER ATTRIBUTES                -->
+<!--                    Attributes for the <award-group> element   -->
+<!ENTITY % award-id-atts
+            "%jats-common-atts;                                       
+             rid        IDREFS                            #IMPLIED
+             award-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    DATE (HISTORICAL) ATTRIBUTES               -->
+<!ENTITY % date-atts
+            "%jats-common-atts;                                       
+             date-type  CDATA                             #IMPLIED
+             publication-format
+                        CDATA                             #IMPLIED
+             iso-8601-date
+                        CDATA                             #IMPLIED
+             calendar   CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    FUNDING STATEMENT ATTRIBUTES               -->
+<!--                    Attributes for the <funding-source> element-->
+<!ENTITY % funding-statement-atts
+            "%jats-common-atts;                                       
+             rid        IDREFS                            #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    PUBLICATION IDENTIFIER ATTRIBUTES          -->
+<!--                    Attributes for the <pub-id> element        -->
+<!ENTITY % pub-id-atts
+            "%jats-common-atts;                                       
+             pub-id-type
+                        CDATA                             #IMPLIED
+             assigning-authority                
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    TRANSLATED TITLE GROUP ATTRIBUTES          -->
+<!--                    Attribute list for the <trans-title-group>
+                        Made xml:lang optional.                    -->
+<!ENTITY % trans-title-group-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+
+<!--                    X(CROSS) REFERENCE ATTRIBUTES              -->
+<!--                    Attribute list for cross references        -->
+<!ENTITY % xref-atts
+            "%jats-common-atts;                                       
+             ref-type   CDATA                             #IMPLIED
+             alt        CDATA                             #IMPLIED
+             rid        IDREFS                            #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ================== End Archiving Content/ATT Over-rides ===== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-archivecustom-modules1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-archivecustom-modules1.ent
@@ -1,0 +1,351 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Journal Archiving DTD-Specific Modules            -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Journal Archiving DTD-Specific Modules v1.2 20190208//EN"
+     Delivered as file "JATS-archivecustom-modules1.ent"           -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     Article Authoring and Interchange DTD of the      --> 
+<!--             JATS DTD Suite                                    -->         
+<!--                                                               -->
+<!-- PURPOSE:    To name any modules created explicitly for this   -->
+<!--             DTD, that is, not present in the JATS DTD Suite   -->
+<!--                                                               -->
+<!-- CONTAINS:   Full external Parameter Entity declarations       -->
+<!--             for all Journal Archiving DTD-Specific modules    -->
+<!--             used by this DTD. (Note: the modules are DECLARED -->
+<!--             in this module, but referenced [invoked] in the   -->
+<!--             Journal Archiving and Interchange DTD module.)    -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This DTD was created from the JATS DTD Suite.     -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             August 2004                                       -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Archiving and Interchange DTD is      -->
+<!--             built from the JATS DTD Suite.                    -->
+<!--                                                               -->
+<!--             This DTD and the Suite are a continuation of      -->
+<!--             the work done by NCBI, Mulberry Technologies,     -->
+<!--             and Inera Inc. on the NLM Journal Archiving       -->
+<!--             and Interchange DTD Suite, which was originally   -->
+<!--             released in December, 2002.                       -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 12. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+
+  ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 11. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+ 10. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed. 
+     
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+  9. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+  8. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+    =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  7. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  6. JATS became version "1.1d3" and "v1.1d3 20150301"
+    =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  5. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  4. Updated the public identifier to "v1.0 20120330//EN", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "1".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+           http://jats.nlm.nih.gov/0.4.
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    CUSTOMIZATION MODULES DECLARED             -->
+<!-- ============================================================= -->
+
+
+<!--                    DTD-SPECIFIC CLASS CUSTOMIZATIONS MODULE   -->
+<!--                    Set up the Parameter Entities and element
+                        class definitions that will be used to
+                        over-ride some element classes in the
+                        DTD Suite.                                 -->
+<!ENTITY % archivecustom-classes.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Classes Module v1.2 20190208//EN"
+"JATS-archivecustom-classes1.ent"                                    >
+
+
+<!--                    DTD-SPECIFIC MIX CUSTOMIZATIONS MODULE     -->
+<!--                    Set up the Parameter Entities and element
+                        mix definitions that will be used to
+                        over-ride some element mixes in the DTD
+                        Suite.                                     -->
+<!ENTITY % archivecustom-mixes.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Mixes Module v1.2 20190208//EN"
+"JATS-archivecustom-mixes1.ent"                                      >
+
+
+<!--                    DTD-SPECIFIC MODELS/ATTRIBUTES CUSTOMIZATIONS
+                        MODULE                                     -->
+<!--                    Set up the Parameter Entities for element-
+                        specific element groups, complete content
+                        models, and attribute list and value over-
+                        rides. These PEs will over-ride selected
+                        content models and attribute lists for the
+                        Journal JATS DTD Suite-->
+<!ENTITY % archivecustom-models.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Content and Attributes Module v1.2 20190208//EN"
+"JATS-archivecustom-models1.ent"                                     >
+
+
+<!--                    NLM CITATION MODULE                        -->
+<!--                    The only new element created for the
+                        Publishing DTD, the highly structured NLM
+                        citation, to enforce a slightly loose version
+                        of an NLM-structured bibliographic reference.
+                        Sequence is enforced and interior punctuation
+                        is expected to be generated.               -->
+<!ENTITY % nlmcitation.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) NLM Citation v1.2 20190208//EN"
+"JATS-nlmcitation1.ent"                                              >
+
+
+<!-- =================== End Archive DTD Module of Modules ======= -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-articlemeta1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-articlemeta1.ent
@@ -1,0 +1,2251 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Journal Article Metadata Elements                 -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Journal Article Metadata Elements v1.2 20190208//EN"
+     Delivered as file "JATS-articlemeta1.ent"                     -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Names all elements used to describe the journal   -->
+<!--             in which the journal article is published.        -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 45. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 44. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 43. PUB-ID-TYPE - @pub-id-type changed back to a fixed list from 
+     CDATA, reversing the decision of Version 1.2d1. Although 
+     the value list is unchanged, best practice will be documented
+     as using @pub-id-type for type and @assigning-authority
+     for the responsible agency.
+       - for <article-id>
+
+ 42. ASSIGNING AUTHORITY - Added @assigning-authority to the
+     following elements, so that the type-of-identifier and
+     the party-responsible-for-identifier could both be
+     recorded. Previously, these values were both assigned to
+     the attribute @pub-id-type.
+         - <article-id>
+
+ 41. NON-MONETARY SUPPORT - Inside <article-meta> added new
+     <support-group> to hold both funding and
+     non-monetary support descriptions. <support-group> is 
+     both a peer to <funding-group> (backward compatibility)
+     and contains <funding-group>.
+ 
+ 40. PUBLICATION DATE-NOT-AVAILABLE - Inside <article-meta>, 
+     <front-stub>, <event>, and <event-desc>
+     added new element <pub-date-not-available>, as an 
+     alternative to <pub-date>. The meaning is that a 
+     publication date was (for whatever reason) not available. 
+     Presence of the element says nothing about publication 
+     status.
+   
+ 39. VOCABULARY/TAXONOMY ATTRIBUTES - Added 2 new attributes for
+     naming (and possibly linking to) general or controlled
+     taxonomy, vocabulary, index, database or other source of
+     terms (@vocab, and @vocab-identifier) to these
+     elements (which could already take the attributes
+     @vocab-term and @vocab-term-identifier):
+        - <kwd>
+        - <compound-kwd>
+        - <nested-kwd>
+        - <subject>
+        - <compound-subject>
+
+ 38. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 37. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 36. EVENTS - 
+      - Added <event>, which will reside only inside
+        <pub-history>. 
+      - Added <pub-history> to hold <event>s. Unlike in BITS, 
+        <pub-history> will contain ONLY <event>s.
+      - Took <event> attributes from BITS. 
+      - Added <article-version> to model of <event>.
+  
+ 35. PUB-ID-TYPE - @pub-id-type changed from a fixed list to
+     CDATA for all usages of the attribute.
+
+ 34. ARTICLE META MODEL
+     - NO DATE - <pub-date> (optional repeatable) is now
+       followed by the optional new element 
+       <pub-date-not-available>. 
+
+     - ARTICLE VERSION - Added new element <article-version>
+       inside <article-meta> to hold one version number for  
+       the article. <article-version> element may repeat inside
+       new element <article-version-alternatives> to hold 
+       version numbers for this article from different systems.
+ 
+     - PUBLICATION HISTORY - Added new element based on BITS,
+       <pub-history>, to hold <event>s as <history> holds
+       <date>s. New internal elements: <event>, <event-desc>
+   
+ 33. VOCABULARY/TAXONOMY ATTRIBUTES - Added 4 new attributes for
+     naming (and possibly linking to) a general or controlled
+     taxonomy, vocabulary, index, database or other source of
+     terms: @vocab, @vocab-identifier, @vocab-term, and
+     @vocab-term-identifier
+
+      - Attributes @vocab and @vocab-identifier were 
+        added to the elements:
+        - <kwd-group>
+        - <subj-group>
+        - <unstructured-kwd-group>
+
+      - Attributes @vocab-term and @vocab-term-identifier were
+        added to the elements:
+        - <kwd>
+        - <compound-kwd>
+        - <nested-kwd>
+        - <subject>
+        - <compound-subject>
+ 
+ 32. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 31. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 30. JATS became version "1.1d3" and "v1.1d3 20150301"
+  
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+ 
+ 29. <VOLUME> INSIDE <ARTICLE-META>
+
+   - Allowed <volume> to repeat inside <article-meta>, the types to 
+     be distinguished using @content-type
+
+   - Added new optional element <volume-issue-group> inside 
+     <article-meta) following all volume and issue elements
+     to hold volume-issue pairs (or n-tuples) when a second
+     and subsequent <volume> has its own related issue
+     information.
+
+   - Made <issue> repeatable, for those who choose not to use
+     the new wrapper element.
+   
+ 28. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 27. NEW <era> ELEMENT
+     Added <era> through date-model
+      - <pub-date>
+
+ 26. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added a new attribute list to:
+      - article-categories
+      - article-meta
+      - counts
+      - history
+      - title-group                          
+
+ 25. ABSTRACTS AND KEYWORDS
+       Changed "abstract*" to "(%abstract.class;)*"
+       and "kwd-group*" to "(%kwd-group.class;)*" since those
+       classes now exist. Elements should have a limited number of
+       ways to be invoked.
+        - article-meta (through %article-meta-model;)
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+ 24. RELATED OBJECT - Added <related-object> everywhere
+     <related-article> was used, including inside 
+     <article-meta> using article-meta-model.
+
+ 23. CONTRIB-GROUP AND CONTRIB MODULE SHIFT - Moved <contrib>
+     and <contrib-group> to common.ent, since they are now used
+     in both article metadata and journal metadata.
+
+ 22. CONTRIBUTOR MODEL - Added "contrib-id.class" to the beginning
+     at the <contrib> model, to hold identifiers for people,
+     such as publishers-specific IDs, ORCIDs, and JST and NII 
+     identifiers.
+   
+ 21. COUNTS - Generic <count> element added to the <counts>
+     wrapper. This element is allowed to repeat, to count
+     anything a publisher or archive may wish to count.
+     The @count-type attribute will name what is being counted
+     (such as figures, tables, sections, contributors, images,
+     etc.) The @count attribute will state how many of the 
+     objects are in the document.
+     
+     Although a publisher or archive could choose to label
+     all the counted objects in a document this way, the
+     specific count elements (fig-count, equation-count,
+     word-count, etc.) will be retained for backwards
+     compatibility.
+     
+     New parameter entities: count-atts.
+   
+ 20. PUBLICATION DATE ATTRIBUTES - Added to the attributes for
+     <pub-date> (through @pub-date-atts):
+       a) @iso-8601-date - ISO 8601 standard date format
+          of the publication date. Format  YYYY-MM-DDThh:mm:ss 
+       b) @calendar - Name of the calendar used (@calendar) in
+          naming this publication date (such as "Gregorian", 
+          "Japanese" (Emperor years), or "Islamic").
+       c) @date-type to record lifecycle information as to which
+          publication date is involved (such as retracted, corrected,
+          preprint).
+       d) @publication-format to hold what format or media was 
+          published on this date (such as "print" or
+          "electronic").
+       e) @xml:lang (comments below said was this added for 0.4).
+   
+ 19. COMPOUND KEYWORD PARTS - Allowed the individual compound 
+     keyword parts (<compound-kwd-part> to be as complex as 
+     ordinary keywords <kwd>), by giving them the same model 
+     as <kwd>.
+   
+ 18. NESTED KEYWORDS - Added new keyword type element for nested
+     keywords (<nested-kwd>), to hold hierarchical keywords such
+     as taxonomic structures. New PEs %nested-kwd-model  and
+     %nested-kwd-atts 
+   
+ 17. MODULE MOVEMENT (from increased reference content)
+
+     a) Element <degrees> - Moved <degrees> and its parameter
+        entities from this module from JATS-common.ent.
+   
+     b) Element <supplement> - Moved <supplement> and its parameter
+        entities from this module from JATS-common.ent.
+   
+     c) Element <conf-sponsor> - Moved <conf-sponsor> and its parameter
+        entities from this module from JATS-common.ent.
+   
+     d) Element <on-behalf-of> - Moved <on-behalf-of> and its parameter
+        entities from this module from JATS-common.ent.
+   
+ 16. Added name comment to %counts-model;
+
+ 15. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+ 14. Updated the DTD-version attribute to "0.4" 
+   
+ 13. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+           http://jats.nlm.nih.gov/0.4.
+
+ 12. UNSTRUCTURED KEYWORD GROUP ATTRIBUTES - Made
+     %unstructured-kwd-group-atts; into its own PE, as
+     documentation stated had already been done.
+
+ 11. KEYWORD ATTRIBUTES - To make the tag set more consistent,
+     added @content-type to <kwd>, since <compound-kwd> already
+     took this attribute. Through %kwd-atts;
+
+ 10. I18N - At the request of the SBJ Working Group (Japan)
+     made <series-text> repeatable inside <article-categories> using
+     %article-categories-model;
+
+  9. TITLE ELEMENTS - Removed the dependency which had both
+     <subtitle> and <alt-title> modeled with the same parameter
+     entity %title-elements;. Created new PEs for each element
+     but set them (as the default) to %title-elements so that no
+     customization would break. Models changed:
+       - alt-title    %alt-title-elements; defined in common.ent
+       - subtitle     %subtitle-elements; (moved to this
+           module)
+
+  8. AFFILIATION ALTERNATIVES - Added the element <aff-alternatives>
+     to <article-meta> through %article meta-model;. This element
+     will hold multiple <aff>s that are a representation of a
+     single affiliation, for example, the name of an institution
+     in two languages or two scripts.
+
+  7. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+      - alt-title through alt-title-atts (both)
+      - article-id through article-id-atts (@specific-use only)
+      - author-comment through author-comment-atts (both)
+      - author-notes through author-notes-atts (both)
+      - article-id through article-id-atts (@xml:lang)
+      - contrib through contrib-atts (@specific-use only)
+      - contrib-group through contrib-group-atts (@xml:lang)
+      - corresp through corresp-atts (@specific-use)
+      - degrees through degrees-atts (both)
+      - kwd-group through kwd-group-atts (@specific-use only
+             @xml:lang already there)
+      - on-behalf-of through on-behalf-of-atts (both) NEW PE
+      - product through product-atts (both)
+      - pub-date through pub-date-atts (@xml:lang)
+      - self-uri through self-uri-atts (both)
+      - series-text through series-text-atts (both)
+      - series-title through series-title-atts (both)
+      - string-conf through string-conf-atts (both)
+      - subj-group through subj-group-atts (both)
+      - subtitle through subtitle-atts (@specific only
+             @xml:lang already there)
+      - supplement through supplement-atts (both)
+
+  6. TITLE ELEMENTS - Removed the dependency which had both
+     <subtitle> and <alt-title> modeled with the same parameter
+     entity %title-elements;. Created new PEs for each element
+     but set them (as the default) to %title-elements so that no
+     customization would break.
+
+  5. COUNT ATTRIBUTES - Removed the dependency which had all of
+     the count elements using a single attribute list (%count-atts;)
+     Created new attributes list PEs for each of them: equation-count,
+     fig-count, page-count, ref-count, table-count, and word-count.
+     *****Customization Alert: New parameter entities could break
+     some customizations. Check the attribute list parameter entity
+     for each of the count elements. *****
+
+  4. COMPOUND SUBJECT - Created a new element <compound-subject>
+     that acts just like <compound-kwd>, in that it takes one or
+     more <compound-subject-part>s to allow a complex, multi-
+     part subject to be captured. New elements, attribute lists,
+     and parameter entities. (An example of a compound subject
+     is a code with a textual keyword (A11 Permeability).
+     Allowed <compound-subject> as an alternative to <subject>
+     inside a <subj-group>.
+
+  3. SERIES TEXT ATTRIBUTES - Both <series-title> and
+     <series-text> used to use the PE %series-title-atts;. Added the
+     PE %series-text-atts;, which is the only one <series-text>
+     uses. No documents need change.
+     *****Customization Alert: New parameter entity could break some
+     customizations. Check your <series-text> attributes. *****
+
+  2. TRANSLATED ABSTRACT ATTRIBUTES - Both <abstract> and
+     <trans-abstract> used to use the PE %abstract-atts;. Added the
+     PE %trans-abstract-atts;, which is the only one <trans-abstract>
+     uses. No documents need change.
+     *****Customization Alert: New parameter entity could break some
+     customizations. Check your <trans-abstract> attributes. *****
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    ABSTRACT ATTRIBUTES                        -->
+<!--                    Attributes for the <abstract> element      -->
+<!ENTITY % abstract-atts
+            "%jats-common-atts;                                       
+             abstract-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ALTERNATE TITLE ATTRIBUTES                 -->
+<!--                    Attributes for the <alt-title> element     -->
+<!ENTITY % alt-title-atts
+            "%jats-common-atts;                                       
+             alt-title-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ARTICLE CATEGORIES ATTRIBUTES              -->
+<!--                    Attributes for the <article-categories> 
+                        element                                    -->
+<!ENTITY % article-categories-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    ARTICLE METADATA ATTRIBUTES                -->
+<!--                    Attributes for the <article-meta> element  -->
+<!ENTITY % article-meta-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    ARTICLE VERSION ATTRIBUTES                 -->
+<!--                    Attributes for the <article-version> 
+                        element                                    -->
+<!ENTITY % article-version-atts
+            "%jats-common-atts;                                       
+             article-version-type
+                        CDATA                             #IMPLIED
+             designator CDATA                             #IMPLIED
+             vocab      CDATA                             #IMPLIED
+             vocab-identifier
+                        CDATA                             #IMPLIED
+             vocab-term CDATA                             #IMPLIED
+             vocab-term-identifier
+                        CDATA                             #IMPLIED
+             iso-8601-date
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    ARTICLE VERSION ALTERNATIVE ATTRIBUTES     -->
+<!--                    Attributes for the 
+                        <article-version-alternatives> element     -->
+<!ENTITY % article-version-alternatives-atts
+            "%jats-common-atts;"                                     >
+
+
+
+<!--                    AUTHOR COMMENT ATTRIBUTES                  -->
+<!--                    Attributes for the <author-comment> element-->
+<!ENTITY % author-comment-atts
+            "%jats-common-atts;                                       
+             content-type
+                       CDATA                              #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    AUTHOR NOTES ATTRIBUTES                    -->
+<!--                    Attributes for the <author-notes> element  -->
+<!ENTITY % author-notes-atts
+            "%jats-common-atts;                                       
+             rid        IDREFS                            #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    ARTICLE IDENTIFIER ATTRIBUTES              -->
+<!--                    Attributes for the <article-id> element    -->
+<!ENTITY % article-id-atts
+            "%jats-common-atts;                                       
+             pub-id-type
+                        (%pub-id-types;)                  #IMPLIED
+             assigning-authority                
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    COMPOUND KEYWORD ATTRIBUTES                -->
+<!--                    Attributes for the <compound-kwd> element
+                                                                   -->
+<!ENTITY % compound-kwd-atts
+            "%jats-common-atts;                                       
+             vocab      CDATA                             #IMPLIED
+             vocab-identifier
+                        CDATA                             #IMPLIED
+             vocab-term CDATA                             #IMPLIED
+             vocab-term-identifier
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    COMPOUND KEYWORD PART ATTRIBUTES           -->
+<!--                    Attributes for the <compound-kwd-part>
+                        element                                    -->
+<!ENTITY % compound-kwd-part-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    COMPOUND SUBJECT ATTRIBUTES                -->
+<!--                    Attributes for the <compound-subject> element
+                                                                   -->
+<!ENTITY % compound-subject-atts
+            "%jats-common-atts;                                       
+             vocab      CDATA                             #IMPLIED
+             vocab-identifier
+                        CDATA                             #IMPLIED
+             vocab-term CDATA                             #IMPLIED
+             vocab-term-identifier
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    COMPOUND SUBJECT PART ATTRIBUTES           -->
+<!--                    Attributes for the <compound-subject-part>
+                        element                                    -->
+<!ENTITY % compound-subject-part-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    CONFERENCE ACRONYM ATTRIBUTES              -->
+<!--                    Attributes for the <conf-acronym> element  -->
+<!ENTITY % conf-acronym-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    CONFERENCE NUMBER ATTRIBUTES               -->
+<!--                    Attributes for the <conf-num> element      -->
+<!ENTITY % conf-num-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    CONFERENCE THEME ATTRIBUTES                -->
+<!--                    Attributes for the <conf-theme> element    -->
+<!ENTITY % conf-theme-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    CONFERENCE ATTRIBUTES                      -->
+<!--                    Attributes for the <conference> element    -->
+<!ENTITY % conference-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    CORRESPONDING ATTRIBUTES                   -->
+<!--                    Attributes for the <corresp> element       -->
+<!ENTITY % corresp-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    COUNT ATTRIBUTES                           -->
+<!--                    Attributes for the <count> element         -->
+<!ENTITY % count-atts
+            "%jats-common-atts;                                       
+             count-type CDATA                             #REQUIRED 
+             count      NMTOKEN                           #REQUIRED" >
+
+
+<!--                    COUNTS ATTRIBUTES                          -->
+<!--                    Attributes for the <counts> element        -->
+<!ENTITY % counts-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    DATE NOT AVAILABLE ATTRIBUTES              -->
+<!--                    Attributes for the <pub-date-not-available> 
+                        element                                    -->
+<!ENTITY % pub-date-not-available-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    EQUATION COUNT ATTRIBUTES                  -->
+<!--                    Attributes for the <equation-count> element-->
+<!ENTITY % equation-count-atts
+            "%jats-common-atts;                                       
+             count      NMTOKEN                          #REQUIRED"  >
+
+<!--                    PUBLICATION EVENT ATTRIBUTES               -->
+<!--                    Attributes for the <event> element         -->
+<!ENTITY % event-atts
+           "%jats-common-atts;
+             event-type CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    EVENT DESCRIPTION ATTRIBUTES               -->
+<!--                    Attributes used with the <event-desc>
+                        element.                                   -->
+<!ENTITY % event-desc-atts
+           "%jats-common-atts;
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    FIGURE COUNT ATTRIBUTES                    -->
+<!--                    Attributes for the <fig-count> element     -->
+<!ENTITY % fig-count-atts
+            "%jats-common-atts;                                       
+             count      NMTOKEN                           #REQUIRED" >
+
+
+<!--                    HISTORY ATTRIBUTES                         -->
+<!--                    Attributes for the <history> element       -->
+<!ENTITY % history-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    KEYWORD ATTRIBUTES                         -->
+<!--                    Attributes for the <kwd> element           -->
+<!ENTITY % kwd-atts
+            "%jats-common-atts;
+             vocab      CDATA                             #IMPLIED
+             vocab-identifier
+                        CDATA                             #IMPLIED
+             vocab-term CDATA                             #IMPLIED
+             vocab-term-identifier
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    KEYWORD GROUP ATTRIBUTES                   -->
+<!--                    Attributes for the <kwd-group> element     -->
+<!ENTITY % kwd-group-atts
+            "%jats-common-atts;                                       
+             kwd-group-type
+                        CDATA                             #IMPLIED
+             vocab      CDATA                             #IMPLIED
+             vocab-identifier
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    NESTED KEYWORD ATTRIBUTES                  -->
+<!--                    Attributes for the <nested-kwd> element    -->
+<!ENTITY % nested-kwd-atts
+            "%jats-common-atts;                                       
+             vocab      CDATA                             #IMPLIED
+             vocab-identifier
+                        CDATA                             #IMPLIED
+             vocab-term CDATA                             #IMPLIED
+             vocab-term-identifier
+                        CDATA                             #IMPLIED
+             content-type
+                       CDATA                             #IMPLIED"  >
+
+
+<!--                    PAGE COUNT ATTRIBUTES                      -->
+<!--                    Attributes for the <page-count> element    -->
+<!ENTITY % page-count-atts
+            "%jats-common-atts;                                       
+             count      NMTOKEN                           #REQUIRED" >
+
+
+<!--                    PRODUCT ATTRIBUTES                         -->
+<!--                    Attributes for the <product> element       -->
+<!ENTITY % product-atts
+            "%jats-common-atts;                                       
+             product-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    PUBLICATION DATE ATTRIBUTES                -->
+<!--                    Attributes for the <pub-date> element      -->
+<!ENTITY % pub-date-atts
+            "%jats-common-atts;                                       
+             pub-type   CDATA                             #IMPLIED
+             publication-format
+                        CDATA                             #IMPLIED
+             date-type  CDATA                             #IMPLIED
+             iso-8601-date
+                        CDATA                             #IMPLIED
+             calendar   CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PUBLICATION HISTORY ATTRIBUTES             -->
+<!--                    Attributes for the <pub-history> element   -->
+<!ENTITY % pub-history-atts
+           "%jats-common-atts;"                                      >
+
+
+<!--                    REFERENCE (CITATION) COUNT ATTRIBUTES      -->
+<!--                    Attributes for the <ref-count> element     -->
+<!ENTITY % ref-count-atts
+            "%jats-common-atts;                                       
+             count      NMTOKEN                           #REQUIRED" >
+
+
+<!--                    SELF URI ATTRIBUTES                        -->
+<!--                    Attributes for the <self-uri> element      -->
+<!ENTITY % self-uri-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    SERIES TEXT ATTRIBUTES                     -->
+<!--                    Attributes for the <series-text> element   -->
+<!ENTITY % series-text-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SERIES TITLE ATTRIBUTES                    -->
+<!--                    Attributes for the <series-title> element  -->
+<!ENTITY % series-title-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    STRING CONFERENCE ATTRIBUTES               -->
+<!--                    Attributes for the <string-conf> element   -->
+<!ENTITY % string-conf-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SUBJECT GROUP ATTRIBUTES                   -->
+<!--                    Attributes for the <subj-group> element    -->
+<!ENTITY % subj-group-atts
+            "%jats-common-atts;                                       
+             subj-group-type
+                        CDATA                             #IMPLIED
+             vocab      CDATA                             #IMPLIED
+             vocab-identifier
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+<!--                    SUBJECT ATTRIBUTES                         -->
+<!--                    Attributes for the <subject> element       -->
+<!ENTITY % subject-atts
+            "%jats-common-atts;                                       
+             vocab      CDATA                             #IMPLIED
+             vocab-identifier
+                        CDATA                             #IMPLIED
+             vocab-term CDATA                             #IMPLIED
+             vocab-term-identifier
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    SUBTITLE ATTRIBUTES                        -->
+<!--                    Attributes for the <subtitle> element      -->
+<!ENTITY % subtitle-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    TABLE COUNT ATTRIBUTES                     -->
+<!--                    Attributes for the <table-count> element   -->
+<!ENTITY % table-count-atts
+            "%jats-common-atts;                                       
+             count      NMTOKEN                           #REQUIRED" >
+
+
+<!--                    TITLE GROUP ATTRIBUTES                     -->
+<!--                    Attributes for the <title-group> element   -->
+<!ENTITY % title-group-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    TRANSLATED ABSTRACT ATTRIBUTES             -->
+<!--                    Attributes for the <trans-abstract> element-->
+<!ENTITY % trans-abstract-atts
+            "%jats-common-atts;                                       
+             abstract-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    UNSTRUCTURED KEYWORD GROUP ATTRIBUTES      -->
+<!--                    Attributes for the <unstructured-kwd-group>
+                                                       element     -->
+<!ENTITY % unstructured-kwd-group-atts
+            "%jats-common-atts;                                       
+             kwd-group-type
+                        CDATA                             #IMPLIED
+             vocab      CDATA                             #IMPLIED
+             vocab-identifier
+                        CDATA                             #IMPLIED 
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    WORD COUNT ATTRIBUTES                      -->
+<!--                    Attributes for the <word-count> element    -->
+<!ENTITY % word-count-atts
+            "%jats-common-atts;                                       
+             count      NMTOKEN                           #REQUIRED" >
+
+
+<!-- ============================================================= -->
+<!--                    ARTICLE METADATA                           -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE METADATA MODEL                     -->
+<!--                    Complete content model for the <article-meta>
+                        element, which names the journal article
+                        metadata                                   -->
+<!ENTITY % article-meta-model
+                       "(article-id*, (%article-version.class;)?, 
+                         article-categories?, title-group?,
+                         (%contrib-group.class; |
+                          %aff-alternatives.class;)*,
+                         author-notes?,  ( (%pub-date.class;)* | 
+                          pub-date-not-available?), 
+                         volume*, volume-id*, volume-series?,
+                         issue*, issue-id*, issue-title*,
+                         issue-sponsor*, issue-part?, 
+                         volume-issue-group*, isbn*,
+                         supplement?,
+                         ( (fpage, lpage?, page-range?) |
+                            elocation-id )?,
+                         (%address-link.class; | product |
+                          supplementary-material)*,
+                         history?, pub-history?, permissions?, 
+                         self-uri*, (%related-article.class;)*, 
+                         (%abstract.class;)*,
+                         trans-abstract*, (%kwd-group.class;)*, 
+                         funding-group*, support-group*,   
+                         conference*, counts?, 
+                         custom-meta-group?)"                        >
+
+
+<!--ELEM   address links (email | ext-link | uri)
+                        Defined in %funding.ent;                   -->
+<!--ELEM   aff          Defined in %common.ent;                    -->
+<!--ELEM   copyright-statement
+                        Defined in %common.ent;                    -->
+<!--ELEM   copyright-year
+                        Defined in %common.ent;                    -->
+<!--ELEM   custom-meta-group
+                        Defined in %common.ent;                    -->
+<!--ELEM   elocation-id Defined in %common.ent;                    -->
+<!--ELEM   ext-link     Defined in %common.ent;                    -->
+<!--ELEM   fpage        Defined in %common.ent;                    -->
+<!--ELEM   funding-group
+                        Defined in %funding.ent;                   -->
+<!--ELEM   isbn         Defined in %common.ent;                    -->
+<!--ELEM   issue        Defined in %common.ent;                    -->
+<!--ELEM   issue-id     Defined in %common.ent;                    -->
+<!--ELEM   issue-title  Defined in %common.ent;                    -->
+<!--ELEM   issue-sponsor
+                        Defined in %common.ent;                    -->
+<!--ELEM   license      Defined in %common.ent;                    -->
+<!--ELEM   lpage        Defined in %common.ent;                    -->
+<!--ELEM   page-range   Defined in %common.ent;                    -->
+<!--ELEM   permissions  Defined in %common.ent;                    -->
+<!--ELEM   related-article and related-object
+                        Defined in %common.ent;                    -->
+<!--ELEM   supplementary-material
+                        Defined in %display.ent;                   -->
+<!--ELEM   volume       Defined in %common.ent;                    -->
+<!--ELEM   volume-id    Defined in %common.ent;                    -->
+<!--ELEM   volume-series
+                        Defined in %common.ent;                    -->
+
+
+<!--                    ARTICLE METADATA                           -->
+<!--                    Metadata that identifies this article, for
+                        example, bibliographic information such as
+                        the title, author, and copyright year.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=article-meta
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=article-meta
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=article-meta
+                                                                   -->
+<!ELEMENT  article-meta %article-meta-model;                         >
+<!ATTLIST  article-meta
+             %article-meta-atts;                                     >
+
+
+<!-- ============================================================= -->
+<!--                    ARTICLE METADATA ELEMENTS                  -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE IDENTIFIER                         -->
+<!--                    Optional element, used to hold one of the
+                        "unique identifiers" that have been assigned
+                        at various times to an article.  Such
+                        identifiers may come from a publisher, a
+                        jobber, from PubMed Central, etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=article-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=article-id
+                                                                   -->
+<!ELEMENT  article-id   (#PCDATA)                                    >
+<!ATTLIST  article-id
+             %article-id-atts;                                       >
+
+
+<!--                    ARTICLE VERSION                            -->
+<!--                    Optional element, used to hold one of the
+                        "version" identifiers (such as version type, 
+                        version status, version statement, or version
+                        number) that have been assigned to the 
+                        current article. 
+                        Remarks: A typical version identifier might 
+                        use terminology from the NISO Journal Article 
+                        Versions Recommendations (such as "preprint"
+                        or "copy-of-record", but it might also be a
+                        publishers internal versioning number such as
+                        "0.9".
+                           The element is allowed to repeat inside a
+                        <article-version-alternatives> element to hold
+                         version numbers from more than one versioning
+                         system. A given article should only be a
+                         single version in any given system.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=article-version
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=article-version
+                                                                   -->
+<!ELEMENT  article-version
+                        (#PCDATA)                                    >
+<!ATTLIST  article-version
+             %article-version-atts;                                  >
+
+
+<!--                    ARTICLE VERSION ALTERNATIVES               -->
+<!--                    Container element to hold multiple
+                        <article-version> elements, when the version
+                        number/identifier for more than one system
+                        needs to be recorded. A given article should
+                        only be a single version in any given system.
+                        Details at:              
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=article-version-alternatives
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=article-version-alternatives 
+                                                                   -->
+<!ELEMENT  article-version-alternatives
+                        (article-version+)                           >
+<!ATTLIST  article-version-alternatives
+             %article-version-alternatives-atts;                     >
+
+
+<!-- ============================================================= -->
+<!--                    ARTICLE GROUPING DATA (ARTICLE METADATA)   -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE CATEGORIES MODEL                   -->
+<!--                    Complete content model for the
+                        <article-categories> element               -->
+<!ENTITY % article-categories-model
+                        "(subj-group*, series-title*, series-text*)" >
+
+
+<!--                    ARTICLE GROUPING DATA                      -->
+<!--                    Container for elements that may be used to
+                        group articles into related clusters
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=article-categories
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=article-categories
+                                                                   -->
+<!ELEMENT  article-categories
+                        %article-categories-model;                   >
+<!ATTLIST  article-categories
+             %article-categories-atts;                               >
+
+
+<!--                    SUBJECT GROUP MODEL                        -->
+<!--                    Complete content model for the <subj-group>
+                        element                                    -->
+<!ENTITY % subj-group-model
+                        "((subject | compound-subject)+, subj-group*)"
+                                                                     >
+
+
+<!--                    GROUPING ARTICLES IN TITLED CATEGORIES
+                        Container element that collects multiple
+                        subjects and/or hierarchically lower subject
+                        groups.
+                        Remarks: For some journals, articles are
+                        grouped into categories, with the category
+                        indicated in the article's display.
+                        Sometimes the grouping or category refers
+                        to the type of article, such as "Essay",
+                        "Commentary", or "Article".  Sometimes the
+                        grouping refers to subject areas, such as
+                        "Physical Sciences", "Biological Sciences",
+                        or "Social Sciences".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=subj-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=subj-group
+                                                                   -->
+<!ELEMENT  subj-group   %subj-group-model;                           >
+<!ATTLIST  subj-group
+             %subj-group-atts;                                       >
+
+
+<!--                    SUBJECT ELEMENTS                           -->
+<!--                    Elements that may be used, along with data
+                        characters inside the content model of the
+                        <subject> element                          -->
+<!ENTITY % subject-elements
+                        "| %emphasis.class; | %inline-display.class; |
+                         %inline-math.class; |
+                         %phrase-content.class; | %subsup.class;"    >
+
+
+<!--                    SUBJECT NAME                               -->
+<!--                    The name of one of the subject groups used
+                        to describe an article.  Such groups are
+                        used, typically, to provide headings for
+                        groups of articles in a printed or online
+                        generated Table of Contents.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=subject
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=subject
+                                                                   -->
+<!ELEMENT  subject      (#PCDATA %subject-elements;)*                >
+<!ATTLIST  subject
+             %subject-atts;                                          >
+
+
+<!--                    COMPOUND SUBJECT MODEL                     -->
+<!--                    Complete content model for the
+                        <compound-subject> element                 -->
+<!ENTITY % compound-subject-model
+                        "(compound-subject-part+)"                   >
+
+
+<!--                    COMPOUND SUBJECT NAME                      -->
+<!--                    Container element to hold all the parts of a
+                        multi-part subject, for example, a subject that
+                        is comprised of both a term and a code value
+                        that represents that term.
+                        Related Elements: If a subject is only a word
+                        or phrase (Neuroscience, Physical Sciences),
+                        the simple <subject> element can be used to
+                        capture this information. If a subject is
+                        logically both a term and a code
+                        (A11 Permeability) but only one of those
+                        objects needs to be captured, a <subject>
+                        element may also be used. If it is useful to
+                        record both the code and the term, they can
+                        each be captured as one
+                        <compound-subject-part>s inside a
+                        <compound-subject>.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=compound-subject
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=compound-subject
+                                                                   -->
+<!ELEMENT  compound-subject
+                        %compound-subject-model;                     >
+<!ATTLIST  compound-subject
+             %compound-subject-atts;                                 >
+
+
+<!--                    COMPOUND SUBJECT PART ELEMENTS             -->
+<!--                    Elements that may be used, along with data
+                        characters inside the content model of the
+                        <compound-subject> element                 -->
+<!ENTITY % compound-subject-part-elements
+                        "| %emphasis.class; | %inline-display.class; |
+                         %inline-math.class; |
+                         %phrase-content.class; | %subsup.class;"    >
+
+
+<!--                    COMPOUND SUBJECT PART NAME                 -->
+<!--                    The name of one of the subject groups used
+                        to describe an article, when that article is
+                        a multi-part rather than a simple subject.
+                        Such groups are used, typically, to provide
+                        headings for groups of articles in a printed
+                        or online generated Table of Contents. The
+                        @content type attribute should be used to
+                        indicate the type of part ("text", "code",
+                        "sponsor", etc.).
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=compound-subject-part
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=compound-subject-part
+                                                                   -->
+<!ELEMENT  compound-subject-part
+                        (#PCDATA %compound-subject-part-elements;)*  >
+<!ATTLIST  compound-subject-part
+             %compound-subject-part-atts;                            >
+
+
+<!-- ============================================================= -->
+<!--                    SERIES INFORMATION                         -->
+<!-- ============================================================= -->
+
+
+<!--                    GROUPING ARTICLES IN SERIES
+                        Series (as used in the <series-title> and
+                        <series-text> elements described below) is
+                        used in two different senses. Some issues of
+                        journals are part of a series and will have
+                        series information just as they have an
+                        issue number as part of the article metadata,
+                        to describe the issue of the journal in which
+                        the article is published.  The second usage
+                        is for groupings of articles within one
+                        issue of a journal. For example, in some
+                        journals, articles are grouped into a
+                        series such as "From the Cover" and
+                        identified as part of a series.
+                        The Series Title element names the series
+                        and the Series Text element provides textual
+                        description (if any) describing the series.-->
+
+
+<!--                    SERIES TITLE ELEMENTS                      -->
+<!--                    Elements that may be used, along with data
+                        characters inside the content model of the
+                        <series-title> element                     -->
+<!ENTITY % series-title-elements
+                        "%rendition-plus;"                           >
+
+
+<!--                    SERIES TITLE                               -->
+<!--                    Title of the journal series (bibliographic
+                        meaning) or the title of a  series of
+                        articles internal to one issue of a journal
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=series-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=series-title
+                                                                   -->
+<!ELEMENT  series-title (#PCDATA %series-title-elements;)*           >
+<!ATTLIST  series-title
+             %series-title-atts;                                     >
+
+
+<!--                    SERIES TEXT ELEMENTS                       -->
+<!--                    Elements that may be used, along with data
+                        characters inside the content model of the
+                        <series-text> element                      -->
+<!ENTITY % series-text-elements
+                        "%rendition-plus;"                           >
+
+
+<!--                    SERIES TEXT: HEADER TEXT to DESCRIBE       -->
+<!--                    Textual description of the series of articles
+                        that are named in a <series-title> element
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=series-text
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=series-text
+                                                                   -->
+<!ELEMENT  series-text  (#PCDATA %series-text-elements;)*            >
+<!ATTLIST  series-text
+             %series-text-atts;                                      >
+
+
+<!-- ============================================================= -->
+<!--                    TOP-LEVEL ARTICLE METADATA CONTINUED       -->
+<!-- ============================================================= -->
+
+
+<!--                    AUTHOR NOTES MODEL                         -->
+<!--                    Content model for an <author-notes> element.
+                                                                   -->
+<!ENTITY % author-notes-model
+                        "(label?, title?,
+                          (%corresp.class; | %fn-link.class; |
+                           %just-para.class;)+ )"                    >
+
+
+<!--                    AUTHOR NOTE GROUP                          -->
+<!--                    Footnotes to authors or notes about authors
+                        (and, potentially other contributors) are
+                        collected in the Author note group.
+                        References to these footnotes are made
+                        using the <xref> element.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=author-notes
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=author-notes
+                                                                   -->
+<!ELEMENT  author-notes %author-notes-model;                         >
+<!ATTLIST  author-notes
+             %author-notes-atts;                                     >
+
+
+<!-- ============================================================= -->
+<!--                 PRODUCT REVIEW INFORMATION (PRODUCT METADATA) -->
+<!-- ============================================================= -->
+
+
+<!--                    PRODUCT ELEMENTS                           -->
+<!--                    Elements that may be used inside the
+                        <product> element
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % product-elements
+                        "| %article-link.class; | %break.class; |
+                         %emphasis.class; | %inline-display.class; |
+                         %inline-math.class; | %phrase.class; |
+                         %price.class; | %references.class; |
+                         %simple-link.class; | %subsup.class; "      >
+
+
+<!--                    PRODUCT INFORMATION                        -->
+<!--                    Used as a wrapper for metadata for a product
+                        (such as a book, software package, hardware
+                        component, web site, etc.) that is being
+                        reviewed.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=product
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=product
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=product
+                                                                   -->
+<!ELEMENT  product      (#PCDATA %product-elements;)*                >
+<!ATTLIST  product
+             %product-atts;                                          >
+
+
+<!-- ============================================================= -->
+<!--                    FURTHER METADATA ELEMENTS                  -->
+<!-- ============================================================= -->
+
+
+<!--                    SELF-URI ELEMENTS                          -->
+<!--                    Elements to be mixed with data characters
+                        inside the <self-uri> element              -->
+<!ENTITY % self-uri-elements
+                        ""                                           >
+
+
+<!--                    URI FOR THIS SAME ARTICLE ONLINE           -->
+<!--                    Sometimes an article is available in several
+                        forms, for example there is the version that
+                        was published in print and there is the same
+                        article (possibly expanded or with different
+                        graphics) available online.
+                           The URI (such as a URL) may be used as a
+                        live link, typically naming a web site or the
+                        element content may name the URL, e.g., and
+                        use the link attributes to hold the real link:
+                           <self-uri xlink:href="...">An expanded
+                           version of this article is available
+                           online</self-uri>
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=self-uri
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=self-uri
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=self-uri
+                                                                   -->
+<!ELEMENT  self-uri     (#PCDATA %self-uri-elements;)*               >
+<!ATTLIST  self-uri
+             %self-uri-atts;                                         >
+
+
+<!-- ============================================================= -->
+<!--                    ABSTRACTS                                  -->
+<!-- ============================================================= -->
+
+
+<!--                    ABSTRACT MODEL                             -->
+<!--                    Content model for an <abstract> element    -->
+<!ENTITY % abstract-model
+                        "((%id.class;)*, %sec-opt-title-model; )"    >
+
+
+<!--                    ABSTRACT                                   -->
+<!--                    A short summation of the content of an
+                        article.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=abstract
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=abstract
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=abstract
+                                                                   -->
+<!ELEMENT  abstract     %abstract-model;                             >
+<!ATTLIST  abstract
+             %abstract-atts;                                         >
+
+
+<!--                    TRANSLATED ABSTRACT MODEL                  -->
+<!--                    Content model for an <trans-abstract> element.
+                                                                   -->
+<!ENTITY % trans-abstract-model
+                        "%sec-opt-title-model;"                      >
+
+
+<!--                    TRANSLATED ABSTRACT                        -->
+<!--                    An abstract that has been translated into
+                        another language
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=trans-abstract
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=trans-abstract
+                                                                   -->
+<!ELEMENT  trans-abstract
+                        %trans-abstract-model;                       >
+<!ATTLIST  trans-abstract
+             %trans-abstract-atts;                                   >
+
+
+<!-- ============================================================= -->
+<!--                    KEYWORD ELEMENTS                           -->
+<!-- ============================================================= -->
+
+
+<!--                    KEYWORD GROUP MODEL                        -->
+<!--                    Content model for a <kwd-group> element    -->
+<!ENTITY % kwd-group-model
+                        "(label?, title?, (%kwd.class;)+ )"          >
+
+
+<!--                    KEYWORD GROUP                              -->
+<!--                    Container element for one set of keywords
+                        <kwd>s used to describe a document.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=kwd-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=kwd-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=kwd-group
+                                                                   -->
+<!ELEMENT  kwd-group    %kwd-group-model;                            >
+<!ATTLIST  kwd-group
+             %kwd-group-atts;                                        >
+
+
+<!--ELEM   title        Defined in %common.ent;                    -->
+
+
+<!--                    KEYWORD CONTENT ELEMENTS                   -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a keyword.                                 -->
+<!ENTITY % kwd-elements
+                        "| %emphasis.class; | %inline-display.class; |
+                         %inline-math.class; |
+                         %phrase-content.class; |
+                         %simple-link.class; | %subsup.class;"       >
+
+
+<!--                    KEYWORD                                    -->
+<!--                    One subject term, critical expression, key
+                        phrase, abbreviation, indexing word, etc.
+                        that is associated with the whole document
+                        and can be used for identification and
+                        indexing purposes.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=kwd
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=kwd
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=kwd
+                                                                   -->
+<!ELEMENT  kwd          (#PCDATA %kwd-elements;)*                    >
+<!ATTLIST  kwd
+             %kwd-atts;                                              >
+
+
+<!--                    COMPOUND KEYWORD MODEL                     -->
+<!--                    The content model of the <compound-kwd>
+                        element                                    -->
+<!ENTITY % compound-kwd-model
+                        "(compound-kwd-part+)"                       >
+
+
+<!--                    COMPOUND KEYWORD                           -->
+<!--                    Some keywords are simple, a text word or
+                        phrase; such keywords can be tagged using the
+                        <kwd> element. But other keywords are more
+                        complicated:
+                         - a code and a term
+                         - an abbreviation and its expansion
+                         - a hierarchical keyword that carries all
+                           the parts of its hierarchy (as index
+                           terms do)
+                        This element was created to handle these
+                        special cases.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=compound-kwd
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=compound-kwd
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=compound-kwd
+                                                                   -->
+<!ELEMENT  compound-kwd %compound-kwd-model;                         >
+<!ATTLIST  compound-kwd
+             %compound-kwd-atts;                                     >
+
+
+<!--                    COMPOUND KEYWORD PART ELEMENTS             -->
+<!--                    Elements to be mixed with data characters
+                        inside the <compound-kwd-part> element     -->
+<!ENTITY % compound-kwd-part-elements
+                        "| %emphasis.class; | %inline-display.class; |
+                         %inline-math.class; |
+                         %phrase-content.class; |
+                         %simple-link.class; | %subsup.class;"       >
+
+
+<!--                    COMPOUND KEYWORD PART                      -->
+<!--                    This element was created to hold one
+                        component of a complex keyword, for example
+                        one for the code and one for the term.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=compound-kwd-part
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=compound-kwd-part
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=compound-kwd-part
+                                                                   -->
+<!ELEMENT  compound-kwd-part
+                        (#PCDATA %compound-kwd-part-elements;)*      >
+<!ATTLIST  compound-kwd-part
+             %compound-kwd-part-atts;                                >
+
+
+<!--                    NESTED KEYWORD MODEL                       -->
+<!--                    The content model of the <nested-kwd>
+                        element                                    -->
+<!ENTITY % nested-kwd-model
+                        "((%nested-kwd.class;)+, nested-kwd*)"       >
+
+
+<!--                    NESTED KEYWORD                             -->
+<!--                    Hierarchical or nested keyword, in which the
+                        levels of a taxonomy that describe the
+                        article can be described.                  -->
+<!ELEMENT  nested-kwd   %nested-kwd-model;                           >
+<!ATTLIST  nested-kwd
+            %nested-kwd-atts;                                        >
+
+
+<!--                    UNSTRUCTURED KEYWORD GROUP ELEMENTS        -->
+<!--                    Content model for a <kwd-group> element    -->
+<!ENTITY % unstructured-kwd-group-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    UNSTRUCTURED KEYWORD GROUP                 -->
+<!--                    Container element for one set of keywords
+                        used to describe a document where the
+                        individual keywords are not tagged as
+                        separate <kwd>s but instead are all run
+                        together in one long text field.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=unstructured-kwd-group
+                                                                   -->
+<!ELEMENT  unstructured-kwd-group
+                        (#PCDATA %unstructured-kwd-group-elements;)* >
+<!ATTLIST  unstructured-kwd-group
+             %unstructured-kwd-group-atts;                           >
+
+
+<!-- ============================================================= -->
+<!--                    STILL FURTHER ARTICLE METADATA             -->
+<!-- ============================================================= -->
+
+
+<!--                    CORRESPONDENCE INFORMATION ELEMENTS        -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the correspondence information.            -->
+<!ENTITY % corresp-elements
+                        "| %address.class; | %address-link.class;|
+                         %emphasis.class; | %label.class; |
+                         %phrase-content.class; | %subsup.class;"    >
+
+
+<!--                    CORRESPONDENCE INFORMATION                 -->
+<!--                    Optional element, used as a container for
+                        information concerning which of the authors
+                        (or other contributors) is the corresponding
+                        contributor, to whom information requests
+                        should be addressed.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=corresp
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=corresp
+                                                                   -->
+<!ELEMENT  corresp      (#PCDATA %corresp-elements;)*                >
+<!ATTLIST  corresp
+             %corresp-atts;                                          >
+
+
+<!--                    PUBLICATION DATE NOT AVAILABLE MODEL       -->
+<!--                    The content model for the EMPTY element 
+                        <pub-date-not-available>.                  -->
+<!ENTITY % pub-date-not-available-model
+                        "EMPTY"                                      >
+
+
+<!--                    DATE NOT AVAILABLE FLAG                    -->
+<!--                    EMPTY element used as a flag to signal that
+                        the publication date (<pub-date>) is not
+                        available. This flag does not mean, necessarily,
+                        that the article is unpublished, just that no
+                        <pub-date> is available.
+                        Details at:                   
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=pub-date-not-available
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=pub-date-not-available
+                                                                   -->
+<!ELEMENT  pub-date-not-available
+                        %pub-date-not-available-model;               >
+<!ATTLIST  pub-date-not-available
+             %pub-date-not-available-atts;                           >
+
+
+<!--                    PUBLICATION DATE MODEL                     -->
+<!--                    The content model for the element <pub-date>
+                                                                   -->
+<!ENTITY % pub-date-model
+                        "%date-model;"                               >
+
+
+<!--                    PUBLICATION DATE                           -->
+<!--                    Date of publication or release of the
+                        material in one particular format.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=pub-date
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=pub-date
+                                                                   -->
+<!ELEMENT  pub-date     %pub-date-model;                             >
+<!ATTLIST  pub-date
+             %pub-date-atts;                                         >
+
+
+<!-- ============================================================= -->
+<!--                    CONFERENCE INFORMATION ELEMENTS            -->
+<!-- ============================================================= -->
+
+
+<!--                    CONFERENCE MODEL                           -->
+<!--                    Content model for the <conference> element -->
+<!ENTITY % conference-model
+                        "(%conference.class;)*"                      >
+
+
+<!--                    CONFERENCE INFORMATION                     -->
+<!--                    The container element for the information
+                        about a single conference and its
+                        proceedings.
+                        Design Note: Conference elements were largely
+                        based on Cross-Ref.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=conference
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=conference
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=conference
+                                                                   -->
+<!ELEMENT  conference   %conference-model;                           >
+<!ATTLIST  conference
+             %conference-atts;                                       >
+
+
+<!--ELEM   conf-date     Defined in %common.ent;                   -->
+<!--ELEM   conf-loc      Defined in %common.ent;                   -->
+<!--ELEM   conf-name     Defined in %common.ent;                   -->
+<!--ELEM   conf-sponsor  Defined in %common.ent;                   -->
+
+
+<!--                    CONFERENCE ACRONYM ELEMENTS                -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the conference acronym.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an online
+                        mix, the OR bar is already there.          -->
+<!ENTITY % conf-acronym-elements
+                        "%simple-text;"                              >
+
+
+<!--                    CONFERENCE ACRONYM                         -->
+<!--                    The short name, popular name, or "jargon
+                        name" for a conference, for example,
+                        "Extreme" for "Extreme Markup Languages" or
+                        "SIGGRAPH" for "Special Interest Group on
+                        Computer Graphics".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=conf-acronym
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=conf-acronym
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=conf-acronym
+                                                                   -->
+<!ELEMENT  conf-acronym (#PCDATA %conf-acronym-elements;)*           >
+<!ATTLIST  conf-acronym
+             %conf-acronym-atts;                                     >
+
+
+<!--                    CONFERENCE NUMBER ELEMENTS                 -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the conference number.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % conf-num-elements
+                        "%simple-text;"                              >
+
+
+<!--                    CONFERENCE NUMBER                          -->
+<!--                    The sequential number of the conference.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=conf-num
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=conf-num
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=conf-num
+                                                                   -->
+<!ELEMENT  conf-num     (#PCDATA %conf-num-elements;)*               >
+<!ATTLIST  conf-num
+             %conf-num-atts;                                         >
+
+
+<!--                    CONFERENCE THEME ELEMENTS                  -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the conference theme.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an online
+                        mix, the OR bar is already there.          -->
+<!ENTITY % conf-theme-elements
+                        "%simple-text;"                              >
+
+
+<!--                    CONFERENCE THEME                           -->
+<!--                    The theme, slogan, or major subject area of
+                        the conference.  For example, the name of an
+                        annual conference may be "16th ACH Gathering"
+                        but each year has different theme topic,
+                        such as "Database Integration" or "Topic
+                        Map Subject Access".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=conf-theme
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=conf-theme
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=conf-theme
+                                                                   -->
+<!ELEMENT  conf-theme   (#PCDATA %conf-theme-elements;)*             >
+<!ATTLIST  conf-theme
+             %conf-theme-atts;                                       >
+
+
+<!--                    STRING CONFERENCE NAME ELEMENTS            -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the extended text name of the conference
+                        <string-conf>
+                        Design Note: %simple-text; begins with an
+                        OR bar.                                    -->
+<!ENTITY % string-conf-elements
+                        "%simple-text;| %conference.class;"          >
+
+
+<!--                    STRING CONFERENCE NAME                     -->
+<!--                    Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=string-conf
+                                                                   -->
+<!ELEMENT  string-conf  (#PCDATA %string-conf-elements;)*            >
+<!ATTLIST  string-conf
+             %string-conf-atts;                                      >
+
+
+<!-- ============================================================= -->
+<!--                    COUNTING INFORMATION (ARTICLE METADATA)    -->
+<!-- ============================================================= -->
+
+
+<!--                    COUNTS MODEL                               -->
+<!--                    Content model for the <counts> element.    -->
+<!ENTITY % counts-model "(count*, fig-count?, table-count?, 
+                          equation-count?, ref-count?, page-count?, 
+                          word-count?)"                              >
+
+
+<!--                    COUNTS                                     -->
+<!--                    Wrapper element to hold all metadata that
+                        "counts how many of something appear in the
+                        article
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=counts
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=counts
+                                                                   -->
+<!ELEMENT  counts       %counts-model;                               >
+<!ATTLIST  counts
+             %counts-atts;                                           >
+
+
+<!--                    COUNT                                      -->
+<!--                    Generic <count> element to count anything a 
+                        publisher or archive may wish to count in a 
+                        document. The @count-type attribute will name 
+                        what is being counted (such as figures, 
+                        tables, sections, contributors, images,
+                        etc.) The @count attribute will state how 
+                        many of the objects are in the document. 
+     
+                        Although a publisher or archive could choose 
+                        to label all the counted objects in a document
+                        using this element, the specific count 
+                        elements (fig-count, equation-count,
+                        word-count, etc.) will be retained for 
+                        backwards compatibility, and may still be
+                        used.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=count
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=count
+                                                                   -->
+<!ELEMENT  count        EMPTY                                        >
+<!ATTLIST  count
+             %count-atts;                                            >
+
+
+<!--                    EQUATION COUNT                             -->
+<!--                    Number of display equations <disp-formula>
+                        that appear in the article. Inline-equations
+                        <inline-formula> are not counted. No
+                        distinction is made between numbered and
+                        unnumbered equations, both are counted.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=equation-count
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=equation-count
+                                                                   -->
+<!ELEMENT  equation-count
+                        EMPTY                                        >
+<!ATTLIST  equation-count
+             %equation-count-atts;                                   >
+
+
+<!--                    FIGURE COUNT                               -->
+<!--                    Number of Figures <fig> that appear in the
+                        article. Loose <graphic>s that appear
+                        outside figures are not counted.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=fig-count
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=fig-count
+                                                                   -->
+<!ELEMENT  fig-count    EMPTY                                        >
+<!ATTLIST  fig-count
+             %fig-count-atts;                                        >
+
+
+<!--                    TABLE COUNT                                -->
+<!--                    Number of tables (Table Wrapper <table-wrap>
+                        elements that appear in the article. Arrays
+                        are not counted as tables.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=table-count
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=table-count
+                                                                   -->
+<!ELEMENT  table-count  EMPTY                                        >
+<!ATTLIST  table-count
+             %table-count-atts;                                      >
+
+
+<!--                    REFERENCE COUNT                            -->
+<!--                    Number of reference citations (whether
+                        <mixed-citation>s, <element-citation>s, or
+                        <nlm-citation>s) that appear in the
+                        bibliographic reference list <ref-list>
+                        in the article
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=ref-count
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=ref-count
+                                                                   -->
+<!ELEMENT  ref-count    EMPTY                                        >
+<!ATTLIST  ref-count
+             %ref-count-atts;                                        >
+
+
+<!--                    PAGE COUNT                                 -->
+<!--                    Number of pages in a print article, counting
+                        each page or partial page as one. Electronic
+                        articles do not have page counts.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=page-count
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=page-count
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=page-count
+                                                                   -->
+<!ELEMENT  page-count   EMPTY                                        >
+<!ATTLIST  page-count
+             %page-count-atts;                                       >
+
+
+<!--                    WORD COUNT                                 -->
+<!--                    Approximate number of words that appear in
+                        the textual portion of an
+                        article (not including the words in the
+                        metadata or header information)
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=word-count
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=word-count
+                                                                   -->
+<!ELEMENT  word-count   EMPTY                                        >
+<!ATTLIST  word-count
+             %word-count-atts;                                       >
+
+
+<!-- ============================================================= -->
+<!--                    TITLE GROUP ELEMENTS (BIBLIOGRAPHIC)       -->
+<!-- ============================================================= -->
+
+
+<!--                    TITLE GROUP MODEL                          -->
+<!--                    Content model for the <title-group> element-->
+<!ENTITY % title-group-model
+                        "(article-title, subtitle*,
+                          trans-title-group*, alt-title*, fn-group?)">
+
+
+<!--                    TITLE GROUP                                -->
+<!--                    Wrapper element to hold the various article
+                        titles.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=title-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=title-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=title-group
+                                                                   -->
+<!ELEMENT  title-group  %title-group-model;                          >
+<!ATTLIST  title-group
+             %title-group-atts;                                      >
+
+
+<!--ELEM   article-title
+                        Defined in %common.ent;                    -->
+<!--ELEM   trans-title  Defined in %common.ent;                    -->
+
+
+<!--                    SUBTITLE ELEMENTS                          -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a paragraph <subtitle>.
+                        An earlier version of this tag set used the
+                        parameter entity %title-elements; for many
+                        title elements including <subtitle>.       -->
+<!ENTITY % subtitle-elements
+                        "%title-elements;"                           >
+
+
+<!--                    ARTICLE SUBTITLE                           -->
+<!--                    Secondary title of a journal article
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=subtitle
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=subtitle
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=subtitle
+                                                                   -->
+<!ELEMENT  subtitle     (#PCDATA %subtitle-elements;)*               >
+<!ATTLIST  subtitle
+             %subtitle-atts;                                         >
+
+
+<!--                    ALTERNATE TITLE                            -->
+<!--                    A "different" version of an article title,
+                        usually created so that it can be processed
+                        in a special way, for example a short
+                        version of the title for use in a Table of
+                        Contents, an ASCII title, a right-running-
+                        head title, etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=alt-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=alt-title
+                                                                   -->
+<!ELEMENT  alt-title    (#PCDATA %alt-title-elements;)*              >
+<!ATTLIST  alt-title
+             %alt-title-atts;                                        >
+
+
+<!-- ============================================================= -->
+<!--                    AUTHOR COMMENTS                            -->
+<!-- ============================================================= -->
+
+
+<!--                    AUTHOR COMMENT MODEL                       -->
+<!--                    Content model for the <author-comment>
+                        element                                    -->
+<!ENTITY % author-comment-model
+                        "(title?, (%just-para.class;)+ )"            >
+
+
+<!--                    AUTHOR COMMENT                             -->
+<!--                    Used for extra textual material associated
+                        with a contributor such as an author or
+                        editor
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=author-comment
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=author-comment
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=author-comment
+                                                                   -->
+<!ELEMENT  author-comment
+                        %author-comment-model;                       >
+<!ATTLIST  author-comment
+             %author-comment-atts;                                   >
+
+
+<!-- ============================================================= -->
+<!--                    PUBLICATION HISTORY DATE ELEMENTS          -->
+<!-- ============================================================= -->
+
+
+<!--                    HISTORY MODEL                              -->
+<!--                    The content model for the <history> element
+                                                                   -->
+<!ENTITY % history-model
+                        "(%date.class;)+"                            >
+
+
+<!--                    HISTORY:  DOCUMENT HISTORY                 -->
+<!--                    Used as a container for dates related to the
+                        processing history of the document, such as
+                        received date and accepted date.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=history
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=history
+                                                                   -->
+<!ELEMENT  history      %history-model;                              >
+<!ATTLIST  history
+             %history-atts;                                          >
+
+
+<!-- ============================================================= -->
+<!--                    PUBLICATION HISTORY EVENT ELEMENTS         -->
+<!--                    More than a date (from BITS)               -->
+<!-- ============================================================= -->
+
+
+<!--                    EVENT DESCRIPTION ELEMENTS                 -->
+<!--                    Elements that may be used, along with data
+                        characters inside the content model of the
+                        <event-desc> element.                      -->
+<!ENTITY % event-desc-elements
+                        "| %address-link.class; |
+                         %article-identifier.class; |
+                         %article-version.class; |  
+                         %date.class; | %pub-date.class; |
+                         pub-date-not-available"                     >
+
+
+<!--                    EVENT DESCRIPTION                          -->
+<!--                    This is a description of an event in the
+                        publishing history of a book, for example,
+                        reprinting or publication of the revised online
+                        edition. This text field may be as
+                        simple a few words or as complex as a
+                        narrative with embedded markup.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=event-desc
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=event-desc
+                                                                    -->
+<!ELEMENT  event-desc   (#PCDATA %event-desc-elements;)*             >
+<!ATTLIST  event-desc
+             %event-desc-atts;                                       >
+
+
+<!--                    EVENT MODEL                                -->
+<!--                    The content model for the <event> element. -->
+<!ENTITY % event-model  "(event-desc?, article-id*, 
+                          (%article-version.class;)?,
+                          ( (%pub-date.class;)* | 
+                             pub-date-not-available?),
+                          (%date.class;)*,
+                          issn*, issn-l?, isbn*, permissions?,
+                          notes*, self-uri*)"                        >
+
+
+<!--                    EVENT IN PUBLISHING HISTORY                -->
+<!--                    This is a description of an event in the
+                        publishing history of a book, for example,
+                        reprinting or publication of the revised online
+                        edition. This text field may be as
+                        simple a few words or as complex as a
+                        narrative with embedded markup.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=event
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=event
+                                                                   -->
+<!ELEMENT  event        %event-model;                                >
+<!ATTLIST  event
+             %event-atts;                                            >
+
+
+<!--                    PUBLICATION HISTORY MODEL                  -->
+<!--                    The content model for the <pub-history>
+                        element.                                   -->
+<!ENTITY % pub-history-model
+                        "((%event.class;)+ )"                        >
+
+
+<!--                    PUBLICATION HISTORY                        -->
+<!--                    Used as a container for events related to the
+                        processing history of the document, such as
+                        online publication date or reprint date.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=pub-history 
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=pub-history 
+                                                                   -->
+<!ELEMENT  pub-history  %pub-history-model;                          >
+<!ATTLIST  pub-history
+             %pub-history-atts;                                      >
+
+
+<!-- ================== End Article Metadata Elements  =========== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-backmatter1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-backmatter1.ent
@@ -1,0 +1,479 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Back Matter Elements                              -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Back Matter Elements v1.2 20190208//EN"
+     Delivered as file "JATS-backmatter1.ent"                      -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Names elements that are not part of the main      -->
+<!--             textual flow of a work, but are considered to be  -->
+<!--             ancillary material.                               -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 16. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 15. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+ 14. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 13. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+ 12. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 11. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 10. JATS became version "1.1d3" and "v1.1d3 20150301"
+ 
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+   9. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  8. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base to every element, whether 
+     metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+
+  7. ABSTRACTS AND KEYWORDS ON NEW STRUCTURES
+     - Added <abstract> (through %abstract.class;) and <kwd-group> 
+       (through %kwd-group.class;) to the following elements:
+        - app (through %sec-model;)
+        - app-group (through %app-group-model;)
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+  
+  6. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  4. Updated the DTD-version attribute to "0.4" 
+   
+  3. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+           http://jats.nlm.nih.gov/0.4.
+
+  2. @XML:LANG - Added @xml:lang to the following elements:
+      - app through app-atts
+      - app-group through app-group-atts
+      - fn-group through fn-group-atts
+      - glossary through glossary-atts
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    BACK MATTER ELEMENTS                       -->
+<!-- ============================================================= -->
+
+
+<!--ELEM   bio          Defined in %common.ent;                    -->
+<!--ELEM   ref-list     Defined in %references.ent;                -->
+<!--ELEM   sec          Defined in %section.ent;                   -->
+<!--ELEM   ack          Defined in %common.ent;                    -->
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    APPENDIX ATTRIBUTES                        -->
+<!--                    Attributes for the Appendix <app> element  -->
+<!ENTITY % app-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    APPENDIX GROUP ATTRIBUTES                  -->
+<!--                    Attributes for the Appendix Group <app-group>
+                        element                                    -->
+<!ENTITY % app-group-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    FOOTNOTE GROUP ATTRIBUTES                  -->
+<!--                    Attributes for the Footnote Group <fn-group>
+                        element                                    -->
+<!ENTITY % fn-group-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    GLOSSARY ATTRIBUTES                        -->
+<!--                    Attributes for the Glossary <glossary>
+                        element                                    -->
+<!ENTITY % glossary-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    APPENDIX ELEMENTS                          -->
+<!-- ============================================================= -->
+
+
+<!--                    APPENDIX GROUP MODEL                       -->
+<!--                    Content model for the <app-group> element  -->
+<!ENTITY % app-group-model
+                        "(label?, title?, 
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          (%para-level;)*,
+                          (%app.class; | %ref-list.class;)*)"        >
+
+
+<!--                    APPENDIX GROUP                             -->
+<!--                    A container element to hold one or more
+                        Appendices.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=app-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=app-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=app-group
+                                                                   -->
+<!ELEMENT  app-group    %app-group-model;                            >
+<!ATTLIST  app-group
+             %app-group-atts;                                        >
+
+
+<!--                    APPENDIX MODEL                             -->
+<!--                    Content model for the <app> element.       -->
+<!ENTITY % app-model    "(%sec-model;, permissions?)"                >
+
+
+<!--                    APPENDIX                                   -->
+<!--                    Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=app
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=app
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=app
+                                                                   -->
+<!ELEMENT  app          %app-model;                                  >
+<!ATTLIST  app
+             %app-atts;                                              >
+
+
+<!-- ============================================================= -->
+<!--                    FOOTNOTE GROUPING ELEMENTS                 -->
+<!-- ============================================================= -->
+
+
+<!--                    FOOTNOTE GROUP MODEL                       -->
+<!--                    Content model for the <fn-group> element   -->
+<!ENTITY % fn-group-model
+                        "(label?, title?, (%fn-link.class;)+ )"      >
+
+
+<!--                    FOOTNOTE GROUP                             -->
+<!--                    Footnotes in a journal article may be
+                        scattered throughout the text, at the places
+                        they occur, or collected in groups at the
+                        end of structural units.  This element is a
+                        wrapper tag for such groups of footnotes.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=fn-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=fn-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=fn-group
+                                                                   -->
+<!ELEMENT  fn-group     %fn-group-model;                             >
+<!ATTLIST  fn-group
+             %fn-group-atts;                                         >
+
+
+<!-- ============================================================= -->
+<!--                    GLOSSARY                                   -->
+<!-- ============================================================= -->
+
+
+<!--                    GLOSSARY MODEL                             -->
+<!--                    Content model for the <glossary> element   -->
+<!ENTITY % glossary-model
+                        "(label?, title?, (%para-level;)*, glossary*)"
+                                                                     >
+
+
+<!--                    GLOSSARY ELEMENTS                          -->
+<!--                    Glossary or list of definitions.  Typically
+                        the content will be one or more <def-list>s.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=glossary
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=glossary
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=glossary
+                                                                   -->
+<!ELEMENT  glossary     %glossary-model;                             >
+<!ATTLIST  glossary
+             %glossary-atts;                                         >
+
+
+<!-- ================== End Back Matter Module =================== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-chars1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-chars1.ent
@@ -1,0 +1,611 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Custom Special Characters Module                  -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Custom Special Characters Module v1.2 20190208//EN"
+     Delivered as file "JATS-chars1.ent"                           -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    XML special character entities                    -->
+<!--                                                               -->
+<!-- CONTAINS:   1) Definitions of DTD-specific and custom         -->
+<!--                special characters (as general entities        -->
+<!--                defined as hexadecimal or decimal character    -->
+<!--                entities - Unicode numbers)                    -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 16. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 15. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 14. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 13. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+ 12. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 11. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 10. JATS became version "1.1d3" and "v1.1 20150301//EN"
+  
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+   9. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+ 
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  8. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+ 
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+ 
+  7. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  6. Updated the DTD-version attribute to "0.4" 
+   
+  5. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  4. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+       - private-char through private-char-atts (@specific-use)
+
+  3. PEs FOR CONTENT MODELS - Added parameter entity redefinitions
+     for the model of the <private-char> element.
+
+  2. PEs FOR ATTLISTS - Added parameter entity redefinitions for the
+     attribute lists of the following elements: (no attributes or
+     values were changed)
+       - glyph-ref         glyph-ref-atts
+       - glyph-data        glyph-data-atts
+       - private-char      private-char-atts
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+<!-- ============================================================= -->
+<!--                    DESIGN COMMENT                             -->
+<!-- ============================================================= -->
+<!--                    This DTD Suite has been designed with Unicode
+                        as the basic representation of all special
+                        characters. The use of combining characters
+                        is supported and encouraged as is the use
+                        of entities defined by the STIX project
+                        (http://www.ams.org/STIX/). Unicode values
+                        in planes other than Plane 0 may be freely
+                        used.
+
+                        Use of private publisher entities and Unicode
+                        Private Use Area is discouraged, but supported
+                        with the <private-char> element, for which a
+                        corresponding bitmap must be submitted.
+
+                        In cases where an entity name has been generally
+                        accepted with a corresponding Unicode number
+                        and the entity has not been added to
+                        the ISO standard entity sets, a named entity
+                        may be defined below (e.g. &euro;).
+
+                        Because of the potential for conflicts in
+                        assignments by different publishers,
+                        the JATS DTD Suite does not support assignment 
+                        of values in the Unicode Private Use Area.
+                        Publishers who have defined characters in the
+                        Private Use Area must remap those characters
+                        to existing Unicode values (using combining
+                        characters for special accented characters
+                        where appropriate), or must submit bitmaps of
+                        those characters using one of the two methods
+                        supported under the <private-char> element.
+
+                        Those custom publisher entities for which
+                        corresponding Unicode values have not been
+                        determined must be tagged with the
+                        <private-char> element. Publishers must submit
+                        bitmaps of those characters using one of the
+                        two methods supported in the <private-char>
+                        element.                                   -->
+
+<!-- ============================================================= -->
+<!--                    COMMONLY ACCEPTED ENTITIES FOR UNICODE
+                        GLYPHS                                     -->
+<!-- ============================================================= -->
+
+<!--                    For each of the following entities a name
+                        and a Unicode numerical character reference
+                        is given. Where a unique Unicode character
+                        could be determined, that character was used.
+                        For some of the symbols combining characters
+                        have been used. Do not use this space to
+                        redefine characters already found in standard
+                        ISO entity sets. Do not use this space to
+                        define any character that cannot be
+                        represented with Unicode.                  -->
+
+<!--                    LATIN SMALL LETTER G WITH CARON            -->
+<!ENTITY  gcaron        "&#x01E7;"                                   >
+
+
+<!--                    LATIN CAPITAL LETTER H WITH MACRON         -->
+<!ENTITY  Hmacr         "&#x0048;&#x0304;"                           >
+
+
+<!--                    EURO CURRENCY                              -->
+<!ENTITY  euro          "&#x20AC;"                                   >
+
+
+<!--                    FRANC CURRENCY                             -->
+<!ENTITY  franc         "&#x20A3;"                                   >
+
+
+<!-- ============================================================= -->
+<!--                    ATTRIBUTE LISTS FOR PRIVATE CHARACTERS     -->
+<!-- ============================================================= -->
+
+
+<!--                    GLYPH DATA ATTRIBUTES                      -->
+<!--                    Attribute list for the <glyph-data>
+                        element                                    -->
+<!ENTITY % glyph-data-atts
+            "%jats-common-atts;                                       
+             fontchar   CDATA                              #IMPLIED
+             fontname   CDATA                              #IMPLIED
+             format     NMTOKEN                            #IMPLIED
+             resolution CDATA                              #IMPLIED
+             xml:space  (preserve)                 #FIXED 'preserve'
+             x-size     CDATA                              #IMPLIED
+             y-size     CDATA                              #IMPLIED" >
+
+
+<!--                    GLYPH REFERENCE ATTRIBUTES                 -->
+<!--                    Attribute list for the <glyph-ref>
+                        element                                    -->
+<!ENTITY % glyph-ref-atts
+            "%jats-common-atts;                                       
+             glyph-data IDREF                             #IMPLIED"  >
+
+
+<!--                    PRIVATE USE AREA AND CUSTOM CHARACTERS
+                        ATTRIBUTES                                 -->
+<!--                    Attribute list for the <private-char>
+                        element                                    -->
+<!ENTITY % private-char-atts
+            "%jats-common-atts;                                       
+             description
+                        CDATA                             #IMPLIED
+             name       CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    PRIVATE USE AREA AND CUSTOM CHARACTERS     -->
+<!-- ============================================================= -->
+<!--
+                        Special characters defined by publishers as
+                        custom entities or in the Unicode Private Use
+                        Area may not be deposited as is. If they
+                        cannot be remapped to existing Unicode values,
+                        they must be submitted as a bitmap using
+                        the <private-char> element. The most
+                        repository-friendly technique is <glyph-data>
+                        although individual bitmap files may be
+                        submitted with inline-graphic.
+
+                        We would like to thank Beacon Publishing and
+                        the APS (American Physical Society) for
+                        providing us with this technique.          -->
+
+
+<!--                    PRIVATE CHARACTER MODEL                    -->
+<!--                    The content model for the <private-char>
+                        element                                    -->
+<!ENTITY % private-char-model
+                        "((glyph-data | glyph-ref) | inline-graphic*)"
+                                                                     >
+
+
+<!--                    PRIVATE CHARACTER (CUSTOM OR UNICODE)      -->
+<!--                    A custom character entity defined by a
+                        publisher or a custom character from the
+                        Unicode private-use area for which a bitmap
+                        is submitted for the glyph.
+
+                        Since there are no completely standard/public
+                        agreements on how such characters are to be
+                        named and displayed, this technique is to be
+                        used instead of a custom general entity
+                        reference, to provide complete information
+                        on the intended character.
+                        A document should contain a <private-char>
+                        element at each location where a private
+                        character is used within the document. The
+                        corresponding image for the glyph may be
+                        given in the <glyph-data> element or as an
+                        external bitmap file referenced by an
+                        <inline-graphic> element.
+
+                        Implementation Note: <inline-graphic> should
+                        only be used outside <private-char> when the
+                        graphic is something other than a special
+                        character.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=private-char
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=private-char
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=private-char
+                                                                   -->
+<!ELEMENT  private-char %private-char-model;                         >
+<!--         description
+                        A human-readable description of the
+                        character, for example, "Arrow, normal
+                        weight, single line, two-headed, Northwest
+                        to Southeast".
+             name       Unique name for the character in all
+                        uppercase ASCII, similar to names found
+                        in Unicode standard (e.g., "NORTHWEST
+                        SOUTHEAST ARROW"                           -->
+<!ATTLIST  private-char
+             %private-char-atts;                                     >
+
+
+<!--                    GLYPH DATA FOR A PRIVATE CHARACTER         -->
+<!--                    This element is used when there is known to
+                        be no font available to render the private
+                        character. The <glyph-data> element can be
+                        used to provide information on the actual
+                        glyph that is associated with the private-use
+                        character. The element includes an inline
+                        bitmap of the glyph encoded in plain
+                        PBM (Plain Bit Map) format so that it is
+                        human-readable.
+
+                        For example:
+                        <private-char name="NORTHWEST SOUTHEAST ARROW"
+                        description="Arrow, normal weight, single
+                        line, two-headed, Northwest to Southeast">
+                        <glyph-data format="PBM" resolution="300"
+                        x-size="34" y-size="34">
+                        0000000000000000000000000000000000
+                        0111111111111100000000000000000000
+                        0111111111111100000000000000000000
+                        0111110000000000000000000000000000
+                        0111110000000000000000000000000000
+                        0111111000000000000000000000000000
+                        0110111100000000000000000000000000
+                        0110011110000000000000000000000000
+                        0110001111000000000000000000000000
+                        0110000111100000000000000000000000
+                        0110000011110000000000000000000000
+                        0110000001111000000000000000000000
+                        0110000000111100000000000000000000
+                        0110000000011110000000000000000000
+                        0110000000001111000000000000000000
+                        0110000000000111100000000000000000
+                        0110000000000011110000000000000000
+                        0000000000000001111000000000000000
+                        0000000000000000111100000000000110
+                        0000000000000000011110000000000110
+                        0000000000000000001111000000000110
+                        0000000000000000000111100000000110
+                        0000000000000000000011110000000110
+                        0000000000000000000001111000000110
+                        0000000000000000000000111100000110
+                        0000000000000000000000011110000110
+                        0000000000000000000000001111000110
+                        0000000000000000000000000111100110
+                        0000000000000000000000000011110110
+                        0000000000000000000000000001111110
+                        0000000000000000000000000001111110
+                        0000000000000000011111111111111110
+                        0000000000000000011111111111111110
+                        0000000000000000000000000000000000
+                        </glyph-data></private-char>
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=glyph-data
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=glyph-data
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=glyph-data
+                                                                   -->
+<!ELEMENT  glyph-data   (#PCDATA)                                    >
+<!--         id         Identifier so that the full glyph data need
+                        not be repeated every time the character is
+                        used. The <glyph-ref> element can be used
+                        to point to this ID, to reuse a character
+                        in subsequent text.
+             fontchar   The offset of the character into a glyph
+                        table, such as a Unicode character.
+             fontname   The name of the character
+             format     Names the image format of the bitmap. Should
+                        be "PBM" if the plain bitmap is included
+                        inline.
+             resolution Resolution of the bitmap in dots per inch,
+                        expressed as a decimal integer (e.g. 72, 300)
+             xml:space  Preserve whitespace within this element.
+             x-size     Number of pixels per row in the bit-mapped
+                        glyph
+             y-size     Number of rows of the bit-mapped glyph     -->
+<!ATTLIST  glyph-data
+             %glyph-data-atts;                                       >
+
+
+<!--                    GLYPH REFERENCE FOR A PRIVATE CHARACTER    -->
+<!--                    Once a private character has been declared
+                        using a <glyph-data> element, the character
+                        can be reused by using this element to
+                        point to the full <glyph-data> element.
+                        The pointing uses the ID/IDREF mechanism,
+                        using the "glyph-data" attribute of this
+                        element to point to the "id" attribute of
+                        another <glyph-data> element.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=glyph-ref
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=glyph-ref
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=glyph-ref
+                                                                   -->
+<!ELEMENT  glyph-ref    EMPTY                                        >
+<!--         glyph-data An IDREF-type attribute that points to the
+                        "id" attribute of a <glyph-data> character.
+                        The idea is to use the full glyph data once,
+                        then point to an existing character instead
+                        of repeating the entire glyph data again.  -->
+<!ATTLIST  glyph-ref
+             %glyph-ref-atts;                                        >
+
+<!-- ================== End Custom XML Special Characters ======== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-common-atts1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-common-atts1.ent
@@ -1,0 +1,307 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Common Attributes (for all elements)              -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Common Attributes (for all elements) v1.2 20190208//EN"
+     Delivered as file "JATS-common-atts1.ent"                     -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Defines attributes intended to be used on ALL the -->
+<!--             elements defined in the NISO JATS, including the  -->
+<!--             elements for the XHTML-inspired and OASIS-inspired-->
+<!--             table models, excluding only <mml:math> and       -->
+<!--             <xi:include>, whose namespaces JATS does not      -->
+<!--             control.                                          -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 10. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+  9. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+  8. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+  7. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+  6. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  5. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  4. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  3. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  2. XML Base
+     Added the attribute @xml:base to the Global (common)
+     attributes used on all elements.
+   
+     =============================================================
+                                                                   -->
+
+
+<!-- ============================================================= -->
+<!--                    NISO JATS COMMON ATTRIBUTES                -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON ATTRIBUTES                          -->
+<!--                    These lists of attributes will be added to 
+                        nearly every element, in both the document 
+                        metadata and the document body, of the entire 
+                        Tag Set:
+                          - including table elements for both the 
+                              XHTML-inspired and OASIS-inspired
+                              table model elements
+                          - excluding only <mml:math> and 
+                              <xi:include> (whose namespaces JATS
+                              does not control).
+                           Great care should be taken to use these
+                        attributes judiciously, not as a shortcut to
+                        thinking through where an attribute should be
+                        used. Potential use cases include adding
+                        @xml:lang or some RDFa attribute to every 
+                        elements.                                  -->
+
+
+<!--                    BASE ATTRIBUTES                            -->
+<!--                    Holds all the common attributes except @id.
+                        Used to keep the two common attribute lists 
+                        in sync. To add a global attribute, modify
+                        this list.                                 -->
+<!ENTITY % jats-base-atts
+            "xml:base   CDATA                             #IMPLIED"  >
+
+
+<!--                    JATS COMMON ATTRIBUTES                     -->
+<!--                    Holds all the common attributes, as defined in
+                        the base attribute parameter entity, plus an
+                        optional @id.                              -->
+<!ENTITY % jats-common-atts
+            "id         ID                                #IMPLIED 
+             %jats-base-atts;"                                       >
+
+
+<!--                    JATS COMMON ATTRIBUTES (ID REQUIRED)       -->
+<!--                    Holds all the common attributes, as defined in
+                        the base attribute parameter entity, plus a 
+                        required @id.                              -->
+<!ENTITY % jats-common-atts-id-required
+            "id         ID                                #REQUIRED
+             %jats-base-atts;"                                       >
+
+
+<!-- ================== End JATS Common Attributes Module ======== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-common1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-common1.ent
@@ -1,0 +1,4457 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Common (Shared) Elements Module                   -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Common (Shared) Elements Module v1.2 20190208//EN"
+Delivered as file "JATS-common1.ent"                               -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Defines the common parameter entities, calls the  -->
+<!--             shared modules (such as special characters and    -->
+<!--             notations) and provides declarations for elements -->
+<!--             that do not properly fit into one class, since    -->
+<!--             they can be used at more than one structural level-->
+<!--                                                               -->
+<!-- MODULES REQUIRED:                                             -->
+<!--             1) Standard XML Special Characters Module         -->
+<!--                                       (%xmlspecchars.ent;)    -->
+<!--             2) Custom XML Special Characters (%chars.ent;)    -->
+<!--             3) Notation Declarations    (%notat.ent;)         -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 61. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 60. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 59. PUB-ID-TYPE - @pub-id-type (for all tag sets EXCEPT 
+     Archiving) changed back to a fixed list from CDATA for some
+     elements, reversing the decision of Version 1.2d1. Although 
+     the value list is unchanged, best practice will be documented
+     as using @pub-id-type for type and @assigning-authority
+     for the responsible agency.
+        The following were changed back. Therefore, Archiving must 
+     override the following attribute lists to make @pub-id-type 
+     CDATA:
+         - <article-id> (now value list)
+         - <pub-id>     (now value list)
+     But no change to the following, which were CDATA in version 1.1
+         - <issue-id>
+         - <object-id>
+         - <volume-id>
+
+ 58. ASSIGNING AUTHORITY - Added @assigning-authority to the
+     following elements, so that the type-of-identifier 
+     could be recorded with @pub-id-type and the party-
+     responsible-for-the-identifier could be recorded
+     using @assigning-authority. Previously, these value 
+     types were conflated in @pub-id-type. However, for
+     backward compatibility, @pub-id-type was left as
+     the SAME restricted list, with both types intermingled. 
+         - <contrib-id>
+         - <institution-id>
+         - <issue-id>
+         - <journal-id>
+         - <object-id>
+         - <volume-id>
+         - Note: <ext-link> already took @assigning-authority
+
+ 57. DATA USAGE - Added new CDATA attribute @use-type to both
+     <mixed-citation> and <element-citation>. First use case is to
+     explain cited data usage ("analyzed", "generated", etc.)
+
+ 56. DEGREE OF CONTRIBUTION - Added new CDATA attribute 
+     @degree-contribution to <role> to hold the degree of 
+     contribution. This is an open list, but values are 
+     expected to be "Lead", "Equal", or "Supporting".
+     Numeric values will be discouraged.
+
+ 55. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 54. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+   
+ 53. VOCABULARY/TAXONOMY ATTRIBUTES - Added 4 new attributes for
+     naming (and possibly linking to) a general or controlled
+     taxonomy, vocabulary, index, database or other source of
+     terms: @vocab, @vocab-identifier, @vocab-term, and
+     @vocab-term-identifier
+      - Added all 4 attributes to:
+        - to <role>, for adding CRediT or other specifically named
+          roles to contributors
+        - Added @vocab amd @vocab-identifier to <institution-id>
+ 
+ 52. JATS became version "1.2d1" and "v1.2d1 20170631"
+ 
+    =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 51. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 50. ALI (NISO Access and License Indicators)
+     - Added <ali:license_ref> to license-p.class, as 
+       alternatives inside <license>
+     - Use the new class: license.class to hold the new ALI
+       element <ali:free_to_read>, as an alternative to
+       <license> inside <permissions>.
+     - Created new parameter entity 'anyURI' to act as 
+       documentation concerning the content of any element whose
+       content is intended to be a URI.  
+
+ 49. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+
+ 48. VOLUME ISSUE GROUPING
+   - Added new optional element <volume-issue-group> inside 
+     <article-meta), following all volume and issue elements,
+     to hold volume-issue pairs (or n-tuples) when a second
+     and subsequent <volume> has its own related issue
+     information.
+
+ 47. NEW ATTRIBUTE VALUES FOR @PUB-ID-TYPE
+     Added three new values to @pub-id-types:
+      - accession
+      - arc
+      - handle
+ 
+ 46. NEW ATTRIBUTE FOR EXT-LINK
+     Added the CDATA attribute @assigning-authority to <ext-link>
+     to the authority (such as CrossRef) responsible for the
+     link
+
+ 45. NEW ATTRIBUTE FOR CONTRIB-ID
+     Added the boolean attribute @authenticated to <contrib-id> to 
+     record whether the agency that assigned the <contrib-id>
+     says the identifier is authenticated. The default value
+     is "false"
+
+ 44. MORE LINKING POSSIBILITIES
+     Added the might-link-atts to:
+      - volume-id
+      - issue-id
+     so that these potentially external identifiers can link,
+     for example to a DOI.
+
+ 43. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+ 42. NEW ADDRESS ELEMENTS
+      - Added 3 new elements: <city>, <state>, <postal-code>
+      - Therefore introduced new PEs: city-element, state-elements,
+        and postal-code-elements, all set initially to null strings.
+      - Therefore introduced new PEs: city-atts, state-atts,
+        and postal-code-atts.
+      - Added the elements (in the default classes module) to:
+          - address.class
+          - addrress-line.class
+        which adds then to: address, addr-line, aff, collab, 
+        conf-loc, corresp, publisher-loc
+
+ 41. CHANGES TO <collab>
+     Added @symbol attribute.
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 40. CHANGES TO <on-behalf-of>
+     Added <institution>, <institution-wrap>, and <xref>
+
+ 39. NEW <contrib> ATTRIBUTE
+     Added @xml:lang as requested with <institution-id>
+
+ 38. NEW <era> ELEMENT
+     Added <era> through date-parts.class to:
+      - <string-date>
+
+ 37. NEW ELEMENT <era>
+     Added to the model of <date>, optional following year,
+     through date-model.
+
+ 36. XML Base
+     Added the attribute @xml:base to the Global (common)
+     attributes used on all elements.
+
+ 35. INSTITUTION WRAP ADDED
+     Added the elements <institution-wrap> to the following elements
+     through the institution-wrap.class:
+      - <copyright-holder>
+      - <on-behalf-of>
+      - <publisher-name>
+      - <std-organization>
+
+ 34. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added a new attribute list to:
+      - aff-alternatives
+      - alternatives
+      - citation-alternatives
+      - collab-alternatives
+      - custom-meta-group
+      - institution-wrap
+      - meta-name
+      - meta-value
+      - name-alternatives
+      - permissions                          
+
+ 33. INSTITUTIONAL IDENTIFIERS
+     - Added <institution-id> to hold institutional identifiers
+       whether publisher specific ("AIP") or from an established 
+       authorities ("Ringgold" and "ISNI").
+
+     - Added <institution-wrap> to hold both the name of an
+       institution <institution> and all of its institutional 
+       identifiers <institution-id>. This element will be allowed
+       everywhere institution is allowed.
+                          
+
+ 32. ABSTRACTS AND KEYWORDS ON NEW STRUCTURES
+     - Added <abstract> (through %abstract.class;) and <kwd-group> 
+       (through %kwd-group.class;) to the following elements:
+        - sec-meta (through %sec-meta-model;)
+
+ 31. ATTRIBUTE ALIGNMENT
+     - Added @publication-format and @content-type to <issn>
+       through %issn-atts The idea is to make the attributes
+       for <issn> and <isbn> as similar as possible.
+
+     - Added @publication-format to <isbn> through %isbn-atts 
+     
+     The idea is to make the attributes for <issn> and <isbn> as 
+     similar as possible. <issn> retains @pub-type for historical
+     reasons. <issn-l> attributes do not change.
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 30. CONTRIB-GROUP AND CONTRIB MODULE SHIFT - Moved <contrib>
+     and <contrib-group> to common.ent from the module
+     articlemeta.ent, since they are now used
+     in both article metadata and journal metadata.
+
+ 29. CONTRIB ID - Added new element <contrib-id> using new PE 
+     contrib-id.class, contrib-id-atts, contrib-id-model.
+     Element holds one identifier, such as an ORCID, for a
+     person such as a contributor or principal investigator.
+
+ 28. COLLABORATION ALTERNATIVES - Added new element 
+     <collab-alternatives> using new PE %collab-alternatives-model;.
+     Element holds different versions (for example, different
+     language renderings) of a single collaboration.   
+   
+ 27. DATE ATTRIBUTES - Added date attributes
+      - to <conf-date> through %conf-date-atts
+      - to <date> through %date-atts
+      - to <string-date> through %string-date-atts
+      - to <year> through %year-atts
+      
+       a) @iso-8601-date - ISO 8601 standard date format
+          of the publication date. Format  YYYY-MM-DDThh:mm:ss 
+
+       b) @calendar - Name of the calendar used (@calendar) in
+          naming this publication date (such as "Gregorian", 
+          "Japanese" (Emperor years), or "Islamic").
+
+       c) Added @publication-format, so that both publication
+          dates and history dates can separate the for amt of the
+          publication from the version/lifecycle event. Thus
+          both an "article" and a "manuscript" might be received.
+
+ 27. PUBLICATION IDENTIFIER @pub-id-type
+      - Added "std-designation" as value in predefined  list 
+        for '@pub-id-type' (% pub-id-types).
+      - Added new value "arxiv" as value in predefined  list 
+        for '@pub-id-type' (% pub-id-types).
+     "pub-id-types" are used within citations for 
+     <object-id> and <pub-id>; 
+     used within the article metadata for <article-id>, 
+     <issue-id>, and <volume-id>; 
+     used within many body elements for <object-id>.
+       
+ 26. LONG DESCRIPTION - Added the might-link attributes to
+     <long-desc> because of an argument over what <long-desc>
+     should be. The semantic web folks want it to be a URI, the
+     librarians and accessibility (for pronouncing readers) want
+     to find a real description there, not a link. So JATS needs
+     to handle both.
+   
+ 25. ISSN Linking - Added new element <issn-l> with the usual
+     %issn-l-elements; and %issn-l-atts;.
+   
+ 24. MODULE MOVEMENT (from increased reference content)
+
+     a) Element <degrees> - Moved <degrees> and its parameter
+        entities into this module from JATS-articlemeta.ent.
+   
+     b) Element <supplement> - Moved <supplement> and its parameter
+        entities into this module from JATS-articlemeta.ent.
+   
+     c) Element <conf-sponsor> - Moved <conf-sponsor> and its parameter
+        entities into this module from JATS-articlemeta.ent.
+   
+     d) Element <on-behalf-of> - Moved <on-behalf-of> and its parameter
+        entities into this module from JATS-articlemeta.ent.
+   
+ 23. Element <license-p> - Added @content-type, which can hold
+     values such as "open-access", "CCC-statement",
+     "non-commercial-use".
+   
+ 22. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+ 21. Updated the DTD-version attribute to "0.4" 
+   
+ 18. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+           http://jats.nlm.nih.gov/0.4.
+
+ 17. MIXED CITATION ATTS PE - Was defined twice, identically,
+     deleted one of them.
+
+ 16. ACCESSIBILITY - Added @alt to <label> through %label-atts;
+
+ 15. ALTERNATIVES ATTRIBUTES- Created a new parameter entity for
+     attributes for <alternatives>; currently null
+
+ 14. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+       - anonymous through anonymous-atts (both) NEW PE
+       - conf-acronym through conf-acronym-atts (both)
+       - conf-date through conf-date-atts (both)
+       - conf-loc through conf-loc-atts (both)
+       - conf-name through conf-name-atts (both)
+       - conf-num through conf-num-atts (both)
+       - conf-sponsor through conf-sponsor-atts (both)
+       - conf-theme through conf-theme-atts (both)
+       - day through day-atts (@specific-use)
+       - degrees through degrees-atts (both)
+       - element-citation through citation-atts (both)
+       - etal through etal-atts (both) NEW PE
+       - ext-link through ext-link-atts (@xml:lang; @specific-use
+           already)
+       - institution through institution-atts (both)
+       - issue-part through issue-part (both + content-type) NEW PE
+       - isbn through isbn-atts (both) NEW PE
+       - label through label-atts (both) NEW PE
+       - mixed-citation through citation-atts (both)
+       - name through name-atts (@xml:lang; @specific-use already)
+       - notes through notes-atts (both)
+       - prefix through prefix-atts (both)
+       - publisher-loc through publisher-loc-atts (both)
+       - publisher-name through publisher-name-atts (both)
+       - string-name through string-name-atts (both and
+            content-type and name-style) NEW PE
+       - suffix through suffix-atts (both)
+       - textual-form through textual-form-atts (both)
+       - trans-subtitle through trans-subtitle-atts
+          (@xml:lang only) NEW PE
+       - x through x-atts (both)
+
+ 13. AFFILIATION ALTERNATIVES - Created new the element
+     <aff-alternatives> to hold multiple <aff>s that are
+     representations of a single affiliation, for example, the
+     name of an institution in two languages or two scripts.
+     New PE; New attribute PE (currently null)
+
+ 12. RELATED-ARTICLE-ATTS - Removed the dependency that tied
+     %related-article-atts to journal-id-atts and added all
+     the journal-id attributes to related-article-atts explicitly.
+
+ 11. TITLE ELEMENTS - Removed the dependency which had both
+     <subtitle> and <alt-title> modeled with the same parameter
+     entity %title-elements;. Created new PEs for each element
+     but set them (as the default) to %title-elements so that no
+     customization would break. Models changed:
+       - alt-title      %alt-title-elements;
+       - subtitle       %subtitle-elements; (defined in
+                                article-meta3.ent;)
+       - trans-title    %trans-title-elements;
+       - trans-subtitle %trans-subtitle-elements;
+
+ 10. TEXTUAL FORM MODEL - Changed the textual-form-elements
+     parameter entity to begin with an OR bar, since it names
+     elements to be mixed with #PCDATA.
+     *****Customization Alert: New parameter entity could break some
+     customizations. Check your %textual-form-elements parameter
+     entity. *****
+
+  9. PUBLISHER - Allowed <publisher-name> and <publisher-loc> to
+     repeat (as an unnamed-parenthetical) inside <publisher>.
+     This will allow co-publishers and publisher names and locations
+     in more than one language. Added to facilitate multiple
+     languages. Also added @specific-use and @xml:lang to
+     both publisher-name and publisher-loc.
+
+  8. ATTLIST PARAMETER ENTITIES - Changed the attribute lists
+     from using the same parameter entity (%day-atts;) to using:
+       - day    %day-atts;   (no change)
+       - month  %month-atts;
+       - season %season-atts;
+
+  7. ISBN - Added "isbn" as value in predefined list for
+    '@pub-id-type' (% pub-id-types)
+
+  6. TEXTUAL FORM - Added the following attributes: (new)
+       - @specific-use
+       - @xml:lang
+
+  5. NAME ALTERNATIVES - Created a new wrapper element for more
+     than one version of a personal name, for example, the name in
+     Japanese kana characters and a transliterated form of the name
+     in Latin alphabet, or a regular name and a search version
+     that transliterates umlauts to unaccented characters.
+      - new element <name-alternatives>
+      - new PE name-alternatives-model
+      - new PE name-alternatives-atts (currently null)
+
+  4. STRING NAME - Added the following attributes: (new)
+       - @content-type
+       - @specific-use
+       - @name-style
+       - @xml:lang
+
+  3. PERSON'S NAME STYLE
+       - Added the value "given-only" to the @name-style on <name>
+
+  2. PERSON'S NAME - Allowed <given-names> as an alternative
+     to <surname, given-names?) to accommodate the Indian
+     names that are only a given name.
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE VALUES    -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE/PUBLICATION IDENTIFIER TYPES       -->
+<!--                    Values for the @pub-id attribute. Used:
+                        1) Within citations with the <pub-id> and 
+                        <object-id> elements to name the type of
+                        identifier (such as DOI) or the organization 
+                        or system that defined the identifier for the 
+                        identifier of the journal article or a cited 
+                        publication, such as a book or standard.
+                        2) Within article metadata with the
+                        <article-id>, <issue-id>, and <volume-id>
+                        elements to name the type of identifier or 
+                        identifying agency.
+                        4) Within many body elements to perform a 
+                        similar function for the <object-id> element.
+                                                                   -->
+<!ENTITY % pub-id-types  "accession | archive | ark | art-access-id | 
+                          arxiv | coden | doaj | doi | 
+                          handle | index | isbn | 
+                          manuscript | medline | mr | other | 
+                          pii | pmcid |  pmid | publisher-id | sici |
+                          std-designation | zbl"                     >
+                                                           
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR CONTENT MODELS      -->
+<!-- ============================================================= -->
+
+
+<!--                    ANY URI SCHEMA TYPE (as documentation)     -->
+<!--                    Indicates that in an XSD or RNG Schema, this
+                        element would be typed as the simple type
+                        'anyURI". This has no enforcement power in a 
+                        DTD, it is intended for human guidance.
+                        but is only for human guidance in a DTD   -->
+<!ENTITY % anyURI       "(#PCDATA)"                                 >
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE VALUES    -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE/PUBLICATION IDENTIFIER TYPES       -->
+<!--                    Values for the @pub-id attribute. Used:
+                        1) Within citations with the <pub-id> and 
+                        <object-id> elements to name the type of
+                        identifier (such as DOI) or the organization 
+                        or system that defined the identifier for the 
+                        identifier of the journal article or a cited 
+                        publication, such as a book or standard.
+                        2) Within article metadata with the
+                        <article-id>, <issue-id>, and <volume-id>
+                        elements to name the type of identifier or 
+                        identifying agency.
+                        4) Within many body elements to perform a 
+                        similar function for the <object-id> element.
+                                                                   -->
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR FULL CONTENT MODELS -->
+<!-- ============================================================= -->
+
+
+<!--                    DATE ELEMENTS MODEL                        -->
+<!--                    The content models for elements that describe
+                        dates, such as Publication Date <pub-date>
+                        and History Dates <date>.                  -->
+<!ENTITY % date-model   "( ( (day?, month?) | season)?,
+                          year?, era?, string-date?)"                >
+
+
+<!--                    CONTENT MODEL FOR A STRUCTURAL SECTION     -->
+<!--                    The model for a section that requires that a
+                        section title be present, used for elements
+                        such as Section and Appendix.              -->
+<!ENTITY % sec-model    "(sec-meta?, label?, title, (%para-level;)*,
+                          (%sec-level;)*,
+                          (%sec-back-matter-mix;)* )"                >
+
+
+<!--                    CONTENT MODEL FOR A SECTION METADATA       -->
+<!--                    In some works, each section has a different
+                        author or some sections are authored by
+                        different contributors from the enclosing
+                        article. This wrapper element for
+                        section-level metadata is used to capture
+                        information such as those contributors.
+                                                                   -->
+<!ENTITY % sec-meta-model
+                        "((%contrib-group.class;)*, 
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          permissions?)"       >
+
+
+<!--                    CONTENT MODEL FOR AN UNTITLED SECTION      -->
+<!--                    The model for a section-like structure that
+                        may or may not have an initial title       -->
+<!ENTITY % sec-opt-title-model
+                        "(sec-meta?, label?, title?, (%para-level;)*,
+                          (%sec-level;)*,
+                          (%sec-back-matter-mix;)* )"                >
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR MIXED CONTENT       -->
+<!-- ============================================================= -->
+
+
+<!--                    LINK ELEMENTS                              -->
+<!--                    Elements for use in the linking elements
+                        such as <xref>, <target>, and <ext-link>   -->
+<!ENTITY % link-elements
+                        "| %emphasis.class; | %phrase-content.class; |
+                         %subsup.class;"                             >
+
+
+<!--                    PARAGRAPH ELEMENTS                         -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a paragraph <p>.
+                        Design Note: There is a major overlap between
+                        this parameter entity and the mix for elements
+                        that are at the same level as a paragraph.
+                        Inline elements appear only inside a
+                        paragraph, but block elements such as quotes
+                        and lists may appear either within a
+                        paragraph or at the same level as a
+                        paragraph. This serves a requirement in a
+                        repository DTD, since some incoming material
+                        will have restricted such elements to only
+                        inside a paragraph, some incoming material
+                        will have restricted them to only outside a
+                        paragraph and some may allow them in both
+                        places. Thus the DTD must allow for them to
+                        be in either or both.
+                        Design Note: Inline mixes begin with an
+                        OR bar                                     -->
+<!ENTITY % p-elements   "| %address-link.class; |
+                         %article-link.class; |
+                         %block-display.class; | %block-math.class; |
+                         %citation.class; |  %emphasis.class; |
+                         %funding.class; |  %inline-math.class; |
+                         %inline-display-noalt.class; |
+                         %list.class; | %math.class; |
+                         %phrase.class; | %rest-of-para.class; |
+                         %simple-link.class; |
+                         %subsup.class;"                             >
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR TITLES              -->
+<!-- ============================================================= -->
+
+
+<!--                    TITLE ELEMENTS                             -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a paragraph <title>.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % title-elements
+                        "%simple-phrase; | %break.class;"            >
+
+
+<!--                    ALTERNATE TITLE ELEMENTS                   -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a paragraph <alt-title>.
+                        An earlier version of this tag set used the
+                        parameter entity %title-elements; for many
+                        title elements including <alt-title>.      -->
+<!ENTITY % alt-title-elements
+                        "%title-elements;"                           >
+
+
+<!--                    TRANSLATED TITLE ELEMENTS                  -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a paragraph <trans-title>.
+                        An earlier version of this tag set used the
+                        parameter entity %title-elements; for many
+                        title elements including <trans-title>.    -->
+<!ENTITY % trans-title-elements
+                        "%title-elements;"                           >
+
+
+<!--                    TRANSLATED SUBTITLE ELEMENTS               -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a paragraph <subtitle>.
+                        An earlier version of this tag set used the
+                        parameter entity %title-elements; for many
+                        title elements including <trans-subtitle>. -->
+<!ENTITY % trans-subtitle-elements
+                        "%title-elements;"                           >
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR LINKING ATTRIBUTES  -->
+<!--                    THE FOLLOWING FEW ARE SHARED ATTRIBUTES    -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON ATTRIBUTES                          -->
+<!--                    These lists of attributes will be added to 
+                        nearly every element, in both the document 
+                        metadata and the document body, of the entire 
+                        Tag Set:
+                          - including table elements for both the 
+                              XHTML-inspired and OASIS-inspired
+                              table model elements
+                          - excluding only <mml:math> and 
+                              <xi:include> (whose namespaces JATS
+                              does not control).
+                           Great care should be taken to use these
+                        attributes judiciously, not as a shortcut to
+                        thinking through where an attribute should be
+                        used. Potential use cases include adding
+                        @xml:lang or some RDFa attribute to every 
+                        elements.                                  -->
+
+
+<!--                    BASE ATTRIBUTES                            -->
+<!--                    Holds all the common attributes except @id.
+                        Used to keep the two common attribute lists 
+                        in sync. To add a global attribute, modify
+                        this list.                                 -->
+<!ENTITY % jats-base-atts
+            "xml:base   CDATA                             #IMPLIED"  >
+
+
+<!--                    JATS COMMON ATTRIBUTES                     -->
+<!--                    Holds all the common attributes, as defined in
+                        the base attribute parameter entity, plus an
+                        optional @id.                              -->
+<!ENTITY % jats-common-atts
+            "id         ID                                #IMPLIED 
+             %jats-base-atts;"                                       >
+
+
+<!--                    JATS COMMON ATTRIBUTES (ID REQUIRED)       -->
+<!--                    Holds all the common attributes, as defined in
+                        the base attribute parameter entity, plus a 
+                        required @id.                              -->
+<!ENTITY % jats-common-atts-id-required
+            "id         ID                                #REQUIRED
+             %jats-base-atts;"                                       >
+
+
+
+<!--                    XLINK LINK ATTRIBUTES                      -->
+<!--                    Used for elements that are a link by
+                        definition, such as the <xref> element.    -->
+<!ENTITY % link-atts
+            "xmlns:xlink CDATA                            #IMPLIED
+             xlink:type  (simple)                         #IMPLIED
+             xlink:href  CDATA                            #REQUIRED 
+             xlink:role  CDATA                            #IMPLIED
+             xlink:title CDATA                            #IMPLIED
+             xlink:show  (embed | new | none | other | replace)
+                                                          #IMPLIED
+             xlink:actuate
+                         (none | onLoad | onRequest | other)
+                                                          #IMPLIED"  >
+
+
+<!--                    MIGHT LINK XLINK ATTRIBUTES                -->
+<!--                    Used for elements which may need to link to
+                        external sources or other objects within
+                        the document, but may not necessarily act
+                        as a link at all.  The attribute
+                        "xlink:href" identifies the object to which
+                        the link points.                           -->
+<!ENTITY % might-link-atts
+            "xmlns:xlink CDATA                            #IMPLIED
+             xlink:type  (simple)                         #IMPLIED
+             xlink:href  CDATA                            #IMPLIED
+             xlink:role  CDATA                            #IMPLIED
+             xlink:title CDATA                            #IMPLIED
+             xlink:show  (embed | new | none | other | replace)
+                                                          #IMPLIED
+             xlink:actuate
+                         (none | onLoad | onRequest | other)
+                                                          #IMPLIED"  >
+
+
+<!--                    CITATION ATTRIBUTES                        -->
+<!--                    Attributes for all two kinds of citations:
+                        <element-citation> and <mixed-citation>    -->
+<!ENTITY % citation-atts
+            "%jats-common-atts;                                        
+             publication-type
+                        CDATA                             #IMPLIED
+             publisher-type
+                        CDATA                             #IMPLIED
+             publication-format
+                        CDATA                             #IMPLIED
+             use-type   CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTES LISTS    -->
+<!--                    (ALPHABETICAL ORDER)                       -->
+<!-- ============================================================= -->
+
+
+<!--                    AFFILIATION ATTRIBUTES                     -->
+<!--                    Attributes for the <ack> element           -->
+<!ENTITY % ack-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ADDRESS ATTRIBUTES                         -->
+<!--                    Attributes for the <address> element       -->
+<!ENTITY % address-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ADDRESS LINE ATTRIBUTES                    -->
+<!--                    Attributes for the <addr-line> element     -->
+<!ENTITY % addr-line-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    AFFILIATION ATTRIBUTES                     -->
+<!--                    Attributes for the Affiliation <aff>
+                        element                                    -->
+<!ENTITY % aff-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             rid        IDREFS                            #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    AFFILIATION ALTERNATIVES ATTRIBUTES        -->
+<!--                    Attributes for the <aff-alternatives>
+                        element                                    -->
+<!ENTITY % aff-alternatives-atts
+            "%jats-common-atts;"                                     >                                        
+
+
+<!--                    ALTERNATE TEXT ATTRIBUTES                  -->
+<!--                    Attributes for the <alt-text> element      -->
+<!ENTITY % alt-text-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ANONYMOUS ATTRIBUTES                       -->
+<!--                    Attributes for the <anonymous> element     -->
+<!ENTITY % anonymous-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ALTERNATIVES ATTRIBUTES                    -->
+<!--                    Attributes for the <alternatives> element  -->
+<!ENTITY % alternatives-atts
+            "%jats-common-atts;"                                     >                                        
+
+
+<!--                    ARTICLE TITLE ATTRIBUTES                   -->
+<!--                    Attributes for the <article-title> element -->
+<!ENTITY % article-title-atts
+            "%jats-common-atts;                                        
+             xml:lang   NMTOKEN                            #IMPLIED" >
+
+
+<!--                    ATTRIBUTION ATTRIBUTES                     -->
+<!--                    Attributes for the <attrib> element        -->
+<!ENTITY % attrib-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    BIOGRAPHY ATTRIBUTES                       -->
+<!--                    Attributes for <bio> element               -->
+<!ENTITY % bio-atts
+            "%jats-common-atts;                                        
+             rid        IDREFS                            #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    CITATION ALTERNATIVES ATTRIBUTES           -->
+<!--                    Attributes for the <citation-alternatives>
+                        element                                    -->
+<!ENTITY % citation-alternatives-atts
+            "%jats-common-atts;"                                     >                                        
+
+
+<!--                    CITY ATTRIBUTES                            -->
+<!--                    Attributes for the <city> element          -->
+<!ENTITY % city-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    COLLABORATION ATTRIBUTES                   -->
+<!--                    Attributes for <collab>                    -->
+<!ENTITY % collab-atts
+            "%jats-common-atts;                                        
+             collab-type
+                        CDATA                             #IMPLIED
+             symbol     CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    COLLABORATION ALTERNATIVES ATTRIBUTES      -->
+<!--                    Attributes for the <collab-alternatives>
+                        element                                    -->
+<!ENTITY % collab-alternatives-atts
+            "%jats-common-atts;"                                      >                                        
+
+
+<!--                    CONFERENCE DATE ATTRIBUTES                 -->
+<!--                    Attributes for the <conf-date> element     -->
+<!ENTITY % conf-date-atts
+            "%jats-common-atts;                                        
+             iso-8601-date
+                        CDATA                             #IMPLIED
+             calendar   CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    CONFERENCE LOCATION ATTRIBUTES             -->
+<!--                    Attributes for the <conf-loc> element      -->
+<!ENTITY % conf-loc-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    CONFERENCE NAME ATTRIBUTES                 -->
+<!--                    Attributes for the <conf-name> element.    -->
+<!ENTITY % conf-name-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    CONFERENCE SPONSOR ATTRIBUTES              -->
+<!--                    Attributes for the <conf-sponsor> element. -->
+<!ENTITY % conf-sponsor-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    CONTRIBUTOR ATTRIBUTES                     -->
+<!--                    Attributes for the <contrib> element       -->
+<!ENTITY % contrib-atts
+            "%jats-common-atts;                                        
+             contrib-type
+                        CDATA                             #IMPLIED
+             corresp    (no | yes)                        #IMPLIED
+             equal-contrib
+                        (no | yes)                        #IMPLIED
+             deceased   (no | yes)                        #IMPLIED
+             rid        IDREFS                            #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    CONTRIBUTOR GROUP ATTRIBUTES               -->
+<!--                    Attributes for the <contrib-group> element -->
+<!ENTITY % contrib-group-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    CONTRIBUTOR IDENTIFIER ATTRIBUTES          -->
+<!--                    Attributes for the <contrib-id> 
+                        element.                                   -->
+<!ENTITY % contrib-id-atts
+            "%jats-common-atts;                                        
+             contrib-id-type
+                        CDATA                             #IMPLIED
+             assigning-authority                
+                        CDATA                             #IMPLIED
+             authenticated
+                        (true | false)                    'false'
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    COPYRIGHT HOLDER ATTRIBUTES                -->
+<!--                    Attributes for the <copyright-holder>
+                        element.                                   -->
+<!ENTITY % copyright-holder-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    COPYRIGHT STATEMENT ATTRIBUTES             -->
+<!--                    Attributes for the <copyright-statement>
+                        element.                                   -->
+<!ENTITY % copyright-statement-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    COPYRIGHT YEAR ATTRIBUTES                  -->
+<!--                    Attributes for the <copyright-year>
+                        element                                    -->
+<!ENTITY % copyright-year-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    COUNTRY ATTRIBUTES                         -->
+<!--                    Attributes for the <country> element       -->
+<!ENTITY % country-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             country    CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    CUSTOM METADATA ATTRIBUTES                 -->
+<!--                    Attributes for the <custom-meta> element   -->
+<!ENTITY % custom-meta-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    CUSTOM METADATA GROUP ATTRIBUTES           -->
+<!--                    Attributes for the <custom-meta-group>
+                        element                                    -->
+<!ENTITY % custom-meta-group-atts
+            "%jats-common-atts;"                                      >                                        
+
+
+<!--                    DATE (HISTORICAL) ATTRIBUTES               -->
+<!--                    Attributes for the <date> element          -->
+<!ENTITY % date-atts
+            "%jats-common-atts;                                        
+             date-type  CDATA                             #IMPLIED
+             publication-format
+                        CDATA                             #IMPLIED
+             iso-8601-date
+                        CDATA                             #IMPLIED
+             calendar   CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    DAY ATTRIBUTES                             -->
+<!--                    Attributes for the <day> element           -->
+<!ENTITY % day-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DEFINITION LIST: DEFINITION ATTRIBUTES     -->
+<!--                    Attribute list for the <def> element       -->
+<!ENTITY % def-atts
+            "%jats-common-atts;                                        
+             rid        IDREFS                            #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DEGREES ATTRIBUTES                         -->
+<!--                    Attributes for the <degrees> element       -->
+<!ENTITY % degrees-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ELEMENT CITATION ATTRIBUTES                -->
+<!--                    Attributes for <element-citation>          -->
+<!ENTITY % element-citation-atts
+            "%citation-atts;"                                        >
+
+
+<!--                    ELECTRONIC LOCATION IDENTIFIER ATTRIBUTES
+                        Attribute list for the <elocation-id>
+                        element                                    -->
+<!ENTITY % elocation-id-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             seq        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    EMAIL ATTRIBUTES                           -->
+<!--                    Attribute list for the <email> element     -->
+<!ENTITY % email-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    ERA ATTRIBUTES                             -->
+<!--                    Attributes for the <era> element           -->
+<!ENTITY % era-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ET AL. ATTRIBUTES                          -->
+<!--                    Attribute list for the <etal> element      -->
+<!ENTITY % etal-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    EXTERNAL LINK ATTRIBUTES                   -->
+<!--                    Attribute list for external links, such as
+                        <ext-link>                                 -->
+<!ENTITY % ext-link-atts
+            "%jats-common-atts;                                        
+             ext-link-type
+                        CDATA                             #IMPLIED
+             assigning-authority                
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    FAX ATTRIBUTES                             -->
+<!--                    Attribute list for the <fax> element       -->
+<!ENTITY % fax-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    FIRST PAGE ATTRIBUTES                      -->
+<!--                    Attribute list for the <fpage> element     -->
+<!ENTITY % fpage-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             seq        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    FREE TO READ ATTRIBUTES                    -->
+<!--                    Attributes for the ALI namespaced
+                        <ali:free_to_read> element                 -->
+<!ENTITY % free-to-read-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             end_date   CDATA                             #IMPLIED
+             start_date CDATA                             #IMPLIED
+             %ali.xmlns.attrib;"                                     >
+
+
+<!--                    GIVEN NAMES ATTRIBUTES                     -->
+<!--                    Attribute list for the <given-names> element
+                                                                   -->
+<!ENTITY % given-names-atts
+            "%jats-common-atts;                                        
+             initials  CDATA                             #IMPLIED"  >
+
+
+<!--                    INSTITUTION ATTRIBUTES                     -->
+<!--                    Attribute list for <institution>           -->
+<!ENTITY % institution-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    INSTITUTION IDENTIFIER ATTRIBUTES          -->
+<!--                    Attribute list for <institution-id>        -->
+<!ENTITY % institution-id-atts
+            "%jats-common-atts;                                        
+             institution-id-type
+                        CDATA                             #IMPLIED
+             assigning-authority                
+                        CDATA                             #IMPLIED
+             vocab      CDATA                             #IMPLIED
+             vocab-identifier
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    INSTITUTION WRAPPER ATTRIBUTES             -->
+<!--                    Attributes for the <institution-wrap>
+                        element                                    -->
+<!ENTITY % institution-wrap-atts
+            "%jats-common-atts;"                                          >                                        
+
+
+<!--                    ISBN ATTRIBUTES                            -->
+<!--                    Attributes for the <isbn> element          -->
+<!ENTITY % isbn-atts
+            "%jats-common-atts;                                        
+             publication-format
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    ISSN ATTRIBUTES                            -->
+<!--                    Attribute list for the <issn> element      -->
+<!ENTITY % issn-atts
+            "%jats-common-atts;                                        
+             pub-type   CDATA                             #IMPLIED
+             publication-format
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    ISSN-L (INKING ISSN) ATTRIBUTES            -->
+<!--                    Attribute list for the <issn-l> element    -->
+<!ENTITY % issn-l-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    ISSUE ATTRIBUTES                           -->
+<!--                    Attribute list for the <issue> element     -->
+<!ENTITY % issue-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             seq        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ISSUE IDENTIFIER ATTRIBUTES                -->
+<!--                    Attributes for the <issue-id> element      -->
+<!ENTITY % issue-id-atts
+            "%jats-common-atts;                                        
+             pub-id-type
+                        CDATA                             #IMPLIED
+             assigning-authority                
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    ISSUE PART ATTRIBUTES                      -->
+<!--                    Attribute list for <issue-part> element    -->
+<!ENTITY % issue-part-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ISSUE SPONSOR ATTRIBUTES                   -->
+<!--                    Attribute list for <issue-sponsor> element -->
+<!ENTITY % issue-sponsor-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ISSUE TITLE ATTRIBUTES                     -->
+<!--                    Attribute list for <issue-title> element   -->
+<!ENTITY % issue-title-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    JOURNAL IDENTIFIER ATTRIBUTES              -->
+<!--                    Attribute list for journal identifier
+                        <journal-id> element                       -->
+<!ENTITY % journal-id-atts
+            "%jats-common-atts;                                        
+             journal-id-type
+                        CDATA                             #IMPLIED
+             assigning-authority                
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    LABEL ATTRIBUTES                           -->
+<!--                    Attributes for the <label> element         -->
+<!ENTITY % label-atts
+            "%jats-common-atts;                                        
+             alt        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    LICENSE ATTRIBUTES                         -->
+<!--                    Attributes for the <license> element       -->
+<!ENTITY % license-atts
+            "%jats-common-atts;                                        
+             license-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    LICENSE PARAGRAPH ATTRIBUTES               -->
+<!--                    Attributes for the <license> element       -->
+<!ENTITY % license-p-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    LICENSE REFERENCE ATTRIBUTES               -->
+<!--                    Attributes for the ALI namespaced
+                        <ali:license_ref> element                  -->
+<!ENTITY % license-ref-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             start_date CDATA                             #IMPLIED
+             %ali.xmlns.attrib;"                                     >
+
+
+<!--                    LONG DESCRIPTION ATTRIBUTES                -->
+<!--                    Attributes for the <long-desc> element     -->
+<!ENTITY % long-desc-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    LPAGE ATTRIBUTES                           -->
+<!--                    Attributes for the <lpage> element         -->
+<!ENTITY % lpage-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    METADATA NAME (CUSTOM) ATTRIBUTES          -->
+<!--                    Attributes for <meta-name> element         -->
+<!ENTITY % meta-name-atts
+            "%jats-common-atts;"                                     >                                       
+
+
+<!--                    METADATA VALUE (CUSTOM) ATTRIBUTES          -->
+<!--                    Attributes for <meta-value> element         -->
+<!ENTITY % meta-value-atts
+            "%jats-common-atts;"                                       >                                       
+
+
+<!--                    MIXED CITATION ATTRIBUTES                  -->
+<!--                    Attributes for <mixed-citation> element    -->
+<!ENTITY % mixed-citation-atts
+            "%citation-atts;"                                        >
+
+
+<!--                    MONTH ATTRIBUTES                           -->
+<!--                    Attributes for the <month> element         -->
+<!ENTITY % month-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    NAME ATTRIBUTES                            -->
+<!--                    Attribute list for the <name> element      -->
+<!ENTITY % name-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             name-style (western | eastern | islensk |
+                         given-only)                      'western'
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang  NMTOKEN                            #IMPLIED"  >
+
+
+<!--                    NAME ALTERNATIVES ATTRIBUTES               -->
+<!--                    Attributes for the <name-alternatives>
+                        element                                    -->
+<!ENTITY % name-alternatives-atts
+            "%jats-common-atts;"                                      >                                       
+
+
+<!--                    NOTES ATTRIBUTES                           -->
+<!--                    Attribute list for the <note> element      -->
+<!ENTITY % notes-atts
+            "%jats-common-atts;                                        
+             notes-type CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    OBJECT IDENTIFIER ATTRIBUTES               -->
+<!--                    Attributes for the <object-id> element     -->
+<!ENTITY % object-id-atts
+            "%jats-common-atts;                                        
+             pub-id-type
+                        CDATA                             #IMPLIED
+             assigning-authority                
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    ON BEHALF OF ATTRIBUTES                    -->
+<!--                    Attributes for the <on-behalf-of> element  -->
+<!ENTITY % on-behalf-of-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PAGE RANGE ATTRIBUTES                      -->
+<!--                    Attributes for the <page-range> element    -->
+<!ENTITY % page-range-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PERMISSIONS ATTRIBUTES                     -->
+<!--                    Attributes for the <permission> element    -->
+<!ENTITY % permissions-atts
+            "%jats-common-atts;"                                     >                                        
+
+
+<!--                    PHONE ATTRIBUTES                           -->
+<!--                    Attributes for the <phone> element         -->
+<!ENTITY % phone-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    POSTAL CODE ATTRIBUTES                     -->
+<!--                    Attributes for the <postal-code> element   -->
+<!ENTITY % postal-code-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PREFIX ATTRIBUTES                          -->
+<!--                    Attributes for the <prefix> element        -->
+<!ENTITY % prefix-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PRICE ATTRIBUTES                           -->
+<!--                    Attributes for the <price> element         -->
+<!ENTITY % price-atts
+            "%jats-common-atts;                                        
+             currency   CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PUBLISHER ATTRIBUTES                       -->
+<!--                    Attributes for the <publisher> element     -->
+<!ENTITY % publisher-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    PUBLISHER LOCATION ATTRIBUTES              -->
+<!--                    Attributes for the <publisher-loc> element -->
+<!ENTITY % publisher-loc-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang  NMTOKEN                            #IMPLIED"  >
+
+
+<!--                    PUBLISHER NAME ATTRIBUTES                  -->
+<!--                    Attributes for the <publisher-name> element-->
+<!ENTITY % publisher-name-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang  NMTOKEN                            #IMPLIED"  >
+
+
+<!--                    RELATED ARTICLE ATTRIBUTES                 -->
+<!--                    Attributes for <related-article>           -->
+<!ENTITY % related-article-atts
+            "%jats-common-atts;                                        
+             related-article-type
+                        CDATA                             #REQUIRED
+             ext-link-type
+                       CDATA                              #IMPLIED
+             vol       CDATA                              #IMPLIED
+             page      CDATA                              #IMPLIED
+             issue     CDATA                              #IMPLIED
+             elocation-id
+                       CDATA                              #IMPLIED
+             journal-id
+                       CDATA                              #IMPLIED
+             journal-id-type
+                        CDATA                             #IMPLIED
+             specific-use
+                       CDATA                              #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    ROLE ATTRIBUTES                            -->
+<!--                    Attributes for the <role> element          -->
+<!ENTITY % role-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             degree-contribution
+                        CDATA                             #IMPLIED
+             vocab      CDATA                             #IMPLIED
+             vocab-identifier
+                        CDATA                             #IMPLIED
+             vocab-term CDATA                             #IMPLIED
+             vocab-term-identifier
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SEASON ATTRIBUTES                          -->
+<!--                    Attributes for the <season> element        -->
+<!ENTITY % season-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SIGNATURE ATTRIBUTES                       -->
+<!--                    Attributes for the <sig> element           -->
+<!ENTITY % sig-atts
+            "%jats-common-atts;                                        
+             rid        IDREFS                            #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SIGNATURE BLOCK ATTRIBUTES                 -->
+<!--                    Attributes for the <sig-block> element     -->
+<!ENTITY % sig-block-atts
+            "%jats-common-atts;                                        
+             rid       IDREFS                            #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    SIZE ATTRIBUTES                            -->
+<!--                    Attribute list for the <size> element      -->
+<!ENTITY % size-atts
+            "%jats-common-atts;                                        
+             units      CDATA                             #REQUIRED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    STATE ATTRIBUTES                           -->
+<!--                    Attributes for the <state> element         -->
+<!ENTITY % state-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    STRING DATE ATTRIBUTES                     -->
+<!--                    Attributes for the <string-date> element   -->
+<!ENTITY % string-date-atts
+            "%jats-common-atts;                                        
+             iso-8601-date
+                        CDATA                             #IMPLIED
+             calendar   CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    STRING NAME ATTRIBUTES                     -->
+<!--                    Attribute list for the <string-name> element
+                                                                   -->
+<!ENTITY % string-name-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             name-style
+                        (western | eastern | islensk | given-only)
+                                                          'western'
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SUFFIX ATTRIBUTES                          -->
+<!--                    Attributes for the <suffix> element        -->
+<!ENTITY % suffix-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SUPPLEMENT ATTRIBUTES                      -->
+<!--                    Attributes for the <supplement> element    -->
+<!ENTITY % supplement-atts
+            "%jats-common-atts;                                        
+             supplement-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SURNAME ATTRIBUTES                         -->
+<!--                    Attribute list for the <surname> element   -->
+<!ENTITY % surname-atts
+            "%jats-common-atts;                                        
+             initials  CDATA                              #IMPLIED"  >
+
+
+<!--                    TEXTUAL FORM ATTRIBUTES                    -->
+<!--                    Attributes for the <textual-form> element  -->
+<!ENTITY % textual-form-atts
+            "%jats-common-atts;                                        
+             specific-use
+                       CDATA                              #IMPLIED
+             xml:lang  NMTOKEN                            #IMPLIED"  >
+
+
+<!--                    TITLE ATTRIBUTES                           -->
+<!--                    Attributes for the <title> element         -->
+<!ENTITY % title-atts
+            "%jats-common-atts;                                        
+             content-type
+                       CDATA                              #IMPLIED
+             specific-use
+                       CDATA                              #IMPLIED"  >
+
+
+<!--                    TRANSLATED SUBTITLE ATTRIBUTES             -->
+<!--                    Attributes for the <trans-subtitle>
+                        element                                    -->
+<!ENTITY % trans-subtitle-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    TRANSLATED TITLE ATTRIBUTES                -->
+<!--                    Attribute list for the <trans-title>       -->
+<!ENTITY % trans-title-atts
+            "%jats-common-atts;                                        
+             content-type
+                       CDATA                              #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    TRANSLATED TITLE GROUP ATTRIBUTES          -->
+<!--                    Attribute list for the <trans-title-group> -->
+<!ENTITY % trans-title-group-atts
+            "%jats-common-atts;                                        
+             content-type
+                       CDATA                              #IMPLIED
+             specific-use
+                       CDATA                              #IMPLIED
+             xml:lang  NMTOKEN                            #IMPLIED"  >
+
+
+<!--                    URI ATTRIBUTES                             -->
+<!--                    Attributes for the <uri> element           -->
+<!ENTITY % uri-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    VOLUME NUMBER ATTRIBUTES                   -->
+<!--                    Attribute list for the <volume> element    -->
+<!ENTITY % volume-atts
+            "%jats-common-atts;                                        
+             seq        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    VOLUME IDENTIFIER ATTRIBUTES               -->
+<!--                    Attributes for the <volume-id> element     -->
+<!ENTITY % volume-id-atts
+            "%jats-common-atts;                                        
+             pub-id-type
+                        CDATA                             #IMPLIED
+             assigning-authority                
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    VOLUME ISSUE GROUPING ATTRIBUTES           -->
+<!--                    Attribute list for the <volume-issue-group>
+                        element                                    -->
+<!ENTITY % volume-issue-group-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    VOLUME SERIES ATTRIBUTES                   -->
+<!--                    Attribute list for the <volume-series>
+                        element                                    -->
+<!ENTITY % volume-series-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    YEAR ATTRIBUTES                            -->
+<!--                    Attributes for the <year> element          -->
+<!ENTITY % year-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             iso-8601-date
+                        CDATA                             #IMPLIED
+             calendar   CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    METADATA USED BY MORE THAN ONE CLASS       -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    NISO ACCESS AND INDICATOR ELEMENTS         -->
+<!-- ============================================================= -->
+
+
+<!--                    FREE TO READ (NISO ALI) MODEL              -->
+<!--                    Content model for the ALI namespaced  
+                        <ali:free_to_read> element.                -->
+<!ENTITY % free-to-read-model
+                        "EMPTY"                                      >
+
+
+<!--                    FREE TO READ (NISO ALI)                    -->
+<!--                    An EMPTY element whose presence indicates 
+                        that a document or portion of a document 
+                        is free to be read. 
+                        Remarks: Defined in "NISO Access License and 
+                        Indicators (ALI) NISO RP-22-2015".    
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=ali:free_to_read
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=ali:free_to_read
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=ali:free_to_read
+                                                                   -->
+<!ELEMENT  ali:free_to_read 
+                        %free-to-read-model;                         >
+<!ATTLIST  ali:free_to_read
+             %free-to-read-atts;                                     >
+
+
+<!--                    LICENSE REFERENCE (NISO ALI) MODEL         -->
+<!--                    Content model for the ALI namespaced  
+                        <ali:license_ref> element.                 -->
+<!ENTITY % license-ref-model
+                        "%anyURI;"                                   >
+
+
+<!--                    LICENSE REFERENCE (NISO ALI)               -->
+<!--                    A URI that is a pointer to a public license
+                        or waiver. If the element has content, it 
+                        must be a URI.
+                        Remarks: Defined in "NISO Access License and 
+                        Indicators (ALI) NISO RP-22-2015".    
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=ali:license_ref
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=ali:license_ref
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=ali:license_ref
+                                                                   -->
+<!ELEMENT  ali:license_ref  
+                        %license-ref-model;                          >
+<!ATTLIST  ali:license_ref
+             %license-ref-atts;                                      >
+
+
+<!-- ============================================================= -->
+<!--                    CONTRIBUTOR GROUP (AUTHOR/EDITOR) ELEMENTS -->
+<!-- ============================================================= -->
+
+
+<!--                    CONTRIBUTOR GROUP MODEL                    -->
+<!--                    Content model for the <contrib-group>
+                        element                                    -->
+<!ENTITY % contrib-group-model
+                        "((%contrib.class;)+, 
+                          (%contrib-info.class;)* )"                 >
+
+
+<!--                    CONTRIBUTOR GROUP                          -->
+<!--                    Wrapper element for information concerning
+                        a grouping of contributors, such as the
+                        primary authors
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=contrib-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=contrib-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=contrib-group
+                                                                   -->
+<!ELEMENT  contrib-group
+                        %contrib-group-model;                        >
+<!ATTLIST  contrib-group
+             %contrib-group-atts;                                    >
+
+
+<!--                    CONTRIBUTOR MODEL                          -->
+<!--                    Content model for the <contrib> element    -->
+<!ENTITY % contrib-model
+                        "((%contrib-id.class;)*, (%name.class;)*,
+                          (%degree.class; | %contrib-info.class;)* )">
+
+
+<!--                    CONTRIBUTOR                                -->
+<!--                    Wrapper element to contain the information
+                        about a single contributor, for example an
+                        author or editor.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=contrib
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=contrib
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=contrib
+                                                                   -->
+<!ELEMENT  contrib      %contrib-model;                              >
+<!ATTLIST  contrib
+             %contrib-atts;                                          >
+
+
+<!-- ============================================================= -->
+<!--                    COMMON COPYRIGHT/PERMISSION ELEMENTS       -->
+<!-- ============================================================= -->
+
+
+<!--                    COPYRIGHT HOLDER ELEMENTS                  -->
+<!--                    Elements to be mixed with data characters
+                        inside the content model for the
+                        <copyright-holder> element.                -->
+<!ENTITY % copyright-holder-elements
+                        "| %institution-wrap.class; | %subsup.class;">
+
+
+<!--                    COPYRIGHT HOLDER                           -->
+<!--                    Name of the organizational or personal
+                        entity that holds the copyright.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=copyright-holder
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=copyright-holder
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=copyright-holder
+                                                                   -->
+<!ELEMENT  copyright-holder
+                        (#PCDATA %copyright-holder-elements;)*       >
+<!ATTLIST  copyright-holder
+             %copyright-holder-atts;                                 >
+
+
+<!--                    COPYRIGHT STATEMENT ELEMENTS               -->
+<!--                    Content model for <copyright-statement>    -->
+<!ENTITY % copyright-statement-elements
+                        "| %address-link.class; | %emphasis.class; |
+                         %phrase-content.class; | %subsup.class;"    >
+
+
+<!--                    COPYRIGHT STATEMENT                        -->
+<!--                    Copyright notice or statement, suitable for
+                        printing or display. Within the statement the
+                        copyright year should be identified, if
+                        expected to be displayed.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=copyright-statement
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=copyright-statement
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=copyright-statement
+                                                                   -->
+<!ELEMENT  copyright-statement
+                        (#PCDATA %copyright-statement-elements;)*    >
+<!ATTLIST  copyright-statement
+             %copyright-statement-atts;                              >
+
+
+<!--                    COPYRIGHT YEAR                             -->
+<!--                    Year of the copyright. Need not be used, if,
+                        for example, having the year as part of the
+                        copyright statement is sufficient.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=copyright-year
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=copyright-year
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=copyright-year
+                                                                   -->
+<!ELEMENT  copyright-year
+                        (#PCDATA)                                    >
+<!ATTLIST  copyright-year
+             %copyright-year-atts;                                   >
+
+
+<!--                    LICENSE MODEL                              -->
+<!--                    Content model for an <license> element     -->
+<!ENTITY % license-model
+                        "((%license-p.class;)+)"                     >
+
+
+<!--                    LICENSE INFORMATION                        -->
+<!--                    The set of conditions under which people are
+                        allowed to use this article or other
+                        license-related information or restrictions.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=license
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=license
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=license
+                                                                   -->
+<!ELEMENT  license      %license-model;                              >
+<!ATTLIST  license
+             %license-atts;                                          >
+
+
+<!--                    LICENSE PARAGRAPH ELEMENTS                 -->
+<!--                    Elements that can be included with the text
+                        inside a <license-p> element.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %p-elements; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % license-p-elements
+                        "%p-elements; | %price.class;"               >
+
+
+<!--                    LICENSE PARAGRAPH                          -->
+<!--                    Paragraphs of text within the description of
+                        a <license>. Not defined as an ordinary
+                        paragraph, so that it can have special
+                        content.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=license-p
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=license-p
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=license-p
+                                                                   -->
+<!ELEMENT  license-p    (#PCDATA %license-p-elements;)*              >
+<!ATTLIST  license-p
+             %license-p-atts;                                        >
+
+
+<!--                    PERMISSIONS MODEL                          -->
+<!--                    Model for <permissions> wrapper element    -->
+<!ENTITY % permissions-model
+                        "(copyright-statement*, copyright-year*,
+                          copyright-holder*, (%license.class;)*)"    >
+
+
+<!--                    PERMISSIONS                                -->
+<!--                    Wrapper element to hold the copyright
+                        information, license material, and any
+                        future similar metadata.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=permissions
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=permissions
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=permissions
+                                                                   -->
+<!ELEMENT  permissions  %permissions-model;                          >
+<!ATTLIST  permissions
+             %permissions-atts;                                      >
+
+
+<!-- ============================================================= -->
+<!--                    COMMON METADATA/BIBLIOGRAPHIC ELEMENTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE TITLE ELEMENTS                     -->
+<!--                    Elements that can be included with the text
+                        inside an <article-title> element.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % article-title-elements
+                        "%simple-phrase; | %break.class;"            >
+
+
+<!--                    ARTICLE TITLE                              -->
+<!--                    The title of the article in the language
+                        in which the article was originally
+                        published
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=article-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=article-title
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=article-title
+                                                                   -->
+<!ELEMENT  article-title
+                        (#PCDATA %article-title-elements;)*          >
+<!ATTLIST  article-title
+             %article-title-atts;                                    >
+
+
+<!--                    AFFILIATION ELEMENTS                       -->
+<!--                    Elements for use in the <aff> element      -->
+<!ENTITY % aff-elements "| %address.class; | %address-link.class; |
+                         %article-link.class; | %break.class; |
+                         %emphasis.class; | %label.class; |
+                         %simple-link.class; | %subsup.class;"       >
+
+
+<!--                    AFFILIATION                                -->
+<!--                    Name of a institution or organization such as
+                        a university or corporation.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=aff
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=aff
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=aff
+                                                                   -->
+<!ELEMENT  aff          (#PCDATA %aff-elements;)*                    >
+<!ATTLIST  aff
+             %aff-atts;                                              >
+
+
+<!--                    AFFILIATION ALTERNATIVES MODEL             -->
+<!--                    Content model for the element
+                        <aff-alternatives>                         -->
+<!ENTITY % aff-alternatives-model
+                        "(aff+)"                                     >
+
+
+<!--                    AFFILIATION ALTERNATIVES                   -->
+<!--                    Container element to hold one or more
+                        representations of a single affiliation, for
+                        example the name of an institution in two
+                        languages or two scripts.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=aff-alternatives
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=aff-alternatives
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=aff-alternatives
+                                                                   -->
+<!ELEMENT  aff-alternatives
+                        %aff-alternatives-model;                     >
+<!ATTLIST  aff-alternatives
+             %aff-alternatives-atts;                                 >
+
+
+<!--                    CONFERENCE DATE ELEMENTS                   -->
+<!--                    Elements for use in the <conf-date> element-->
+<!ENTITY % conf-date-elements
+                        ""                                           >
+
+
+<!--                    CONFERENCE DATE                            -->
+<!--                    The date(s) on which the conference was held.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=conf-date
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=conf-date
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=conf-date
+                                                                   -->
+<!ELEMENT  conf-date    (#PCDATA %conf-date-elements;)*              >
+<!ATTLIST  conf-date
+             %conf-date-atts;                                        >
+
+
+<!--                    CONFERENCE LOCATION ELEMENTS               -->
+<!--                    Elements for use in the <conf-loc> element
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % conf-loc-elements
+                        "%simple-text; | %address.class;"            >
+
+
+<!--                    CONFERENCE LOCATION                        -->
+<!--                    The physical location(s) of the conference.
+                        This may include a city, a country, or a
+                        campus or organization location if that is
+                        the only location available.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=conf-loc
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=conf-loc
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=conf-loc
+                                                                   -->
+<!ELEMENT  conf-loc     (#PCDATA %conf-loc-elements;)*               >
+<!ATTLIST  conf-loc
+             %conf-loc-atts;                                         >
+
+
+<!--                    CONFERENCE NAME ELEMENTS                   -->
+<!--                    Elements for use in the <conf-name> element.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % conf-name-elements
+                        "%simple-text;"                            >
+
+
+<!--                    CONFERENCE NAME                            -->
+<!--                    The full name of the conference, including any
+                        qualifiers such as "43rd Annual".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=conf-name
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=conf-name
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=conf-name
+                                                                   -->
+<!ELEMENT  conf-name    (#PCDATA %conf-name-elements;)*              >
+<!ATTLIST  conf-name
+             %conf-name-atts;                                        >
+
+
+<!--                    CONFERENCE SPONSOR  ELEMENTS               -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the conference sponsor.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % conf-sponsor-elements
+                        "%simple-text; | %institution-wrap.class;"   >
+
+
+<!--                    CONFERENCE SPONSOR                         -->
+<!--                    One organization that sponsored the
+                        conference. If more than one organization
+                        sponsored the conference, multiple
+                        <conf-sponsor> elements should be used.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=conf-sponsor
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=conf-sponsor
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=conf-sponsor
+                                                                   -->
+<!ELEMENT  conf-sponsor (#PCDATA %conf-sponsor-elements;)*           >
+<!ATTLIST  conf-sponsor
+             %conf-sponsor-atts;                                     >
+
+
+<!--                    OBJECT IDENTIFIER                          -->
+<!--                    Used to record an identifier such as a DOI
+                        for an interior element such as an <abstract>
+                        or <figure>.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=object-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=object-id
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=object-id
+                                                                   -->
+<!ELEMENT  object-id    (#PCDATA)                                    >
+<!ATTLIST  object-id
+             %object-id-atts;                                        >
+
+
+<!--                    ISBN ELEMENTS                              -->
+<!--                    Elements for use with data characters inside
+                        the model for the <isbn> element           -->
+<!ENTITY % isbn-elements
+                        ""                                           >
+
+
+<!--                    ISBN                                       -->
+<!--                    International Standard Book Number
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=isbn
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=isbn
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=isbn
+                                                                   -->
+<!ELEMENT  isbn         (#PCDATA %isbn-elements;)*                   >
+<!ATTLIST  isbn
+             %isbn-atts;                                             >
+
+
+<!--                    ISSN ELEMENTS                              -->
+<!--                    Elements for use with data characters inside
+                        the model for the <issue> element          -->
+<!ENTITY % issn-elements
+                        ""                                           >
+
+
+<!--                    ISSN                                       -->
+<!--                    International Standard Serial Number
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=issn
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=issn
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=issn
+                                                                   -->
+<!ELEMENT  issn         (#PCDATA %issn-elements;)*                   >
+<!ATTLIST  issn
+             %issn-atts;                                             >
+
+
+<!--                    ISSN-L ELEMENTS                            -->
+<!--                    Elements for use with data characters inside
+                        the model for the <issn-l> element         -->
+<!ENTITY % issn-l-elements
+                        ""                                           >
+
+
+<!--                    ISSN LINKING                               -->
+<!--                    International Standard Linking Serial Number
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=issn-l
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=issn-l
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=issn-l
+                                                                   -->
+<!ELEMENT  issn-l       (#PCDATA %issn-l-elements;)*                 >
+<!ATTLIST  issn-l
+             %issn-l-atts;                                           >
+
+
+<!--                    ISSUE ELEMENTS                             -->
+<!--                    Elements for use with data characters inside
+                        the model for the <issue> element          -->
+<!ENTITY % issue-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    ISSUE NUMBER                               -->
+<!--                    The issue number, issue name, or other
+                        identifier of an issue of a journal that
+                        is displayed or printed with the issue.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=issue
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=issue
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=issue
+                                                                   -->
+<!ELEMENT  issue        (#PCDATA %issue-elements;)*                  >
+<!ATTLIST  issue
+             %issue-atts;                                            >
+
+
+<!--                    ISSUE IDENTIFIER                           -->
+<!--                    Used to record an identifier such as a DOI
+                        that describes an entire issue of a
+                        journal
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=issue-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=issue-id
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=issue-id
+                                                                   -->
+<!ELEMENT  issue-id     (#PCDATA)                                    >
+<!ATTLIST  issue-id
+             %issue-id-atts;                                         >
+
+
+<!--                    ISSUE PART ELEMENTS                        -->
+<!--                    Elements that can be added to the text
+                        within the element <issue-part>            -->
+<!ENTITY % issue-part-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    ISSUE PART                         -->
+<!--                    A publisher may split an issue into two or
+                        more separately bound or separately issued
+                        parts. This element holds the identifiers
+                        (titles, part numbers, etc.) for those
+                        publishing components.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=issue-part
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=issue-part
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=issue-part
+                                                                   -->
+<!ELEMENT  issue-part   (#PCDATA %issue-part-elements;)*             >
+<!ATTLIST  issue-part
+             %issue-part-atts;                                       >
+
+
+<!--                    ISSUE SPONSOR ELEMENTS                     -->
+<!--                    Elements for use in the <issue-sponsor>
+                        element                                    -->
+<!ENTITY % issue-sponsor-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    ISSUE TITLE                                -->
+<!--                    Used to record the sponsor for an issue of
+                        the journal
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=issue-sponsor
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=issue-sponsor
+                                                                   -->
+<!ELEMENT  issue-sponsor
+                        (#PCDATA %issue-sponsor-elements;)*          >
+<!ATTLIST  issue-sponsor
+             %issue-sponsor-atts;                                      >
+
+
+<!--                    ISSUE TITLE ELEMENTS                       -->
+<!--                    Elements for use in the <issue-title> element
+                                                                   -->
+<!ENTITY % issue-title-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    ISSUE TITLE                                -->
+<!--                    Used to record the theme or special issue
+                        title for an issue of the journal
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=issue-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=issue-title
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=issue-title
+                                                                   -->
+<!ELEMENT  issue-title  (#PCDATA %issue-title-elements;)*            >
+<!ATTLIST  issue-title
+             %issue-title-atts;                                      >
+
+
+<!--                    JOURNAL IDENTIFIER                         -->
+<!--                    Short code that represents the journal; used
+                        as an alternative to or short form of the
+                        journal title; used for identification of
+                        the journal domain.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=journal-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=journal-id
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=journal-id
+                                                                   -->
+<!ELEMENT  journal-id   (#PCDATA)                                    >
+<!ATTLIST  journal-id
+             %journal-id-atts;                                       >
+
+
+<!--                    ROLE ELEMENTS                              -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <role>
+                        Design Note: All inline mixes begin with an
+                        OR bar; since %rendition-plus; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % role-elements
+                        "%rendition-plus;"                           >
+
+
+<!--                    ROLE OR FUNCTION TITLE OF CONTRIBUTOR      -->
+<!--                    A title or the role of a contributor
+                        (such as an author) in this work. For example,
+                        Editor-in-Chief, Contributor, Chief
+                        Scientist, Photographer, Research Associate,
+                        etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=role
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=role
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=role
+                                                                   -->
+<!ELEMENT  role         (#PCDATA %role-elements;)*                   >
+<!ATTLIST  role
+             %role-atts;                                             >
+
+
+<!--                    TRANSLATED TITLE GROUP MODEL               -->
+<!--                    Content model for the element
+                        <trans-title-group>                        -->
+<!ENTITY % trans-title-group-model
+                        "(trans-title, trans-subtitle*)"             >
+
+
+<!--                    TRANSLATED TITLE GROUP                     -->
+<!--                    Container element for all translated, and
+                        transliterated journal titles.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=trans-title-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=trans-title-group
+                                                                   -->
+<!ELEMENT  trans-title-group
+                        %trans-title-group-model;                    >
+<!ATTLIST  trans-title-group
+             %trans-title-group-atts;                                >
+
+
+<!--                    TRANSLATED SUBTITLE                        -->
+<!--                    An alternate version of an article subtitle
+                        that has been translated out of the original
+                        language of the article subtitle <subtitle>
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=trans-subtitle
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=trans-subtitle
+                                                                   -->
+<!ELEMENT  trans-subtitle
+                        (#PCDATA %trans-subtitle-elements;)*         >
+<!ATTLIST  trans-subtitle
+             %trans-subtitle-atts;                                   >
+
+
+<!--                    TRANSLATED TITLE                           -->
+<!--                    An alternate version of the title that has
+                        been translated into a language other than
+                        that of the original article title
+                        <article-title>
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=trans-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=trans-title
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=trans-title
+                                                                   -->
+<!ELEMENT  trans-title  (#PCDATA %trans-title-elements;)*            >
+<!ATTLIST  trans-title
+            %trans-title-atts;                                       >
+
+
+<!--                    VOLUME NUMBER ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <volume>                                 -->
+<!ENTITY % volume-elements
+                        "%just-rendition; "                          >
+
+
+<!--                    VOLUME NUMBER                              -->
+<!--                    NEW DEFINITION FOR RELEASE 2.0:
+                        The volume number, volume name, or other
+                        identifier of an volume of a journal that
+                        is displayed or printed with the volume.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=volume
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=volume
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=volume
+                                                                   -->
+<!ELEMENT  volume       (#PCDATA %volume-elements;)*                 >
+<!ATTLIST  volume
+            %volume-atts;                                            >
+
+
+<!--                    VOLUME IDENTIFIER ELEMENTS                 -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <volume-id>                              -->
+<!ENTITY % volume-id-elements
+                        "%just-rendition; "                          >
+
+
+<!--                    VOLUME IDENTIFIER                          -->
+<!--                    Used to record an identifier such as a DOI
+                        that describes an entire volume of a
+                        journal.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=volume-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=volume-id
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=volume-id
+                                                                   -->
+<!ELEMENT  volume-id    (#PCDATA %volume-id-elements;)*              >
+<!ATTLIST  volume-id
+             %volume-id-atts;                                        >
+
+
+<!--                    VOLUME SERIES ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <volume>                                 -->
+<!ENTITY % volume-series-elements
+                        "%just-rendition; "                          >
+
+
+<!--                    VOLUME SERIES                              -->
+<!--                    This is a rare metadata element, intended to
+                        hold the series number, in those odd cases
+                        where, for example, a Publisher has reissued
+                        a journal, restarting the volume numbers
+                        with "1", so duplicate volume numbers
+                        would exist and need to be differentiated.
+                        Such a publisher typically adds a series
+                        number to their volume numbers, and
+                        this element has been created to hold such
+                        a series number.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=volume-series
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=volume-series
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=volume-series
+                                                                   -->
+<!ELEMENT  volume-series
+                        (#PCDATA %volume-series-elements;)*          >
+<!ATTLIST  volume-series
+            %volume-series-atts;                                     >
+
+
+<!--                    VOLUME ISSUE GROUP                         -->
+<!--                    Content model for the element
+                        <volume-issue-group>.                      -->
+<!ENTITY % volume-issue-group-model
+                        "(volume*, volume-id*, volume-series?,
+                         issue*, issue-id*, issue-title*,
+                         issue-sponsor*, issue-part?)"               >
+
+
+<!--                    TRANSLATED TITLE GROUP                     -->
+<!--                    Container element to hold together related
+                        volume and issue elements.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=volume-issue-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=volume-issue-group
+                                                                   -->
+<!ELEMENT  volume-issue-group
+                        %volume-issue-group-model;                   >
+<!ATTLIST  volume-issue-group
+             %volume-issue-group-atts;                               >
+
+
+<!-- ============================================================= -->
+<!--                    COMMON ARTICLE METADATA/BIBLIOGRAPHIC      -->
+<!--                    CONTRIBUTOR IDENTIFICATION ELEMENTS        -->
+<!-- ============================================================= -->
+
+
+<!--                    ANONYMOUS ELEMENTS                         -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        an <anonymous> element                     -->
+<!ENTITY % anonymous-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    ANONYMOUS CONTENT MODEL                    -->
+<!--                    The content model for the <anonymous> 
+                        element                                    -->
+<!ENTITY % anonymous-model
+                        "(#PCDATA %anonymous-elements;)*"            >
+
+
+<!--                    ANONYMOUS                                  -->
+<!--                    Place holder for the name of a contributor
+                        whose name is unknown or not disclosed.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=anonymous
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=anonymous
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=anonymous
+                                                                   -->
+<!ELEMENT  anonymous    %anonymous-model;                            >
+<!ATTLIST  anonymous
+             %anonymous-atts;                                        >
+
+
+<!--                    ET AL ELEMENTS                             -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        an <etal> element                          -->
+<!ENTITY % etal-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    ET AL CONTENT MODEL                        -->
+<!--                    The content model for the <etal> element   -->
+<!ENTITY % etal-model   "(#PCDATA %etal-elements;)*"                 >
+
+
+<!--                    ET AL                                      -->
+<!--                    Most journals model this as an EMPTY element,
+                        typically used to generate the text "et al."
+                        from a stylesheet. However, a few journal
+                        DTDs (Blackwell's, for example) expect
+                        content for this element, with such text as
+                        "Associates, coworkers, and colleagues".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=etal
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=etal
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=etal
+                                                                   -->
+<!ELEMENT  etal         %etal-model;                                 >
+<!ATTLIST  etal
+             %etal-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    COMMON ARTICLE METADATA/BIBLIOGRAPHIC      -->
+<!--                    PUBLISHER IDENTIFICATION ELEMENTS          -->
+<!-- ============================================================= -->
+
+
+<!--                    ON BEHALF OF CONTENT ELEMENTS              -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <on-behalf-of>
+                        Design Note: -%rendition-plus; begins with
+                        an OR bar, so this inline mix beguines with
+                        an OR bar.                                 -->
+<!ENTITY % on-behalf-of-elements
+                        "%rendition-plus; | %institution-wrap.class;"
+                                                                     >
+
+<!--                    ON BEHALF OF                               -->
+<!--                    When a contributor has written or edited
+                        a work  "on-behalf-of" an organization or
+                        group the contributor is acting as a
+                        representative of the organization, which
+                        may or may not be his/her usual affiliation.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=on-behalf-of
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=on-behalf-of
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=on-behalf-of
+                                                                   -->
+<!ELEMENT  on-behalf-of (#PCDATA %on-behalf-of-elements;)*           >
+<!ATTLIST  on-behalf-of
+             %on-behalf-of-atts;                                     >
+
+
+<!--                    PUBLISHER CONTENT MODEL                    -->
+<!--                    The content model for the <publisher>
+                        element                                    -->
+<!ENTITY % publisher-model
+                        "((publisher-name, publisher-loc?)+)"        >
+
+
+<!--                    PUBLISHER                                  -->
+<!--                    Who published the work
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=publisher
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=publisher
+                                                                   -->
+<!ELEMENT  publisher    %publisher-model;                            >
+<!ATTLIST  publisher
+             %publisher-atts;                                        >
+
+
+<!--                    PUBLISHER'S NAME ELEMENTS                  -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <publisher-name>
+                        Design Note: All inline mixes begin with an
+                        OR bar; since %just-rendition; is an
+                        inline mix, the OR bar is already there    -->
+<!ENTITY % publisher-name-elements
+                        "%just-rendition;| %institution-wrap.class;" >
+
+
+<!--                    PUBLISHER'S NAME                           -->
+<!--                    Name of the publisher of the work
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=publisher-name
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=publisher-name
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=publisher-name
+                                                                   -->
+<!ELEMENT  publisher-name
+                        (#PCDATA %publisher-name-elements;)*         >
+<!ATTLIST  publisher-name
+             %publisher-name-atts;                                   >
+
+
+<!--                    PUBLISHER'S LOCATION ELEMENTS              -->
+<!--                    Elements for use in the Publisher Location
+                        <publisher-loc> element                    -->
+<!ENTITY % publisher-loc-elements
+                        "| %address.class; | %address-link.class; |
+                         %emphasis.class; | %subsup.class;"          >
+
+
+<!--                    PUBLISHER'S LOCATION                       -->
+<!--                    Place of publication, usually a city such
+                        as New York or London
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=publisher-loc
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=publisher-loc
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=publisher-loc
+                                                                   -->
+<!ELEMENT  publisher-loc
+                        (#PCDATA %publisher-loc-elements;)*          >
+<!ATTLIST  publisher-loc
+             %publisher-loc-atts;                                    >
+
+
+<!-- ============================================================= -->
+<!--                    COMMON METADATA ELEMENTS CONTINUED         -->
+<!--                    PAGE NUMBERING (SIZE) ELEMENTS             -->
+<!-- ============================================================= -->
+
+
+<!--                    FIRST PAGE                                 -->
+<!--                    The page number on which the article starts,
+                        for print journals that have page numbers
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=fpage
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=fpage
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=fpage
+                                                                   -->
+<!ELEMENT  fpage        (#PCDATA)                                    >
+<!ATTLIST  fpage
+             %fpage-atts;                                            >
+
+
+<!--                    LAST PAGE                                  -->
+<!--                    The page number on which the article ends,
+                        for print journals that have page numbers
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=lpage
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=lpage
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=lpage
+                                                                   -->
+<!ELEMENT  lpage        (#PCDATA)                                    >
+<!ATTLIST  lpage
+             %lpage-atts;                                            >
+
+
+<!--                    PAGE RANGES                                -->
+<!--                    A container element for additional page
+                        information (TO BE USED TO SUPPLEMENT AND
+                        NOT TO REPLACE <fpage> and <lpage>) to record
+                        discontinuous pages ranges such as
+                            "8-11, 14-19, 40"
+                        meaning that the article begins on page
+                        8, runs 8 through 11, skips to pages 14
+                        through 19, and concludes on page 40.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=page-range
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=page-range
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=page-range
+                                                                   -->
+<!ELEMENT  page-range   (#PCDATA)                                    >
+<!ATTLIST  page-range
+             %page-range-atts;                                       >
+
+
+<!--                    SIZE ELEMENTS                              -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the size element.                          -->
+<!ENTITY % size-elements
+                        ""                                           >
+
+
+<!--                    SIZE                                       -->
+<!--                    The size (such as running time, page count,
+                        or physical measurements) of the object being
+                        described, usually by a <product> element.
+                        The "units" attribute must be used to name
+                        the unit of measure (pages, minutes, hours,
+                        linear feet, etc.).
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=size
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=size
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=size
+                                                                   -->
+<!ELEMENT  size         (#PCDATA %size-elements;)*                   >
+<!ATTLIST  size
+             %size-atts;                                             >
+
+
+<!--                    ELECTRONIC LOCATION IDENTIFIER             -->
+<!--                    Used to identify an article that
+                        does not have traditional page numbers.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=elocation-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=elocation-id
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=elocation-id
+                                                                   -->
+<!ELEMENT  elocation-id (#PCDATA)                                    >
+<!ATTLIST  elocation-id
+             %elocation-id-atts;                                     >
+
+
+<!-- ============================================================= -->
+<!--                    CITATIONS (BIBLIOGRAPHIC REFERENCE)        -->
+<!-- ============================================================= -->
+
+
+<!--                    CITATION ALTERNATIVES MODEL                -->
+<!--                    Model for the <citation-alternatives>
+                        element.                                   -->
+<!ENTITY % citation-alternatives-model
+                        "(%citation-minus-alt.class;)+"              >
+
+
+<!--                    CITATION ALTERNATIVES                      -->
+<!--                    This element will hold alternative versions of 
+                        one citation, for example, a single citation 
+                        in multiple languages or a single citation 
+                        tagged as both a <mixed-citation> complete 
+                        with punctuation and spacing and as an
+                        <element-citation> with punctuation and 
+                        spacing removed.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=citation-alternativesv
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=citation-alternatives
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=citation-alternatives
+                                                                   -->
+<!ELEMENT  citation-alternatives
+                        %citation-alternatives-model;                >
+<!ATTLIST  citation-alternatives
+             %citation-alternatives-atts;                            >
+
+
+<!--                    CITATION ELEMENTS                          -->
+<!--                    Content for both types of citation. These
+                        elements may be mixed with #PCDATA in the
+                        <mixed-citation> element (in which all
+                        punctuation and spacing are left intact), and
+                        they also constitute the choices that can be
+                        used to form the all-element-content of the
+                        <element-citation> element (in which
+                        punctuation and spacing are removed).
+                        Design Note: All inline mixes begin with an
+                        OR bar.                                    -->
+<!ENTITY % citation-elements
+                        "%emphasis.class; | %inline-display.class; |
+                         %inline-math.class; | %label.class; |
+                         %phrase.class; | %references.class; |
+                         %subsup.class;"                             >
+
+
+<!--                    MIXED CITATION                             -->
+<!--                    A citation is a description of a work, such
+                        as a journal article, book, or personal
+                        communication, that is cited in the text of
+                        the article. This citation element is
+                        completely loose, with text, punctuation,
+                        spacing, and any of the citation elements
+                        in any order.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=mixed-citation
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=mixed-citation
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=mixed-citation
+                                                                   -->
+<!ELEMENT  mixed-citation
+                        (#PCDATA | %citation-elements;)*             >
+<!ATTLIST  mixed-citation
+             %mixed-citation-atts;                                   >
+
+
+<!--                    ELEMENT CITATION                           -->
+<!--                    A citation is a description of a work, such
+                        as a journal article, book, or personal
+                        communication, that is cited in the text of
+                        the article. This citation model contains
+                        element-only content, with elements in
+                        any order as many times as needed. This
+                        citation is intended for use in capturing
+                        a publisher's specific element order.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=element-citation
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=element-citation
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=element-citation
+                                                                   -->
+<!ELEMENT  element-citation
+                        (%citation-elements;)+                       >
+<!ATTLIST  element-citation
+             %element-citation-atts;                                 >
+
+
+<!-- ============================================================= -->
+<!--                    ADDRESS ELEMENTS                           -->
+<!-- ============================================================= -->
+
+
+<!--                    ADDRESS MODEL                              -->
+<!--                    Content model for the <address> element    -->
+<!ENTITY % address-model
+                        "(%address.class; | %address-link.class;)*"  >
+
+
+<!--                    ADDRESS/CONTACT INFORMATION                -->
+<!--                    Wrapper element for contact information such
+                        as address, phone, fax, email, url, country,
+                        etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=address
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=address
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=address
+                                                                   -->
+<!ELEMENT  address      %address-model;                              >
+<!ATTLIST  address
+             %address-atts;                                          >
+
+
+<!--                    ADDRESS LINE ELEMENTS                      -->
+<!--                    Elements for use in the <addr-line> element-->
+<!ENTITY % addr-line-elements
+                        "%simple-text; | %address-line.class;"       >
+
+
+<!--                    ADDRESS LINE                               -->
+<!--                    One line in an address                     -->
+<!--                    Conversion Note: If the address is
+                        undifferentiated data characters, the entire
+                        address may be inside one of these elements.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=addr-line
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=addr-line
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=addr-line
+                                                                   -->
+<!ELEMENT  addr-line    (#PCDATA %addr-line-elements;)*              >
+<!ATTLIST  addr-line
+             %addr-line-atts;                                        >
+
+
+<!--                    CITY ELEMENTS                              -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the city element.                          -->
+<!ENTITY % city-elements
+                        ""                                           >
+
+
+<!--                    CITY: IN AN ADDRESS                        -->
+<!--                    The name of a city.                   
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=city
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=city
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=city
+                                                                   -->
+<!ELEMENT  city         (#PCDATA %city-elements;)*                   >
+<!ATTLIST  city
+             %city-atts;                                             >
+
+
+<!--                    COUNTRY ELEMENTS                           -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the country element.                       -->
+<!ENTITY % country-elements
+                        ""                                           >
+
+
+<!--                    COUNTRY: IN AN ADDRESS                     -->
+<!--                    The name of a country.                    
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=country
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=country
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=country
+                                                                   -->
+<!ELEMENT  country      (#PCDATA %country-elements;)*                >
+<!ATTLIST  country
+             %country-atts;                                          >
+
+
+<!--                    EMAIL ADDRESS ELEMENTS                     -->
+<!--                    Elements to be mixed with #PCDATA inside the
+                        <email> element                            -->
+<!ENTITY % email-elements
+                        ""                                           >
+
+
+<!--                    EMAIL ADDRESS                              -->
+<!--                    The email address of a person or institution.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=email
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=email
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=email
+                                                                   -->
+<!ELEMENT  email        (#PCDATA %email-elements;)*                  >
+<!ATTLIST  email
+             %email-atts;                                            >
+
+
+<!--                    FAX NUMBER ELEMENTS                        -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <fax>                                    -->
+<!ENTITY % fax-elements
+                        "%just-rendition; "                          >
+
+
+<!--                    FAX NUMBER: IN AN ADDRESS                  -->
+<!--                    The number used to send faxes.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=fax
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=fax
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=fax
+                                                                   -->
+<!ELEMENT  fax          (#PCDATA %fax-elements;)*                    >
+<!ATTLIST  fax
+             %fax-atts;                                              >
+
+
+<!--                    INSTITUTION NAME ELEMENTS                  -->
+<!--                    Elements for use in the <institution>
+                        element                                    -->
+<!ENTITY % institution-elements
+                        "| %break.class; | %emphasis.class; |
+                         %subsup.class;"                             >
+
+
+<!--                    INSTITUTION NAME: IN AN ADDRESS            -->
+<!--                    Name of a institution or organization such as
+                        a university or corporation used in an
+                        address or within a citation (such as a
+                        <mixed-citation> or an <element-citation>)
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=institution
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=institution
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=institution
+                                                                   -->
+<!ELEMENT  institution  (#PCDATA %institution-elements;)*            >
+<!ATTLIST  institution
+             %institution-atts;                                      >
+
+
+<!--                    INSTITUTION IDENTIFIER MODEL               -->
+<!--                    Content model for the <institution-id>
+                        element                                    -->
+<!ENTITY % institution-id-model
+                        "(#PCDATA)"                                  >
+
+
+<!--                    INSTITUTION IDENTIFIER                     -->
+<!--                    Contains an institutional identifier,
+                        whether publisher-specific (for example,  
+                        "AIP") or from an established identifying
+                        authority (for example,"Ringgold" or "ISNI").
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=institution-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=institution-id
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=institution-id
+                                                                   -->
+<!ELEMENT  institution-id  
+                        %institution-id-model;                       >
+<!ATTLIST  institution-id
+             %institution-id-atts;                                   >
+
+
+<!--                    INSTITUTION WRAPPER MODEL                  -->
+<!--                    Content model for the <institution-wrap>
+                        element                                    -->
+<!ENTITY % institution-wrap-model
+                        "(%institution.class;)*"                     >
+
+
+<!--                    INSTITUTION WRAPPER                        -->
+<!--                    A container element to hold the name of an
+                        institution <institution> and any formal
+                        identifiers for that institution 
+                        <institution-id>), for example, a INSI or
+                        Ringgold ID.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=institution-wrap
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=institution-wrap
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=institution-wrap
+                                                                   -->
+<!ELEMENT  institution-wrap  
+                        %institution-wrap-model;                     >
+<!ATTLIST  institution-wrap
+             %institution-wrap-atts;                                 >
+
+
+<!--                    PHONE NUMBER ELEMENTS                      -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <phone number>
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %just-rendition; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % phone-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    PHONE NUMBER: IN AN ADDRESS                -->
+<!--                    A callable phone number in some telephone or
+                        wireless system somewhere in the world.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=phone
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=phone
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=phone
+                                                                   -->
+<!ELEMENT  phone        (#PCDATA %phone-elements;)*                  >
+<!ATTLIST  phone
+             %phone-atts;                                            >
+
+
+<!--                    POSTAL CODE ELEMENTS                       -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the postal-code element.                   -->
+<!ENTITY % postal-code-elements
+                        ""                                           >
+
+
+<!--                    POSTAL CODE: IN AN ADDRESS                 -->
+<!--                    A postal number such as a zip-code or postal
+                        code used to address physical mail.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=postal-code
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=postal-code
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=postal-code
+                                                                   -->
+<!ELEMENT  postal-code  (#PCDATA %postal-code-elements;)*            >
+<!ATTLIST  postal-code
+             %postal-code-atts;                                      >
+
+
+<!--                    STATE ELEMENTS                             -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the state element.                         -->
+<!ENTITY % state-elements
+                        ""                                           >
+
+
+<!--                    STATE or PROVINCE: IN AN ADDRESS           -->
+<!--                    The name of a state, province, territory or
+                        other political unit used in an address. This
+                        is a lower level subdivision than a country,
+                        but higher than a city, county, or parish. 
+                        The names for such a unit vary geopolitically.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=state
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=state
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=state
+                                                                   -->
+<!ELEMENT  state        (#PCDATA %state-elements;)*                  >
+<!ATTLIST  state
+             %state-atts;                                            >
+
+
+<!--                    URI ELEMENTS                               -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <uri>
+                        Design Note: This PE begins with an OR
+                        bar because %just-rendition; begins with an
+                        OR bar.                                    -->
+<!ENTITY % uri-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    URI                                        -->
+<!--                    URI such as a URL that may be used as a
+                        live link, typically naming a web site, such
+                        as:
+                           <url>http://www.mulberrytech.com</url>
+                        Alternatively the element content may name
+                        the URL, e.g., "Mulberry's Website" and the
+                        "xlink:href" attribute may hold the real
+                        URL.
+                           <url xlink:href="http://www.mulberrytech.
+                           com">Mulberry's Website</url>
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=uri
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=uri
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=uri
+                                                                   -->
+<!ELEMENT  uri          (#PCDATA %uri-elements;)*                    >
+<!ATTLIST  uri
+             %uri-atts;                                              >
+
+
+<!-- ============================================================= -->
+<!--                    SUPPLEMENT ELEMENTS                        -->
+<!-- ============================================================= -->
+
+
+<!--                    SUPPLEMENT ELEMENTS                        -->
+<!--                    Elements for use in the <supplement> element
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % supplement-elements
+                        "%simple-text; | %contrib-group.class; |
+                         %title.class;"                              >
+
+
+<!--                    SUPPLEMENT                                 -->
+<!--                    For a journal published as a supplement, this
+                        is a container element for all the provided
+                        supplement information, such as additional
+                        identification numbers, titles, authors, and
+                        supplement series information.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=supplement
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=supplement
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=supplement
+                                                                   -->
+<!ELEMENT  supplement   (#PCDATA %supplement-elements;)*             >
+<!ATTLIST  supplement
+            %supplement-atts;                                        >
+
+
+<!-- ============================================================= -->
+<!--                    DATE ELEMENTS (PUBLICATION HISTORY)        -->
+<!-- ============================================================= -->
+
+
+<!--                    DATE                                       -->
+<!--                    The elements <day>, <month>, and <year> should
+                        ALWAYS be numeric values. The date may be
+                        represented as a string in <string-date>, but
+                        the numeric values should be present whenever
+                        possible.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=date
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=date
+                                                                   -->
+<!ELEMENT  date         %date-model;                                 >
+<!ATTLIST  date
+              %date-atts;                                            >
+
+
+<!--                    DAY                                        -->
+<!--                    The numeric value of a day of the month, used
+                        in both article metadata and inside a citation,
+                        in two digits as it would be stated in the "DD"
+                        in an international date format YYYY-MM-DD, for
+                        example "03", "25".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=day
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=day
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=day
+                                                                   -->
+<!ELEMENT  day          (#PCDATA)                                    >
+<!ATTLIST  day
+             %day-atts;                                              >
+
+
+<!--                    MONTH                                      -->
+<!--                    Names one of the months of the year. Used in
+                        both article metadata and inside a citation,
+                        this element may contain a full month
+                        "December", an abbreviation "Dec", or,
+                        preferably, a numeric month such as "12".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=month
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=month
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=month
+                                                                   -->
+<!ELEMENT  month        (#PCDATA)                                    >
+<!ATTLIST  month
+             %month-atts;                                            >
+
+
+<!--                    SEASON                                     -->
+<!--                    Season of publication, such as "Spring".
+                        Used in both article metadata and inside a
+                        citation (such as a <mixed-citation> or an
+                        <element-citation>)
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=season
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=season
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=season
+                                                                   -->
+<!ELEMENT  season       (#PCDATA)                                    >
+<!ATTLIST  season
+             %season-atts;                                           >
+
+
+<!--                    ERA                                        -->
+<!--                    Era of publication. Used in certain Japanese
+                        and Korean dates.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=era
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=era
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=era
+                                                                   -->
+<!ELEMENT  era         (#PCDATA)                                     >
+<!ATTLIST  era
+             %era-atts;                                              >
+
+
+<!--                    YEAR                                       -->
+<!--                    Year of publication, which should be expressed
+                        as a 4-digit number: "1776" or "1924"
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=year
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=year
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=year
+                                                                   -->
+<!ELEMENT  year         (#PCDATA)                                    >
+<!ATTLIST  year
+             %year-atts;                                             >
+
+
+<!--                    STRING DATE ELEMENTS                       -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <string-date> element                  -->
+<!ENTITY % string-date-elements
+                        " | %date-parts.class;"                      >
+
+
+<!--                    DATE AS A STRING                           -->
+<!--                    This is a representation of the date as a
+                        string; usually used for dates for which
+                        months and years are not given, but may be
+                        used for any date as a string (i.e., "January,
+                        2001" "Fall 2001" "March 11, 2001").
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=string-date
+                                                                   -->
+<!ELEMENT  string-date  (#PCDATA %string-date-elements;)*            >
+<!ATTLIST  string-date
+             %string-date-atts;                                      >
+
+
+<!-- ============================================================= -->
+<!--                    GROUP OR CORPORATE AUTHOR ELEMENTS         -->
+<!-- ============================================================= -->
+
+
+<!--                    COLLABORATION ALTERNATIVES ELEMENTS        -->
+<!--                    Content model for the <collab-alternatives>
+                        element.                                   -->
+<!ENTITY % collab-alternatives-model
+                        "(%collab.class;)+"                          >
+
+
+<!--                    COLLABORATION ALTERNATIVES                 -->
+<!--                    Wrapper element for more than one version of
+                        a collaboration, for example, the name of a
+                        laboratory in more than one language such as
+                        the lab name in Japanese kana characters and 
+                        a transliterated form of the lab name in Latin 
+                        alphabet.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=collab-alternatives
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=collab-alternatives
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=collab-alternatives
+                                                                   -->
+<!ELEMENT  collab-alternatives
+                        %collab-alternatives-model;                  >
+<!ATTLIST  collab-alternatives
+             %collab-alternatives-atts;                              >
+
+
+<!--                    COLLABORATIVE (GROUP) AUTHOR ELEMENTS      -->
+<!--                    Elements for use in the <collab> element
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % collab-elements
+                        "%simple-text; | %address.class; |
+                         %contrib-group.class; |
+                         %contrib-info.class; | %fn-link.class;"     >
+
+
+<!--                    COLLABORATIVE (GROUP) AUTHOR               -->
+<!--                    Used for groups of authors credited under
+                        one name, either as a collaboration in the
+                        strictest sense, or when an organization,
+                        institution, or corporation is the group.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=collab
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=collab
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=collab
+                                                                   -->
+<!ELEMENT  collab       (#PCDATA %collab-elements;)*                 >
+<!ATTLIST  collab
+             %collab-atts;                                           >
+
+
+<!-- ============================================================= -->
+<!--                    PERSON'S NAME ELEMENTS (BIBLIOGRAPHIC)     -->
+<!-- ============================================================= -->
+
+
+<!--                    CONTRIBUTOR IDENTIFIER MODEL               -->
+<!--                    Content model for the <contrib-id> element -->
+<!ENTITY % contrib-id-model
+                        "(#PCDATA)"                                  >
+
+
+<!--                    CONTRIBUTOR IDENTIFIER                     -->
+<!--                    One identifier for a person such as a
+                        contributor or principal investigator. This
+                        element will hold an ORCID, a trusted
+                        publisher's identifier, or a JST or NII 
+                        identifier.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=contrib-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=contrib-id
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=contrib-id
+                                                                   -->
+<!ELEMENT  contrib-id   %contrib-id-model;                           >
+<!ATTLIST  contrib-id 
+             %contrib-id-atts;                                       >
+
+
+<!--                    NAME ALTERNATIVES MODEL                    -->
+<!--                    Content model for the <name-alternatives>
+                        element                                    -->
+<!ENTITY % name-alternatives-model
+                        "((%name-alternatives.class;)+)"             >
+
+
+<!--                    NAME ALTERNATIVES                          -->
+<!--                    Wrapper element for more than one version of
+                        a personal name, for example, the name in
+                        Japanese kana characters and a transliterated
+                        form of the name in Latin alphabet.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=name-alternatives
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=name-alternatives
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=name-alternatives
+                                                                   -->
+<!ELEMENT  name-alternatives
+                        %name-alternatives-model;                    >
+<!ATTLIST  name-alternatives
+             %name-alternatives-atts;                                >
+
+
+
+<!--                    NAME OF PERSON (STRUCTURED)                -->
+<!--                    Wrapper element for personal names.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=name
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=name
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=name
+                                                                   -->
+<!ELEMENT  name         ( ( (surname, given-names?) | given-names),
+                          prefix?, suffix?)                          >
+<!ATTLIST  name
+             %name-atts;                                             >
+
+
+<!--                    STRING NAME ELEMENTS                       -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <string-name> element                  -->
+<!ENTITY % string-name-elements
+                        " | %person-name.class;"                     >
+
+
+<!--                    NAME OF PERSON (UNSTRUCTURED)              -->
+<!--                    Wrapper element for personal names where the
+                        stricter format of the <name> element cannot
+                        be followed. This is a very loose element,
+                        allowing data characters, generated text,
+                        and any or all of the naming elements.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=string-name
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=string-name
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=string-name
+                                                                   -->
+<!ELEMENT  string-name  (#PCDATA %string-name-elements;)*            >
+<!ATTLIST  string-name
+             %string-name-atts;                                      >
+
+
+<!-- ============================================================= -->
+<!--                    PARTS OF A PERSON'S NAME ELEMENTS          -->
+<!-- ============================================================= -->
+
+
+<!--                    DEGREE(S) ELEMENTS                         -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <degrees>
+                        Design Note: -%just-rendition; begins with
+                        an OR bar, so this inline mix begins with
+                        an OR bar.                                 -->
+<!ENTITY % degrees-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    DEGREE(S)                                  -->
+<!--                    Academic degrees or professional
+                        certifications
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=degrees
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=degrees
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=degrees
+                                                                   -->
+<!ELEMENT  degrees      (#PCDATA %degrees-elements;)*                >
+<!ATTLIST  degrees
+             %degrees-atts;                                          >
+
+
+<!--                    GIVEN (FIRST) NAMES ELEMENTS               -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <given-names>                            -->
+<!ENTITY % given-names-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    GIVEN (FIRST) NAMES                        -->
+<!--                    Includes all given names for a person, such
+                        as the first name, middle names, maiden
+                        name if used as part of the married name,
+                        etc.)
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=given-names
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=given-names
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=given-names
+                                                                   -->
+<!ELEMENT  given-names  (#PCDATA %given-names-elements;)*            >
+<!ATTLIST  given-names
+             %given-names-atts;                                      >
+
+
+<!--                    SURNAME ELEMENTS                           -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <surname>
+                        Design Note: This PE begins with an OR
+                        bar because %just-rendition; begins with an
+                        OR bar.                                    -->
+<!ENTITY % surname-elements
+                        "%just-rendition; "                          >
+
+
+<!--                    SURNAME                                    -->
+<!--                    The surname (family name) of an individual.
+                        or the single name if there is only one
+                        name, for example, "Cher" or "Pele".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=surname
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=surname
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=surname
+                                                                   -->
+<!ELEMENT  surname      (#PCDATA %surname-elements;)*                >
+<!ATTLIST  surname
+             %surname-atts;                                          >
+
+
+<!--                    PREFIX ELEMENTS                            -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <prefix>
+                        Design Note: This PE begins with an OR
+                        bar because %just-rendition; begins with an
+                        OR bar.                                    -->
+<!ENTITY % prefix-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    PREFIX                                     -->
+<!--                    Honorifics or other qualifiers that usually
+                        precede the surname, for example,  Professor,
+                        Rev., President, Senator, Dr., Sir, The
+                        Honorable, et al.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=prefix
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=prefix
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=prefix
+                                                                   -->
+<!ELEMENT  prefix       (#PCDATA %prefix-elements;)*                 >
+<!ATTLIST  prefix
+             %prefix-atts;                                           >
+
+
+
+<!--                    SUFFIX ELEMENTS                            -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <suffix>
+                        Design Note: This PE begins with an OR bar,
+                        it is inside %just-rendition;              -->
+<!ENTITY % suffix-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    SUFFIX                                     -->
+<!--                    Text used as a suffix to a person's name, for
+                        example: Sr., Jr., III, 3rd
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=suffix
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=suffix
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=suffix
+                                                                   -->
+<!ELEMENT  suffix       (#PCDATA %suffix-elements;)*                 >
+<!ATTLIST  suffix
+             %suffix-atts;                                           >
+
+
+<!-- ============================================================= -->
+<!--                    EXTERNAL LINK ELEMENTS                     -->
+<!-- ============================================================= -->
+
+
+<!--                    EXTERNAL LINK ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        an <ext-link>
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %link-elements; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % ext-link-elements
+                        "%link-elements;"                            >
+
+
+<!--                    EXTERNAL LINK                              -->
+<!--                    Link to an external file, such as Medline,
+                        Genbank, etc.  Linking may be accomplished
+                        using the XLink linking attributes.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=ext-link
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=ext-link
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=ext-link
+                                                                   -->
+<!ELEMENT  ext-link     (#PCDATA %ext-link-elements;)*               >
+<!ATTLIST  ext-link
+             %ext-link-atts;                                         >
+
+
+<!-- ============================================================= -->
+<!--                    SHARED STRUCTURAL ELEMENTS                 -->
+<!-- ============================================================= -->
+
+
+<!--                    ATTRIBUTION ELEMENTS                       -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        an attribution
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % attrib-elements
+                        "%emphasized-text;"                          >
+
+
+<!--                    ATTRIBUTION                                -->
+<!--                    Source, author, formal thanks, or other
+                        information (other than copyright material)
+                        concerning the origins of an extract, a poem
+                        <verse-group> or similar element.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=attrib
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=attrib
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=attrib
+                                                                   -->
+<!ELEMENT  attrib       (#PCDATA %attrib-elements;)*                 >
+<!ATTLIST  attrib
+             %attrib-atts;                                           >
+
+
+<!--                    DEFINITION LIST: DEFINITION MODEL          -->
+<!--                    Content model for the <def> element, which
+                        is used in contexts outside of <def-list>s -->
+<!ENTITY % def-model    "((%just-para.class;)+ )"                    >
+
+
+<!--                    DEFINITION LIST: DEFINITION                -->
+<!--                    Used in two senses:
+                        1) The definition, description, or other
+                        explanation of the word, phrase, or picture
+                        of a 2-part or definition list
+                        2) The definition or expansion of an
+                        abbreviation or acronym <abbrev>
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=def
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=def
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=def
+                                                                   -->
+<!ELEMENT  def          %def-model;                                  >
+<!ATTLIST  def
+             %def-atts;                                              >
+
+
+<!--                    LABEL ELEMENTS                             -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <label> element                        -->
+<!ENTITY % label-elements
+                        "| %emphasis.class; | %inline-display.class; |
+                         %inline-math.class; | %subsup.class;"       >
+
+
+<!--                    LABEL OF A FIGURE, REFERENCE, ETC.         -->
+<!--                    The number and any prefix word that comes
+                        before, for example, the caption of a Figure,
+                        such as "Figure 3." or "Exhibit 2.".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=label
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=label
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=label
+                                                                   -->
+<!ELEMENT  label        (#PCDATA %label-elements;)*                  >
+<!ATTLIST  label
+             %label-atts;                                            >
+
+
+<!--                    PRICE ELEMENTS                             -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <price> element                        -->
+<!ENTITY % price-elements
+                        "| %emphasis.class;"                         >
+
+
+<!--                    PRICE                                      -->
+<!--                    Sale price of a work, typically a book or
+                        software package that is being reviewed
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=price
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=price
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=price
+                                                                   -->
+<!ELEMENT  price        (#PCDATA %price-elements;)*                  >
+<!ATTLIST  price
+             %price-atts;                                            >
+
+
+<!--                    STRUCTURAL TITLE ELEMENTS                  -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <title> element
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % struct-title-elements
+                        "%simple-phrase; | %break.class; |
+                         %citation.class;"                           >
+
+
+<!--                    TITLE                                      -->
+<!--                    Heading or title for a structural element
+                        such as a Section, Figure, Boxed Text, etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=title
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=title
+                                                                   -->
+<!ELEMENT  title        (#PCDATA %struct-title-elements;)*           >
+<!ATTLIST  title
+             %title-atts;                                            >
+
+
+<!-- ============================================================= -->
+<!--                    RELATED ARTICLE ELEMENTS                   -->
+<!--                    (METADATA AND STRUCTURAL)                  -->
+<!-- ============================================================= -->
+
+
+<!--                    RELATED ARTICLE ELEMENTS                   -->
+<!--                    Elements allowed inside <related-article>  -->
+<!ENTITY % related-article-elements
+                        "| %emphasis.class; | %journal-id.class; |
+                         %phrase-content.class; |
+                         %references.class; |  %subsup.class;"       >
+
+
+<!--                    RELATED ARTICLE INFORMATION                -->
+<!--                    Wrapper element, used as a container for
+                        text links to a related article, possibly
+                        accompanied by a very brief description
+                        such as "errata (correction)".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=related-article
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=related-article
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=related-article
+                                                                   -->
+<!ELEMENT  related-article
+                        (#PCDATA %related-article-elements;)*        >
+<!ATTLIST  related-article
+             %related-article-atts;                                  >
+
+
+<!-- ============================================================= -->
+<!--                    SIGNATURE BLOCK ELEMENTS                   -->
+<!-- ============================================================= -->
+
+
+<!--                    SIGNATURE BLOCK ELEMENTS                   -->
+<!--                    Elements to be mixed with data characters
+                        inside the content model for the
+                        <sig-block> element.                       -->
+<!ENTITY % sig-block-elements
+                         "| %break.class; | %emphasis.class; |
+                          %just-base-display.class; |
+                          %inline-display-noalt.class; |
+                          %phrase-content.class; |
+                          %sig.class; | %subsup.class;"              >
+
+
+<!--                    SIGNATURE BLOCK                            -->
+<!--                    An area of text and graphic material placed
+                        at the end of an article or section to hold
+                        the graphical signature or other description
+                        of the person responsible for or attesting
+                        to the content.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=sig-block
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=sig-block
+                                                                   -->
+<!ELEMENT  sig-block    (#PCDATA %sig-block-elements;)*              >
+<!ATTLIST  sig-block
+             %sig-block-atts;                                        >
+
+
+<!--                    SIGNATURE ELEMENTS                         -->
+<!--                    Elements to be mixed with data characters
+                        inside the content model for the
+                        <sig> element.                             -->
+<!ENTITY % sig-elements "%rendition-plus; | %break.class; |
+                         %inline-display-noalt.class; |
+                         %just-base-display-noalt.class;"            >
+
+
+<!--                    SIGNATURE                                  -->
+<!--                    One contributor signature and associated
+                        material (such as a text restatement of the
+                        affiliation) inside a signature block.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=sig
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=sig
+                                                                   -->
+<!ELEMENT  sig          (#PCDATA %sig-elements;)*                    >
+<!ATTLIST  sig
+             %sig-atts;                                              >
+
+
+<!-- ============================================================= -->
+<!--                    FRONT MATTER/BACK MATTER ELEMENTS          -->
+<!-- ============================================================= -->
+
+
+<!--                    ACKNOWLEDGMENTS MODEL                      -->
+<!--                    Content model for the <ack> element        -->
+<!ENTITY % ack-model    "%sec-opt-title-model;"                      >
+
+
+<!--                    ACKNOWLEDGMENTS                            -->
+<!--                    Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=ack
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=ack
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=ack
+                                                                   -->
+
+<!ELEMENT  ack          %ack-model;                                  >
+<!ATTLIST  ack
+             %ack-atts;                                              >
+
+
+<!--                    BIOGRAPHY MODEL                            -->
+<!--                    Content model for the <bio> element        -->
+<!ENTITY % bio-model    "%sec-opt-title-model;"                      >
+
+
+<!--                    BIOGRAPHY                                  -->
+<!--                    Short biography of a person, usually the
+                        author
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=bio
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=bio
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=bio
+                                                                   -->
+<!ELEMENT  bio          %bio-model;                                  >
+<!ATTLIST  bio
+             %bio-atts;                                              >
+
+
+<!--                    NOTES MODEL                                -->
+<!--                    Content model for the <notes> element      -->
+<!ENTITY % notes-model  "%sec-opt-title-model;"                      >
+
+
+<!--                    NOTES                                      -->
+<!--                    A container element for the notes that may
+                        appear at the end of an Article or at the
+                        end of a Table, for example, a typical
+                        end-of-article note is a "Note in Proof".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=notes
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=notes
+                                                                   -->
+<!ELEMENT  notes        %notes-model;                                >
+<!ATTLIST  notes
+             %notes-atts;                                            >
+
+
+<!-- ============================================================= -->
+<!--                    ACCESSIBILITY ELEMENTS                     -->
+<!-- ============================================================= -->
+
+
+<!--                    ALTERNATE TITLE TEXT FOR A FIGURE, ETC.    -->
+<!--                    Short phrase used to display or pronounce
+                        as an alternative to providing the full
+                        graphic for accessibility display or
+                        graphic-limited web sites or devices. For
+                        example, <alt-text> may be used to display
+                        "behind" a figure or graphic.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=alt-text
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=alt-text
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=alt-text
+                                                                   -->
+<!ELEMENT  alt-text     (#PCDATA)                                    >
+<!ATTLIST  alt-text
+             %alt-text-atts;                                         >
+
+
+<!--                    LONG DESCRIPTION ELEMENTS                  -->
+<!--                    Elements to be mixed with data characters
+                        inside the <long-desc> element             -->
+<!ENTITY % long-desc-elements
+                        ""                                           >
+
+
+<!--                    LONG DESCRIPTION                           -->
+<!--                    Description or summary of the content of a
+                        graphical object, table, or textual object
+                        such as a text box, used by some systems to
+                        make the object accessible, even to people
+                        or systems that cannot read/see/display the
+                        object.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=long-desc
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=long-desc
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=long-desc
+                                                                   -->
+<!ELEMENT  long-desc    (#PCDATA %long-desc-elements;)*              >
+<!ATTLIST  long-desc
+             %long-desc-atts;                                        >
+
+
+<!-- ============================================================= -->
+<!--                    CUSTOM METADATA ELEMENTS                   -->
+<!-- ============================================================= -->
+
+
+<!--                    CUSTOM METADATA GROUP MODEL                -->
+<!--                    Content model for the <custom-meta-group>
+                        element                                    -->
+<!ENTITY % custom-meta-group-model
+                        "(custom-meta+)"                             >
+
+
+<!--                    CUSTOM METADATA GROUP                      -->
+<!--                    Some DTDs and schemas allow for metadata
+                        above and beyond that which can be specified
+                        by this DTD. This element is a grouping
+                        element used to contain all these additional
+                        metadata elements.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=custom-meta-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=custom-meta-group
+                                                                   -->
+<!ELEMENT  custom-meta-group
+                        %custom-meta-group-model;                    >
+<!ATTLIST  custom-meta-group
+             %custom-meta-group-atts;                                >
+
+
+<!--                    CUSTOM METADATA MODEL                      -->
+<!--                    Content model for the <custom-meta> element-->
+<!ENTITY % custom-meta-model
+                        "(meta-name, meta-value)"                    >
+
+
+<!--                    CUSTOM METADATA                            -->
+<!--                    Some DTDs and schemas allow for metadata
+                        above and beyond that which can be specified
+                        by this DTD. This element is used to capture
+                        metadata elements that have not been defined
+                        explicitly in the models for this DTD, so
+                        that the intellectual content will not be lost.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=custom-meta
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=custom-meta
+                                                                   -->
+<!ELEMENT  custom-meta  %custom-meta-model;                          >
+<!ATTLIST  custom-meta
+             %custom-meta-atts;                                      >
+
+
+<!--                    METADATA DATA NAME ELEMENTS                -->
+<!--                    Elements that may be used, along with data
+                        characters, inside the <meta-name> element
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % meta-name-elements
+                        ""                                           >
+
+
+<!--                    METADATA DATA NAME FOR CUSTOM METADATA     -->
+<!--                    The <custom-meta> element
+                        allows for an infinite number of name/value
+                        pairs, with few constraints on the length or
+                        content of the value. This element contains
+                        the name of the metadata field.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=meta-name
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=meta-name
+                                                                   -->
+<!ELEMENT  meta-name    (#PCDATA %meta-name-elements;)*              >
+<!ATTLIST  meta-name
+             %meta-name-atts;                                        >
+
+
+<!--                    METADATA DATA VALUE ELEMENTS               -->
+<!--                    Elements that may be used, along with data
+                        characters, inside the <meta-value> element
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % meta-value-elements
+                        "%simple-phrase;"                            >
+
+
+<!--                    METADATA DATA VALUE FOR CUSTOM METADATA    -->
+<!--                    The <custom-meta> element
+                        allows for an infinite number of name/value
+                        pairs, with few constraints on the length or
+                        content of the value. This element contains
+                        the value of the metadata field that is named
+                        by the <meta-name> element.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=meta-value
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=meta-value
+                                                                   -->
+<!ELEMENT  meta-value   (#PCDATA %meta-value-elements;)*             >
+<!ATTLIST  meta-value
+             %meta-value-atts;                                       >
+
+
+<!-- ============================================================= -->
+<!--                    PROCESSING ALTERNATIVES ELEMENTS           -->
+<!-- ============================================================= -->
+
+
+<!--                    ALTERNATIVES MODEL                         -->
+<!--                    Model for the <alternatives> processing
+                        alternatives element                       -->
+<!ENTITY % alternatives-model
+                        "(%alternatives-display.class; |
+                          %math.class;)+"                            >
+
+
+<!--                    ALTERNATIVES FOR PROCESSING                -->
+<!--                    Container element used to hold a group of
+                        processing alternatives, for example, a
+                        single logical <graphic> that ships in
+                        different formats (tif, gif, jpeg) or
+                        different resolutions. This element is a
+                        physical grouping to contain multiple
+                        logically equivalent (substitutable) versions
+                        of the same information object.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=alternatives
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=alternatives
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=alternatives
+                                                                   -->
+<!ELEMENT  alternatives %alternatives-model;                         >
+<!ATTLIST  alternatives
+             %alternatives-atts;                                     >
+
+
+<!--                    TEXTUAL FORM ELEMENTS                      -->
+<!--                    Model for the <textual-form> element       -->
+<!ENTITY % textual-form-elements
+                        "| %emphasis.class; |
+                         %inline-display-noalt.class; |
+                         %math.class; |
+                         %phrase-content.class; | %subsup.class;"    >
+
+
+<!--                    TEXTUAL FORM                               -->
+<!--                    Container element (for use only inside
+                        <alternatives>) that will hold text and
+                        mixed content objects that act as alternatives
+                        to, for example, graphics.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=textual-form
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=textual-form
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=textual-form
+                                                                   -->
+<!ELEMENT  textual-form (#PCDATA %textual-form-elements;)*           >
+<!ATTLIST  textual-form
+             %textual-form-atts;                                     >
+
+
+<!-- ============================================================= -->
+<!--                    GENERATED TEXT OR PUNCTUATION              -->
+<!-- ============================================================= -->
+
+
+<!--                    X TEXT ATTRIBUTES                          -->
+<!--                    Attributes for the element <x>             -->
+<!ENTITY % x-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             xml:space ( default | preserve)       #FIXED 'preserve'
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    X ELEMENTS                                 -->
+<!--                    Elements for use inside the <x> element    -->
+<!ENTITY % x-elements   ""                                           >
+
+
+<!--                    X - GENERATED TEXT AND PUNCTUATION         -->
+<!--                    A container element to hold punctuation or
+                        other generated text, typically when 1) an
+                        archive decides not to have any text
+                        generated and thus to pre-generate such
+                        things as commas or semicolons between
+                        keywords or 2) when an archive receives text
+                        with <x> tags embedded and wishes to retain
+                        them.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=x
+                                                                   -->
+<!ELEMENT  x            (#PCDATA %x-elements;)*                      >
+<!ATTLIST  x
+             %x-atts;                                                >
+
+
+<!-- ================== End NISO JATS Common (Shared) Elements === -->
+

--- a/src/main/resources/dtd/archiving/1.2/JATS-default-classes1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-default-classes1.ent
@@ -1,0 +1,1426 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Default Element Classes Module                    -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Default Element Classes Module v1.2 20190208//EN"
+Delivered as file "JATS-default-classes1.ent"                      -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    To declare the Parameter Entities (PEs) used to   -->
+<!--             define the default element classes. Classes are   -->
+<!--             OR-groups of elements that are defined together   -->
+<!--             to be used in mixes and in Element Declarations.  -->
+<!--                                                               -->
+<!--             Note: Since PEs must be declared before they      -->
+<!--             are used, this module must be called before all   -->
+<!--             content modules that declare elements, and after  -->
+<!--             the class customization module (if any).          -->
+<!--                                                               -->
+<!-- CONTAINS:   PEs that define the element classes to be used    -->
+<!--             in the JATS DTD Suite modules.                    -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             August 2004                                       -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 24. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 23. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 38. INLINE-INDEX - Added the elements <index-term> and
+     <index-term-range-end> to phrase class to add the ability
+     to tag inline (embedded) index terms.
+
+ 38. INLINE-MEDIA - <inline-media> added to all the classes that 
+     contained <inline-graphic>
+
+ 37. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 36. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+ 35. NEW CLASS FOR TITLES/SOURCES - Made the element <abbrev>
+     into its own class, so it can be added to title elements 
+     without adding milestones.
+
+ 34. INSIDE A TABLE: Added <disp-formula> as a sibling to
+     <graphic>, <list>, etc. as the content of a <table-wrap>
+     that does not contain a <table>. Added <disp-formula> to 
+     simple-intable-display.class.
+
+ 33. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 32. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 32. ALI (NISO Access and License Indicators)
+     - Added <ali:license_ref> to license-p.class, as 
+       alternatives inside <license>
+     - Created a new class: license.class to hold the new ALI
+       element <ali:free_to_read>, as an alternative to
+       <license> inside <permissions>. 
+
+ 31. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 30. ADDED TO REFERENCES - Added the following elements to 
+     %references.class so that it would be allowed inside all 
+     citation types, product, et al.
+      - conf-acronym
+      - data-title (for citing datasets and parts of datasets)
+      - version (for data and software, similar to edition)
+
+ 29. STATEMENT - Added new statement.class, so that statements
+     can be recursive.
+
+ 28. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+ 27. ADDRESS ELEMENTS IN NEW CLASSES
+      - Added 3 new elements: <city>, <state>, <postal-code>
+          - address.class
+          - address-line.class
+        which adds then to: address, addr-line, add, collab, 
+        conf-loc, corresp, publisher-loc      
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 26. NEW <era> ELEMENT
+     Added <era> to date-parts.class
+
+ 25. NEW CLASSES
+     - def-item.class
+     - def-list.class
+     - list-item.class
+     - ref.class for use in <ref-list>
+     - unstructured-kwd-group.class for use in Green
+
+ 24. NEW CODE ELEMENT- Added <code> to
+      - alternatives-display.class
+      - block-display.class
+      - block-display-noalt.class
+      - floats-display.class
+      - inside-chem-struct-wrap.class      
+      - simple-display.class
+      - simple-display-noalt.class
+      - simple-intable-display.class
+
+ 23. INSTITUTION-WRAP ADDED
+     Added the element <institution-wrap> to the following classes:
+      - address.class
+      - address-line.class
+      - recipient-name.class
+      - references.class
+
+ 18. RUBY
+     - Added <ruby> to emphasis class
+     - Added a face-markup class (all the emphasis class except 
+         <ruby>) for use inside <ruby>
+
+ 17. ADDED NEW CLASSES (for new locations for the elements)
+     - abstract.class
+     - kwd-group.class
+     - institution.class
+     - institution-wrap.class
+     
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+ 16. CITATION ALTERNATIVES - Added a new element 
+     <citation-alternatives> to the citation.class. The element
+     will hold, for example, a single citation in multiple
+     languages or a single citation tagged as a <mixed-citation>
+     complete with punctuation and spacing and also as an
+     <element-citation> with all punctuation and spacing removed.
+
+ 15. CONTRIBUTOR ID CLASS - Created a new class "contrib-id.class"
+     to hold identifiers for people such as contributors such
+     as <contrib> and <principal-investigator>s. This will hold
+     publishers-specific IDs, ORCIDs, and JST and NII identifiers.
+
+ 14. NESTED KEYWORD CLASS - Created a new class "nested-kwd.class"
+     to hold the kinds of keywords that can be used inside
+     a nested keyword structure.
+     
+ 13. COLLAB CLASS - Created a new class "collab.class" to hold 
+     only the element <collab>, for use in the element
+     <collab-alternatives>.
+
+ 12. COLLABORATION ALTERNATIVES - Added <collab-alternatives> to
+     the name.class and -references.class to allow the
+     <collab-alternatives> element to occur anywhere <collab> 
+     was already used.
+   
+ 11. STANDARDS CLASS - Created a new class "std.class" to hold all
+     the elements inside the <std> element within citations.
+   
+ 10. REFERENCES CLASS - Added <issn-l> to the class.
+   
+  9. NOTHING BUT PARA CLASS - Added a new %nothing-but-para.class;
+     to get rid of PE clashes when the entity %just-para.class; needed
+     to be expanded to include other elements. The nothing-but
+     parameter entity contains <p> and only <p> and should never
+     be changed in a customization. The infelicitously-named PE
+     %just-para.class; can be modified for a customization to include
+     other elements as well.
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  8. Updated the DTD-version attribute to "0.4" 
+   
+  7. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+           http://jats.nlm.nih.gov/0.4.
+
+  6. NEW CLASS FOR just <alt-text> %small-access.class;
+     Since not everything needs a <long-desc>
+
+  5. ALTERNATIVES - Added <private-char> so that the alternatives
+     wrapper may be used to hold alternative characters, some as
+     <private-char>, some as <textual-form>, some as <graphic>,
+     etc.
+
+  4. AFFILIATION ALTERNATIVES - Added the element <aff-alternatives>
+     to hold multiple <aff>s that are representations of a single
+     affiliation, for example, the name of an institution in two
+     languages or two scripts.
+      -  contrib-info.class
+      -  person-group-info.class
+      -  Made a new class %aff-alternatives.class to hold just
+         <aff> and <aff-alternatives> NEW PE
+
+  3. NAME ALTERNATIVES - Added a new container element to hold
+     alternate versions of a person's name, for example:
+       -  a Roman alphabet transliteration, the Japanese characters,
+          and the Japanese with Ruby annotations or
+       -  the full peerage title of a person as well as a name
+          that is just surname and given names
+       -  a name and a sort version of the name that transliterates
+          the diacritics (such as cedillas and umlauts) to the same
+          character with no diacritic.
+     a. This structure was added to name.class PE
+     b. This structure was added to %investigator-name.class;
+     c. This structure was added to %recipient-name.class;
+     d. This structure was added to %references.class;
+
+  2. ROLE - Added <role> to %person-group-info.class; thereby
+     adding it to: <person-group> and <sig-block>
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    CLASSES FOR COMMON ELEMENTS (%common.ent;) -->
+<!-- ============================================================= -->
+
+
+<!--                    ADDRESS CLASS ELEMENTS                     -->
+<!--                    Potential element components of an address;
+                        not a proper class                         -->
+<!ENTITY % address.class
+                        "addr-line | city | country | fax |
+                         institution | institution-wrap | phone |
+                         postal-code | state"                        >
+
+
+<!--                    ADDRESS LINE CLASS ELEMENTS                -->
+<!--                    Potential element components of an address;
+                        line not a proper class                    -->
+<!ENTITY % address-line.class
+                        "city | country | fax | institution | 
+                         institution-wrap | phone |
+                         postal-code | state"                        >
+
+
+<!--                    CITATION CLASS ELEMENTS                    -->
+<!--                    Reference to an external document, as used
+                        within, for example, the text of a
+                        paragraph                                  -->
+<!ENTITY % citation.class
+                        "citation-alternatives | element-citation | 
+                         mixed-citation"                             >
+
+
+<!--                    CITATION MINUS ALTERNATIVES CLASS ELEMENTS -->
+<!--                    All the citation elements except the
+                        <citation-alternatives> element.           -->
+<!ENTITY % citation-minus-alt.class
+                        "element-citation | mixed-citation | 
+                         nlm-citation"                               >
+
+
+<!--                    DEFINITION CLASS ELEMENTS                  -->
+<!--                    Definitions and other elements to match
+                        with terms and abbreviations               -->
+<!ENTITY % def.class    "def"                                        >
+
+
+<!--                    DEGREE CLASS                               -->
+<!--                    The academic or professional degrees that
+                        accompany a person's name                  -->
+<!ENTITY % degree.class "degrees"                                    >
+
+
+<!--                    IDENTIFIER CLASS ELEMENTS                  -->
+<!--                    DOIs and other identifiers are used by
+                        publishers at many levels, for example for
+                        an <abstract> or a <fig>.                  -->
+<!ENTITY % id.class     "object-id"                                  >
+
+
+<!--                    LABEL CLASS                                -->
+<!--                    The label element, used to hold the number
+                        or character of a labeled object such as a
+                        table or footnote                          -->
+<!ENTITY % label.class  "label"                                      >
+
+
+<!--                    NOTE CLASS ELEMENTS                        -->
+<!--                    A note may appear at the end of an Article
+                        or at the end of a Table.  For example, a
+                        typical end-of-article note is a
+                        "Note in Proof".                           -->
+<!ENTITY % note.class   "note"                                       >
+
+
+<!-- ============================================================= -->
+<!--                    PERSON NAMING ELEMENTS (%common.ent;)      -->
+<!-- ============================================================= -->
+
+
+<!--                    COLLAB CLASS                               -->
+<!--                    A class to hold the <collab> element, so that
+                        more than on collaboration can be named 
+                        inside <collab-alternatives>.              -->
+<!ENTITY % collab.class "collab"                                     >
+
+
+<!--                    INVESTIGATOR NAMES CLASS                   -->
+<!--                    The elements used to name the personal names
+                        for principal investigators.               -->
+<!ENTITY % investigator-name.class
+                        "name | name-alternatives | string-name"     >
+
+
+<!--                    NAMES ALTERNATIVES CLASS                   -->
+<!--                    Elements that may contain the name of a
+                        person. These elements act as alternatives
+                        inside the <name-alternatives> wrapper, to
+                        allow multiple versions of one person's name
+                        to be included. These variants are
+                        differentiated by attributes: @xml:lang for
+                        language, region, language variant, etc. and
+                        @specific-use for indexing names,
+                        search names, etc.                         -->
+<!ENTITY % name-alternatives.class
+                        "name | string-name"                         >
+
+
+<!--                    NAMES CLASS                                -->
+<!--                    The elements used to name the personal names
+                        for individuals and the collaboration names
+                        for groups.                                -->
+<!ENTITY % name.class   "anonymous | collab | collab-alternatives |
+                         name | name-alternatives | string-name"     >
+                         
+
+
+<!--                    PERSONAL NAMES CLASS                       -->
+<!--                    The element components of a person's name,
+                        for the name of a contributor              -->
+<!ENTITY % person-name.class
+                        "degrees | given-names | prefix | surname |
+                         suffix"                                     >
+
+
+<!--                    STRING NAME CLASS                          -->
+<!--                    The element <string-name> is most useful
+                        inside citations, but some tag sets restrict
+                        its use in metadata. A one-element class.  -->
+<!ENTITY % string-name.class
+                        "string-name"                                >
+
+
+<!--                    RECIPIENT NAMES CLASS                      -->
+<!--                    The elements used to name the personal names
+                        or corporate names (such as Labs) for
+                        funded award recipients                    -->
+<!ENTITY % recipient-name.class
+                        "name | name-alternatives | institution |
+                         institution-wrap | string-name"             >
+
+
+<!-- ============================================================= -->
+<!--                    ARTICLE METADATA CONTRIBUTOR CLASSES;      -->
+<!-- ============================================================= -->
+
+
+<!--                    CONTRIBUTOR CLASS                          -->
+<!--                    Sometimes only the <contrib> element needs to
+                        be added to a model. Used mostly in the
+                        model for <contrib-group>.                 -->
+<!ENTITY % contrib.class
+                        "contrib"                                    >
+
+
+<!--                    CONTRIBUTOR GROUP CLASS                    -->
+<!--                    Sometimes only the <contrib-group> element
+                        needs to be added to a model.              -->
+<!ENTITY % contrib-group.class
+                        "contrib-group"                              >
+
+
+<!--                    CONTRIBUTOR IDENTIFIER CLASS               -->
+<!--                    Names the class to hold unique
+                        person identifiers, such as an ORCID or
+                        a trusted publisher identifier.            -->
+<!ENTITY % contrib-id.class
+                        "contrib-id"                                 >
+
+
+<!--                    CONTRIBUTOR INFORMATION CLASS              -->
+<!--                    Metadata about a contributor               -->
+<!ENTITY % contrib-info.class
+                        "address | aff | aff-alternatives |
+                         author-comment | bio | email |  etal |
+                         ext-link | on-behalf-of | role | uri | xref">
+
+
+<!--                    CONTRIBUTOR INFORMATION FOR REFERENCES     -->
+<!--                    The additions and alternatives to a person's
+                        name that may be used inside the element
+                        <person-group>                             -->
+<!ENTITY % person-group-info.class
+                        "aff | aff-alternatives | etal | role"       >
+
+
+<!-- ============================================================= -->
+<!--                    ARTICLE METADATA CLASSES %articlemeta.ent; -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE IDENTIFIER CLASS ELEMENTS          -->
+<!--                    Collected article identifiers for use in
+                        various models.                            -->
+<!ENTITY % article-identifier.class
+                        "article-id | issn | issn-l | isbn"          >
+
+
+<!--                    ARTICLE VERSION CLASS ELEMENTS             -->
+<!--                    Making sure that wherever <article-version>
+                        is allowed, <article-version-alternatives>
+                        is also allowed.                           -->
+<!ENTITY % article-version.class
+                        "article-version |
+                         article-version-alternatives"               > 
+
+
+<!--                    ABSTRACT CLASS ELEMENTS                    -->
+<!--                    Potential element components of an address;
+                        not a proper class                         -->
+<!ENTITY % abstract.class
+                        "abstract"                                   >
+
+
+<!--                    AFFILIATIONS ALTERNATIVES CLASS            -->
+<!--                    The <aff> and <aff-alternatives> elements only
+                                                                   -->
+<!ENTITY % aff-alternatives.class
+                        "aff | aff-alternatives"                     >
+
+
+<!--                    CONFERENCE CLASS                           -->
+<!--                    The element components of the description
+                        of a conference; not a proper class        -->
+<!ENTITY % conference.class
+                        "conf-date | conf-name | conf-num |
+                         conf-loc | conf-sponsor | conf-theme |
+                         conf-acronym | string-conf"                 >
+
+
+<!--                    CORRESPONDING AUTHOR CLASS                 -->
+<!--                    Elements associated with the corresponding
+                        author                                     -->
+<!ENTITY % corresp.class
+                        "corresp"                                    >
+
+
+<!--                    DATE CLASS ELEMENTS                        -->
+<!--                    Dates and other matters of history         -->
+<!ENTITY % date.class   "date | string-date"                         >
+
+
+<!--                    DATE PARTS CLASS ELEMENTS                  -->
+<!--                    Components of date-style elements          -->
+<!ENTITY % date-parts.class
+                        "day | era | month | season | year"          >
+
+
+<!--                    EVENT CLASS ELEMENTS                       -->
+<!--                    Dates and other matters of history         -->
+<!ENTITY % event.class  "event"                                      >
+
+
+<!--                    INSTITUTION CLASS ELEMENTS                 -->
+<!--                    To hold an <institution> and its
+                        identifiers, so you always can use both
+                        together.                                  -->
+<!ENTITY % institution.class
+                        "institution | institution-id"               >
+
+
+<!--                    INSTITUTION CLASS ELEMENTS                 -->
+<!--                    To allow both of the institution elements to 
+                        be used anywhere one of them might be needed.
+                                                                   -->
+<!ENTITY % institution-wrap.class
+                        "institution | institution-wrap"             >
+
+
+<!--                    JOURNAL IDENTIFIER CLASS ELEMENTS          -->
+<!--                    The <journal-id> element and any synonyms.
+                        Created for use inside <related-article>.  -->
+<!ENTITY % journal-id.class
+                        "journal-id"                                 >
+
+
+<!--                    KEYWORD CLASS ELEMENTS                     -->
+<!--                    Keywords and any keyword-synonyms          -->
+<!ENTITY % kwd.class    "kwd | compound-kwd | nested-kwd"            >
+
+
+<!--                    KEYWORD GROUP CLASS ELEMENTS               -->
+<!--                    The element <kwd-group> for use in models. -->
+<!ENTITY % kwd-group.class    
+                        "kwd-group"                                  >
+
+
+<!--                    LICENSE CLASS ELEMENTS                     -->
+<!--                    The alternatives to <license> that may live
+                        inside <permissions>.                      -->
+<!ENTITY % license.class    
+                        "ali:free_to_read | license"                 >
+
+
+<!--                    LICENSE PARAGRAPH CLASS ELEMENTS           -->
+<!--                    To hold the paragraphs and license
+                        references that may be inside the element
+                        <license>.                                 -->
+<!ENTITY % license-p.class
+                        "ali:license_ref | license-p"                >
+
+
+<!--                    NESTED KEYWORD CLASS ELEMENTS              -->
+<!--                    The kinds of keywords that can be used inside
+                        a nested keyword structure.                -->
+<!ENTITY % nested-kwd.class    
+                        "kwd | compound-kwd"                         >
+
+
+<!--                    PUBLICATION DATE CLASS ELEMENTS            -->
+<!--                    New element <pub-date-not-available> added to
+                        <book-meta> as an alternative to <pub-date>. 
+                        The meaning is that a publication date was 
+                        (for whatever reason) not available. Presence 
+                        of the element says nothing about
+                        publication status. The element
+                        <pub-date-not-available> was NOT added to 
+                        this class, since the new element may
+                        occur only once.                           -->
+<!ENTITY % pub-date.class
+                        "pub-date"                                   >
+
+
+<!--                    TITLE CLASS                                -->
+<!--                    Title metadata element that can be used
+                        to provide article-like metadata about
+                        other objects, for example a <supplement>  -->
+<!ENTITY % title.class  "title"                                      >
+
+
+<!--                    UNSTRUCTURED KEYWORD GROUP CLASS           -->
+<!--                    The <unstructured-kwd-group> element for use 
+                        by itself.                                 -->
+<!ENTITY % unstructured-kwd-group.class  
+                        "unstructured-kwd-group"                     >
+
+
+<!--                    STRING DATE CLASS                          -->
+<!--                    The <string-date> element for use by itself.
+                                                                   -->
+<!ENTITY % string-date.class  
+                        "string-date"                                >
+
+
+<!-- ============================================================= -->
+<!--                    BACK MATTER CLASSES (%backmatter.ent;)     -->
+<!-- ============================================================= -->
+
+
+<!--                    JUST APPENDIX CLASS                        -->
+<!--                    The appendix and only the appendix         -->
+<!ENTITY % app.class    "app"                                        >
+
+
+<!--                    BACK MATTER CLASS                          -->
+<!--                    Ancillary elements, typically used in the
+                        back matter of an article, section, etc.   -->
+<!ENTITY % back.class   "ack | app-group | bio | fn-group |
+                         glossary |  ref-list"                       >
+
+
+<!--                    FRONT MATTER CLASS                         -->
+<!--                    Ancillary elements, typically used in the
+                        front matter of an article, book, etc.  .  -->
+<!ENTITY % front.class  "ack | bio | fn-group | glossary"            >
+
+
+<!--                    FRONT AND BACK CLASS                       -->
+<!--                    Ancillary elements, typically used in the
+                        front or back matter of an article         -->
+<!ENTITY % front-back.class
+                        "notes"                                      >
+
+
+<!--                    SECTION BACK MATTER CLASS                  -->
+<!--                    Ancillary elements, typically used in the
+                        back matter of a section, etc.             -->
+<!ENTITY % sec-back.class
+                        "fn-group | glossary |  ref-list"            >
+
+
+<!--                    JUST SIGNATURE CLASS                       -->
+<!--                    The signature and only the signature <sig>
+                        for use inside <sig-block>s                -->
+<!ENTITY % sig.class    "sig"                                        >
+
+
+<!-- ============================================================= -->
+<!--                    CLASSES USED IN DISPLAY ELEMENTS           -->
+<!-- ============================================================= -->
+
+
+<!--                    ACCESSIBILITY CLASS ELEMENTS               -->
+<!--                    Elements added to make it easier to process
+                        journal articles in ways that are more
+                        accessible to people and devices with special
+                        needs, for example the visually handicapped.
+                          <alt-text> is a short phrase description of
+                        an objects, <long-desc> is a more complete
+                        description of the content or intent of an
+                        object.                                    -->
+<!ENTITY % access.class "alt-text | long-desc"                       >
+
+
+<!--                    SMALL ACCESSIBILITY CLASS ELEMENTS         -->
+<!--                    Elements added to make it easier to process
+                        journal articles in ways that are more
+                        accessible to people and devices with special
+                        needs, for example the visually handicapped.
+                          <alt-text> is a short phrase description of
+                        an objects. This class is for use when
+                        <long-desc> is just too much.              -->
+<!ENTITY % small-access.class
+                        "alt-text"                                   >
+
+
+<!--                    CAPTION DISPLAY ELEMENTS                   -->
+<!--                    Basic figure display elements              -->
+<!ENTITY % caption.class
+                        "caption"                                    >
+
+
+<!--                    DISPLAY ELEMENT BACK MATTER ELEMENTS       -->
+<!--                    Miscellaneous stuff (such as photo credits or
+                        copyright statement) at the end of a display
+                        element such as a figure or a boxed text
+                        element such as a sidebar.                 -->
+<!ENTITY % display-back-matter.class
+                        "attrib | permissions"                       >
+
+
+<!-- ============================================================= -->
+<!--                    DISPLAY ELEMENTS CLASSES                   -->
+<!-- ============================================================= -->
+
+
+<!--                    DISPLAY CLASS ELEMENTS                     -->
+<!--                    Graphical or other image-related elements.
+                        The display elements may occur within
+                        the text of a table cell or paragraph
+                        although they are typically at the same
+                        hierarchical level as a paragraph.         -->
+<!ENTITY % block-display.class
+                        "address | alternatives | array |
+                         boxed-text | chem-struct-wrap | code | 
+                         fig | fig-group | graphic | media |
+                         preformat | supplementary-material |
+                         table-wrap | table-wrap-group"              >
+
+
+<!ENTITY % block-display-noalt.class
+                        "address | array |
+                         boxed-text | chem-struct-wrap | code | 
+                         fig | fig-group | graphic | media |
+                         preformat | supplementary-material |
+                         table-wrap | table-wrap-group"              >
+
+
+<!--                    FLOATING DISPLAY CLASS ELEMENTS            -->
+<!--                    Block display elements that can take the
+                        position attribute, and thus may be floating
+                        as opposed to fixed in narrative position in
+                        an article. Created for use as the content
+                        of <floats-group>.                         -->
+<!ENTITY % floats-display.class
+                        "alternatives | boxed-text |
+                         chem-struct-wrap | code | fig | fig-group |
+                         graphic | media | preformat |
+                         supplementary-material |
+                         table-wrap | table-wrap-group"              >
+
+
+<!--                    FIGURE DISPLAY ELEMENTS                    -->
+<!--                    Basic figure display elements              -->
+<!ENTITY % fig-display.class
+                        "fig"                                        >
+
+
+<!--                    INLINE DISPLAY CLASS ELEMENTS              -->
+<!--                    Non-block display elements that set or
+                        display inline with the text               -->
+<!ENTITY % inline-display.class
+                        "alternatives | inline-graphic |
+                         inline-media | 
+                         private-char"                               >
+
+
+<!ENTITY % inline-display-noalt.class
+                        "inline-graphic | 
+                         inline-media | private-char"                >
+
+
+<!--                    MOST BASIC DISPLAY ELEMENTS                -->
+<!--                    Just the few display elements that are
+                        simple display objects: a picture, a movie,
+                        a sound file.                              -->
+<!ENTITY % just-base-display.class
+                        "alternatives | graphic | media"             >
+
+
+<!ENTITY % just-base-display-noalt.class
+                        "graphic | media"                            >
+
+
+<!--                    SIMPLE DISPLAY ELEMENTS                    -->
+<!--                    The simplest and most basic of the Display
+                        Class elements, which may be allowed in many
+                        places, for example, inside other Display
+                        Class elements or inside the cell of a
+                        Table                                      -->
+<!ENTITY % simple-display.class
+                        "alternatives | array | code | graphic | 
+                         media | preformat"                          >
+
+
+<!ENTITY % simple-display-noalt.class
+                        "array | code | graphic | media | preformat" >
+
+<!--                    SIMPLE TABLE DISPLAY ELEMENTS              -->
+<!--                    Very similar to the simple-display.class, but
+                        Table Wrappers <table-wrap> should contain
+                        <table>s, <oasis:table>s, etc., not
+                        arrays.                                    -->
+<!ENTITY % simple-intable-display.class
+                        "alternatives | chem-struct-wrap | code |
+                         disp-formula | 
+                         graphic | media | preformat"                >
+
+
+<!--                    INSIDE CHEMICAL STRUCTURE ELEMENTS         -->
+<!--                    Very similar to the simple-display.class, but
+                        for use inside <chem-struct-wrap>, so it
+                        can contain both <chem-struct> and
+                        <textual-form>                             -->
+<!ENTITY % inside-chem-struct-wrap.class
+                        "alternatives | chem-struct | code | graphic |
+                         media | preformat | textual-form"           >
+
+
+<!--                    ALTERNATIVES DISPLAY CLASS ELEMENTS        -->
+<!--                    Display elements that can be alternatives to
+                        each  other inside an alternatives element.
+                                                                   -->
+<!ENTITY % alternatives-display.class
+                        "array | chem-struct | code | graphic |
+                         inline-graphic | inline-media | 
+                         inline-supplementary-material |
+                         media | preformat | private-char |
+                         supplementary-material | table |
+                         textual-form"                               >
+
+
+<!-- ============================================================= -->
+<!--                    MATH CLASSES (%math.ent;)                  -->
+<!-- ============================================================= -->
+
+
+<!--                    MATHEMATICAL EXPRESSIONS AND FORMULAE
+                        CLASS ELEMENTS                             -->
+<!ENTITY % block-math.class
+                        "disp-formula | disp-formula-group"          >
+
+
+<!--                    CHEMICAL STRUCTURE WRAPPER CLASS           -->
+<!ENTITY % chem-struct-wrap.class
+                        "chem-struct-wrap"                           >
+
+
+<!--                    INLINE MATHEMATICAL EXPRESSIONS MIX CLASS
+                        ELEMENTS                                   -->
+<!ENTITY % inline-math.class
+                        "chem-struct | inline-formula"               >
+
+
+<!--                    MATHEMATICAL EXPRESSIONS CLASS ELEMENTS    -->
+<!ENTITY % math.class   "tex-math | mml:math"                        >
+
+
+<!--                    SIMPLE MATHML CLASS                        -->
+<!ENTITY % simple-math.class
+                        "mml:math"                                   >
+
+
+<!-- ============================================================= -->
+<!--                    FORMAT CLASSES (%format.ent;)              -->
+<!-- ============================================================= -->
+
+
+<!--                    APPEARANCE CLASS ELEMENTS                  -->
+<!--                    Names those elements (inherited from the
+                        XHTML table DTD that are only concerned with
+                        appearance, not with structure or content.
+                        Use of these elements is to be discouraged.-->
+<!ENTITY % appearance.class
+                        "hr"                                         >
+
+
+<!--                    FORCED BREAK FORMATTING CLASS ELEMENTS     -->
+<!--                    Element to force a formatting break such as
+                        a line break                               -->
+<!ENTITY % break.class  "break"                                      >
+
+
+<!--                    EMPHASIS/RENDITION ELEMENTS                -->
+<!--                    Elements concerning with marking the location
+                        of typographical emphasis (highlighting)
+                        DTD Design Note: There are no emphasis
+                        elements for <fractur>, <openface> (black
+                        board), <script>, etc. because this DTD
+                        recommends the use of the STIX extensions
+                        to accomplish this, as soon as they are
+                        available.                                 -->
+<!ENTITY % emphasis.class
+                        "bold | fixed-case | italic | monospace |
+                         overline | overline-start | overline-end |
+                         roman | sans-serif | sc | strike |
+                         underline | underline-start | 
+                         underline-end |
+                         ruby"                                       >
+
+
+<!--                    FACE MARKUP ELEMENTS                       -->
+<!--                    All of the emphasis/rendition elements
+                        except <ruby>, for use (initially) inside
+                        <ruby> itself.                             -->
+<!ENTITY % face-markup.class
+                        "bold | fixed-case | italic | monospace |
+                         overline | overline-start | overline-end |
+                         roman | sans-serif | sc | strike |
+                         underline | underline-start | 
+                         underline-end"                              >
+
+
+<!--                    UP/DOWN RENDITION ELEMENTS                 -->
+<!ENTITY % subsup.class "sub | sup"                                  >
+
+
+<!-- ============================================================= -->
+<!--                    LINK CLASSES (%link.ent;)                  -->
+<!-- ============================================================= -->
+
+
+<!--                    ADDRESS LINK CLASS ELEMENTS                -->
+<!--                    Link elements that can be used inside
+                        addresses. This is essentially the three
+                        generic external links.
+                        (Note: in earlier releases, this Parameter
+                        Entity was named %address-elements;,
+                        although it functioned as a class.)        -->
+<!ENTITY % address-link.class
+                        "email | ext-link | uri"                     >
+
+
+
+<!--                    SIMPLE LINKS/CROSS-REFERENCES CLASS        -->
+<!--                    The smaller and simpler linking elements
+                        that might be inside, for example, a
+                        Keyword <kwd>                              -->
+<!ENTITY % simple-link.class
+                        "fn | target | xref"                         >
+
+
+<!--                    CROSS-REFERENCES CLASS                     -->
+<!--                    A class just to hold <xref>.               -->
+<!ENTITY % xref.class   "xref"                                       >
+
+
+<!-- ============================================================= -->
+<!--                    FOOTNOTE CLASSES (%link.ent;)              -->
+<!-- ============================================================= -->
+
+<!--                    FOOTNOTE LINKS CLASS                       -->
+<!--                    Only the most basic, internal links        -->
+<!ENTITY % fn-link.class
+                        "fn"                                         >
+
+
+<!--                    FOOTNOTE GROUP CLASS                       -->
+<!--                    Collections of footnotes                   -->
+<!ENTITY % fn-group.class
+                        "fn-group"                                   >
+
+
+<!-- ============================================================= -->
+<!--                    RELATED-OBJECT CLASSES                     -->
+<!-- ============================================================= -->
+
+
+<!--                    JOURNAL ARTICLE LINK CLASS ELEMENTS        -->
+<!--                    Links used inside journal articles, to point
+                        to related material                        -->
+<!ENTITY % article-link.class
+                        "inline-supplementary-material |
+                         related-article | related-object"           >
+
+
+<!--                    RELATED ARTICLE LINKS CLASS                -->
+<!--                    For using <related-article> at the paragraph
+                        level                                      -->
+<!ENTITY % related-article.class
+                        "related-article  | related-object"          >
+
+
+<!-- ============================================================= -->
+<!--                    LIST CLASSES (%list.ent;)                  -->
+<!-- ============================================================= -->
+
+
+<!--                    DEFINITION LIST CLASS ELEMENT              -->
+<!--                    Class for the <list-item>, so it may be used
+                        in OR groups.                              -->
+<!ENTITY % def-list.class   
+                        "def-list"                                   >
+
+
+<!--                    DEFINITION LIST ITEM CLASS ELEMENT         -->
+<!--                    Class for the <list-item>, so it may be used
+                        in OR groups.                              -->
+<!ENTITY % def-item.class   
+                        "def-item"                                   >
+
+
+<!--                    LIST CLASS ELEMENTS                        -->
+<!--                    All the types of lists that may occur
+                        as part of the text, therefore excluding
+                        Bibliographic Reference Lists <ref-list>   -->
+<!ENTITY % list.class   "def-list | list"                            >
+
+
+<!--                    LIST ITEM CLASS ELEMENT                    -->
+<!--                    Class for the <list-item>, so it may be used
+                        in OR groups.                              -->
+<!ENTITY % list-item.class   
+                        "list-item"                                  >
+
+
+<!-- ============================================================= -->
+<!--                    PARAGRAPH CLASSES (%para.ent;)             -->
+<!-- ============================================================= -->
+
+
+<!--                    REST OF PARAGRAPH CLASS                    -->
+<!--                    Information for the reader that is at the
+                        same structural level as a Paragraph.
+                        Contains all paragraph-level objects that are
+                        not also used inside tables and excepting
+                        also the paragraph element itself          -->
+<!ENTITY % rest-of-para.class
+                        "ack | disp-quote | speech | statement |
+                         verse-group"                                >
+
+
+<!--                    IN TABLE PARAGRAPH CLASS                   -->
+<!--                    The simpler of the paragraph-level elements
+                        that might be found inside a table cell    -->
+<!ENTITY % intable-para.class
+                        "disp-quote | speech | statement |
+                         verse-group"                                >
+
+
+<!--                    JUST PARAGRAPH CLASS                       -->
+<!--                    Set by default to hold the just the Paragraph 
+                        element, alone. This parameter entity may
+                        be redefined by a customization to name any
+                        element(s) that the Tag Set wishes to be
+                        able to use anywhere within textual elements
+                        that a paragraph may occur. Such elements
+                        would also need to be added to the PE
+                        %block-display.class; and to some individual
+                        element PEs.                               -->
+<!ENTITY % just-para.class
+                        "p"                                          >
+
+
+<!--                    NOTHING BUT PARAGRAPH CLASS                -->
+<!--                    To hold the paragraph element <p>, alone.
+                        This parameter entity should be left
+                        untouched by any customization             -->
+<!ENTITY % nothing-but-para.class
+                        "p"                                          >
+
+
+<!--                    STATEMENT CLASS                            -->
+<!--                    To hold the paragraph element <statement>, 
+                        alone.                                     -->
+<!ENTITY % statement.class
+                        "statement"                                  >
+
+
+<!-- ============================================================= -->
+<!--                    PHRASE CLASSES (%phrase.ent;)              -->
+<!-- ============================================================= -->
+
+
+<!--                    ABBREVIATION CLASS ELEMENTS                -->
+<!--                    The element <abbrev>, so it can be added
+                        to title elements without adding milestones.
+                                                                   -->
+<!ENTITY % abbrev.class "abbrev"                                     >
+
+
+<!--                    FUNDING CLASS ELEMENTS                     -->
+<!--                    Small inline elements, that surround a word
+                        or phrase in the text to identify pieces of
+                        funding metadata. where such material is not
+                        pulled out separately but just mixed into
+                        text as phrases or sentences within a
+                        paragraph. These elements may be used to mark,
+                        for example, the <award-id> (such as a grant
+                        number or contract number) or the
+                        <funding-source> such as the sponsoring
+                        organization or trust that awarded the grant.
+                                                                   -->
+<!ENTITY % funding.class
+                        "award-id | funding-source | open-access"    >
+
+
+<!--                    PHRASE CLASS ELEMENTS                      -->
+<!--                    Small inline elements, that surround a word
+                        or phrase in the text because the subject
+                        (content) should be identified as something
+                        special or different                       -->
+<!ENTITY % phrase.class "abbrev | 
+                         index-term | index-term-range-end |
+                         milestone-end | milestone-start |
+                         named-content | styled-content"             >
+
+
+<!--                    STYLED CONTENT CLASS ELEMENTS              -->
+<!--                    The <styled-content> element alone, so it
+                        can be used in places where emphasis is used.
+                                                                   -->
+<!ENTITY % styled-content.class
+                        "styled-content"                             >
+
+
+<!--                    PHRASE CONTENT CLASS ELEMENTS              -->
+<!--                    Small inline elements, that surround a word
+                        or phrase in the text because the subject
+                        (content) should be identified as something
+                        special or different. This class in is
+                        intended to be a subset of the  Phrase Class,
+                        for use in restricted situations, such as
+                        within metadata paragraphs, to record
+                        publisher-identified semantic or usage
+                        material.                                  -->
+<!ENTITY % phrase-content.class
+                        "named-content | styled-content"             >
+
+
+<!--                    PRICE CLASS ELEMENTS                       -->
+<!--                    Created to hold the <price> element so that
+                        it can be selectively added to elements,
+                        initially to <product>.                    -->
+<!ENTITY % price.class  "price"                                      >
+
+
+<!--                    PRODUCT ELEMENTS                           -->
+<!--                    Created to hold the <product> element so that
+                        it can be selectively added to elements,
+                        initially to <note>.                       -->
+<!ENTITY % product.class
+                        "product"                                    >
+
+
+<!-- ============================================================= -->
+<!--                    REFERENCES CLASSES (references.ent)        -->
+<!-- ============================================================= -->
+
+
+<!--                    BIBLIOGRAPHIC REFERENCE (CITATION) CLASS   -->
+<!--                    The elements that may be included inside a
+                        citation (bibliographic reference), either
+                        in an all-element-content (<element-citation>)
+                        or in a mixed-content citation
+                        (<mixed-citation>).                        -->
+<!ENTITY % references.class
+                        "annotation | article-title | chapter-title |
+                         collab | collab-alternatives |comment | 
+                         conf-acronym | conf-date | conf-loc | 
+                         conf-name | conf-sponsor | 
+                         data-title | date | date-in-citation | 
+                         day | edition |  email | elocation-id |  
+                         etal | ext-link | fpage |
+                         gov | institution | institution-wrap |
+                         isbn | issn | issn-l | 
+                         issue | issue-id | issue-part | issue-title |
+                         lpage | month | name | name-alternatives |
+                         object-id | page-range | part-title |
+                         patent | person-group | pub-id |
+                         publisher-loc | publisher-name | role |
+                         season | series | size | source | std |
+                         string-name | supplement |
+                         trans-source | trans-title | uri | version |
+                         volume | volume-id | volume-series | year"  >
+
+
+<!--                    JUST REFERENCE-LIST CLASS                  -->
+<!--                    The reference list and only the reference
+                        list                                       -->
+<!ENTITY % ref-list.class
+                        "ref-list"                                   >
+
+
+<!--                    STANDARDS CLASS                            -->
+<!--                    The elements that can be used in the mixed
+                        content model of a <std>, which is a
+                        cited standard inside a citation:
+                          source contains the name of the standard
+                          pub-id contains the standard designator
+                          date elements name the official date
+                          std-organization names the standards body
+                          named-content takes anything else a 
+                            publisher/archive needs (come in 
+                            from %rendition-plus.                  -->
+<!ENTITY % std.class    "day | month | pub-id | source | 
+                         std-organization | year"                    >
+
+
+<!--                    JUST REFERENCE CLASS                       -->
+<!--                    The element <ref> for use in models.       -->
+<!ENTITY % ref.class    "ref"                                        >
+
+
+<!-- ============================================================= -->
+<!--                    SECTION CLASS (%section.ent;)              -->
+<!-- ============================================================= -->
+
+
+<!--                    SECTION CLASS ELEMENTS                     -->
+<!--                    Information for the reader that is at the
+                        same structural level as a Section, which is
+                        a headed structure full of smaller elements
+                        such as paragraphs.                        -->
+<!ENTITY % sec.class    "sec"                                        >
+
+
+<!-- ============================================================= -->
+<!--                    TABLE MODEL CLASSES                        -->
+<!-- ============================================================= -->
+
+
+<!--                    JUST TABLE CLASS                           -->
+<!--                    To include just a table <table-wrap>
+                        element                                    -->
+<!ENTITY % just-table.class
+                        "table-wrap"                                 >
+
+
+<!--                    TABLE CLASS ELEMENTS                       -->
+<!--                    Elements that will be used to contain the
+                        rows and columns inside the Table Wrapper
+                        element <table-wrap>.  The following elements
+                        can be set up for inclusion:
+                          XHTML Table Model    table               -->
+<!ENTITY % table.class  "table"                                      >
+
+
+<!--                    TABLE FOOT CLASS                           -->
+<!--                    Elements to include at the end of a table
+                        in the table.                              -->
+<!ENTITY % table-foot.class
+                        "table-wrap-foot"                            >
+
+
+<!--                    TABLE BODY CLASS                           -->
+<!--                    To include just a table <table-wrap>
+                        element                                    -->
+<!ENTITY % tbody.class  "tbody"                                      >
+
+
+<!-- ================== End Journal Suite Default Classes  ======= -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-default-mixes1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-default-mixes1.ent
@@ -1,0 +1,541 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Default Element Mixes Module                      -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Default Element Mixes Module v1.2 20190208//EN"
+Delivered as file "JATS-default-mixes1.ent"                        -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Declares default values for all the element mixes -->
+<!--             used in the content models of the DTD Suite       -->
+<!--                                                               -->
+<!--             Mixes are Or-groups of classes, used in many      -->
+<!--             different content models. Mixes should not use    -->
+<!--             element names directly, only through classes.     -->
+<!--                                                               -->
+<!--             Note: Since PEs must be declared before they      -->
+<!--             are used, this module must be called after the    -->
+<!--             customize mixes module (if any).                  -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             August 2004                                       -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 14. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 13. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+ 12. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 11. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+ 10. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  9. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  8. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+    
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  6. PARAGRAPH IN TABLE CELL - Added <p> to the contents of
+     table cells, through %inside-cell; (using
+     %nothing-but-para.class;).
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  5. PARA-LEVEL PARAMETER ENTITY CONFLICT - Changed the parameter
+     entity %para-level; to use the PE %nothing-but-para.class;,
+     removing the similar PE "just-para.class;". It is possible to 
+     add element(s) to %just-para.class;, so that the added element(s)
+     may be used everywhere <p> is used. Such elements would also be
+     named in %block-display.class;. This would lead to a conflict
+     in %para-level; if both %just-para.class; and
+     %block-display.class; named <p>. So %just-para.class; is replaced
+     here in %para-level;. This is backward compatible for all XML
+     documents. If a JATS customization has modified %just-para.class;
+     they may need to change their customization to accommodate.
+   
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+           http://jats.nlm.nih.gov/0.4.
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    ELEMENT MIXES FOR USE IN CONTENT MODELS    -->
+<!--                    (MIXES ARE COMPOSED USING CLASSES)         -->
+<!-- ============================================================= -->
+
+
+<!--                    SECTION-LEVEL ELEMENTS                     -->
+<!--                    Elements that may be used at the same
+                        structural level as a Section for example
+                        inside the Body <body>                     -->
+<!ENTITY % sec-level    "%sec.class;"                                >
+
+
+<!-- ============================================================= -->
+<!--                    BACK MATTER ELEMENT MIXES(%backmatter.ent;)-->
+<!-- ============================================================= -->
+
+
+<!--                    DOCUMENT BACK MATTER ELEMENTS              -->
+<!--                    Back Matter Elements used by a full document
+                        such as a journal article. This is an element
+                        grouping rather than a class. These
+                        elements may also appear in the content models
+                        of structural elements, such as back matter.
+                        (Note: Technically this should have used
+                        %sec.class;, but %sec-level; was used in an
+                        earlier release and backwards compatibility
+                        must be maintained.                        -->
+<!ENTITY % doc-back-matter-mix
+                        "%back.class; | %front-back.class; |
+                         %sec.class;"                                >
+
+
+<!--                    SECTION BACK MATTER ELEMENTS               -->
+<!--                    Back matter elements used inside smaller
+                        structures, such as sections and sidebars  -->
+<!ENTITY % sec-back-matter-mix
+                        "%front-back.class; | %sec-back.class;"      >
+
+
+<!-- ============================================================= -->
+<!--                    PARAGRAPH-LEVEL ELEMENT MIXES              -->
+<!-- ============================================================= -->
+
+
+<!--                    PARAGRAPH-LEVEL ELEMENTS                   -->
+<!--                    Elements that may be used at the same
+                        structural level as a paragraph, for
+                        example inside a Section
+                        Note: There a major overlap between this
+                        parameter entity and that for the elements
+                        that are at the same level as a paragraph.
+                        Inline elements appear only inside a
+                        paragraph, but block elements such as quotes
+                        and lists may appear either within a
+                        paragraph or at the same level as a
+                        paragraph. This serves a requirement in a
+                        repository DTD, since some incoming material
+                        will have restricted such elements to only
+                        inside a paragraph,  some incoming material
+                        will have restricted them to only outside a
+                        paragraph and some may allow them in both
+                        places. Thus the DTD must allow for them to
+                        be in either or both.                      -->
+<!ENTITY % para-level   "%block-display.class; | %block-math.class; |
+                         %list.class; | %math.class; | 
+                         %nothing-but-para.class; | 
+                         %related-article.class; |
+                         %rest-of-para.class;"                       >
+
+
+<!-- ============================================================= -->
+<!--                    TABLE ELEMENT MIXES                        -->
+<!-- ============================================================= -->
+
+
+<!--                    INSIDE TABLE CELL ELEMENTS                 -->
+<!--                    Mixed with #PCDATA inside a table cell, such
+                        as a <td> or <th> element in the XHTML table
+                        model, the <entry> element in the OASIS CALS
+                        table model, etc.  This PE will be used as the
+                        value of %Flow.mix;, %paracon;, etc.
+                        ### Usage Alert ###
+                        Design Note: Inside cell is an exception, an
+                        inline mix that does not start with an OR
+                        bar. This is because is used within the
+                        PE -%Flow.mix;, which is an inline mix
+                        defined in the course of the XHTML Table DTD,
+                        a DTD not under control of this DTD Suite. -->
+<!ENTITY % inside-cell  "%address-link.class; |  %appearance.class; |
+                         %article-link.class; |
+                         %block-math.class; | %break.class; |
+                         %citation.class; | %emphasis.class; |
+                         %inline-math.class; |
+                         %list.class; | %math.class; |
+                         %nothing-but-para.class; |
+                         %phrase.class; | %simple-display.class; |
+                         %inline-display-noalt.class; |
+                         %simple-link.class; | %subsup.class;"       >
+
+
+<!--                    INSIDE TABLE WRAPPER ELEMENTS              -->
+<!--                    Usually a Table Wrapper contains a table,
+                        properly tagged with rows and columns, but
+                        sometimes, a structure that is labeled as
+                        a "table" is actually a list, or two
+                        paragraphs.  This Parameter Entity names
+                        all the alternatives to table that may
+                        occur inside a table wrapper.              -->
+<!ENTITY % inside-table-wrap
+                        "%intable-para.class; | %list.class; |
+                         %simple-intable-display.class;  |
+                         %table.class;"                              >
+
+
+<!-- ============================================================= -->
+<!--                    INLINE ELEMENT MIXES                       -->
+<!-- ============================================================= -->
+
+
+<!--                    EMPHASIS MIX ELEMENTS                      -->
+<!--                    Elements that may be used inside most of the
+                        emphasis class elements
+                        Design Note: Inline mixes begin with an
+                        OR bar                                     -->
+<!ENTITY % emphasized-text
+                        "| %address-link.class; |
+                         %article-link.class; | %emphasis.class;  |
+                         %inline-display.class; |
+                         %inline-math.class; | %math.class; |
+                         %phrase.class; | %simple-link.class; |
+                         %subsup.class;"                             >
+
+
+<!--                    JUST RENDITION                             -->
+<!--                    Only the simplest of the typographic
+                        emphasis elements, as well as subscript and
+                        superscript.  Usually used in a model that
+                        allows #PCDATA and this restricted mixture.
+                        This mix may be stripped down to only
+                        subscript and superscript by some, more
+                        restrictive DTDs.
+                        MAINTENANCE NOTE: This Parameter Entity
+                        and the related PE "rendition-plus" have
+                        been put in place to restrict the amount of
+                        variability that a person modifying the DTD
+                        through PE redefinition can achieve. Some
+                        elements have been set #PCDATA plus one PE
+                        and some have been set to #PCDATA plus the
+                        other in an effort to allow designers to
+                        modify entire groups of elements, but not
+                        to change similar models individually .
+                        Design Note: Inline mixes begin with an
+                        OR bar                                     -->
+<!ENTITY % just-rendition
+                        "| %emphasis.class;  | %subsup.class; |
+                         %phrase-content.class;"                     >
+
+
+<!--                    RENDITION MARKUP PLUS                      -->
+<!--                    Only the simplest of the typographic
+                        emphasis elements, as well as subscript and
+                        superscript.  Usually used in a model that
+                        allows #PCDATA and this restricted mixture.
+                        This mix may be enhanced slightly in some
+                        more permissive DTDs, and should always
+                        contain at least typographic emphasis,
+                        subscript, and superscript.
+                        MAINTENANCE NOTE:: This Parameter Entity
+                        and the related PE "just-rendition" have
+                        been put in place to restrict the amount of
+                        variability that a person modifying the DTD
+                        through PE redefinition can achieve. Some
+                        elements have been set #PCDATA plus one PE
+                        and some have been set to #PCDATA plus the
+                        other in an effort to allow designers to
+                        modify entire groups of elements, but not
+                        to individually change similar models.
+                        modify entire groups of elements, but not
+                        to change similar models individually .
+                        Design Note: Inline mixes begin with an
+                        OR bar                                     -->
+<!ENTITY % rendition-plus
+                        "| %emphasis.class;  | %subsup.class; |
+                         %phrase-content.class;"                     >
+
+
+<!--                    SIMPLE PHRASE-LEVEL TEXTUAL ELEMENTS       -->
+<!--                    Elements that may be used almost anywhere
+                        text is used, for example, inside a title.
+                        Simple text plus inline display and math
+                        elements. In practice, This is the next step
+                        up from "simple-text", adding the links.
+                        Design Note: Inline mixes begin with an
+                        OR bar                                     -->
+<!ENTITY % simple-phrase
+                        "| %address-link.class; |
+                         %article-link.class; | %emphasis.class; |
+                         %inline-display.class; |
+                         %inline-math.class; | %math.class; |
+                         %phrase.class; | %simple-link.class; |
+                         %subsup.class;"                             >
+
+
+<!--                    SIMPLE TEXTUAL CONTENT                     -->
+<!--                    Elements that may be used inside elements
+                        that are really expected to be #PCDATA and
+                        not to contain any of these things.
+                        Note that there is only inline math and no 
+                        links.
+                        Simpler even than %simple-phrase;
+                        Design Note: Inline mixes begin with an
+                        OR bar                                     -->
+<!ENTITY % simple-text  "| %emphasis.class; | %inline-display.class; |
+                         %inline-math.class; | %phrase.class; |
+                         %subsup.class; "                            >
+
+
+<!-- ================== End Archiving DTD Mixes Customization ==== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-display1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-display1.ent
@@ -1,0 +1,1147 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Display Class Elements                            -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Display Class Elements v1.2 20190208//EN"
+     Delivered as file "JATS-display1.ent"                         -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                     -->
+<!--                                                               -->
+<!-- PURPOSE:    Describes display-related elements such as        -->
+<!--             Figures, Graphics, Math, Chemical Structures,     -->
+<!--             Graphics, etc.                                    -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd) 
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 24. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 23. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+     =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 22. INLINE-MEDIA - Added new element <inline-media>, which is to
+     <media> as <inline-graphic> is to <graphic>. The content
+     model is the same as <inline-supplementary-material>, in
+     other words there should be content, this is not typically 
+     an empty element. The attributes are the same as <media>,
+     except without @position and @orientation.
+
+ 21. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 20. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+     
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 19. INLINE GRAPHIC and PRIVATE-CHAR - Both <inline-graphic> and
+     <private-char> added to elements allowed in <code>.
+ 
+ 18. INLINE GRAPHIC - Changed from small-access.class to
+     access.class to add <long-desc>
+ 
+ 17. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 16. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 15. JATS became version "1.1d3" and "v1.1d3 20150301"
+ 
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  14. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 13. CAPTION ATTRIBUTE - Changed the mechanism by which the @style
+      attribute is associated with the element <caption>. 
+      Previously, the <caption> element's base attributes were 
+      declared in this module and additional attributes (@style) 
+      for it were declared in the XHTML Table Module. The @style 
+      attribute is now declared in this module, and the caption 
+      attributes in the XHTML table model have been set to IGNORE. 
+      This was done to make sure that the attributes available on 
+      the JATS <caption> element did not change based on which table
+      model a JATS user was using.
+
+ 12. CODE - Added the new element <code> (using code-atts and
+     code-elements). Resembles <preformat>, but different
+     semantics.
+
+ 11. CAPTION ATTRIBUTES - Added the new PE %jats-common-atts; to
+     the caption attributes, even though doing so while making
+     no other changes would mean multiple definitions
+     of the @id and @content-type attributes. This would produce a
+     warning, which should be ignored, so see item #13 above.
+
+ 10. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+
+  9. ABSTRACT AND KEYWORDS ON NEW STRUCTURES
+     - Added <abstract> (through %abstract.class;) and <kwd-group> 
+       (through %kwd-group.class;) to the following elements:
+        - chem-struct-wrap (through %chem-struct-wrap-model;)
+        - fig (through %fig-model;)
+        - fig-group (through %fig-group-model;)
+        - graphic (through %graphic-model;)
+        - media (through %media-model;)
+        - table-wrap (through %table-wrap-model;)
+        - table-wrap-group (through %table-wrap-group-model;)
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  8. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  7. Updated the DTD-version attribute to "0.4" 
+   
+  6. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  5. INLINE GRAPHIC - Uses new class %small-access.class; (no
+     model change)
+
+  4. POSITION ATTRIBUTE - Added the value "background"
+
+  3. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to %display-atts;. If these attribute were
+     already part of the list, deleted them. These attributes were
+     added to:
+      - array       (already there)
+      - boxed-text  (already there)
+      - caption     (already there)
+      - chem-struct (added @xml:lang, @specific-use already)
+      - chem-struct-wrap (added @xml:lang, @specific-use already)
+      - fig (already there)
+      - fig-group (added @xml:lang, @specific-use already there)
+      - graphic (added @xml:lang, @specific-use already there)
+      - inline-graphic (both)
+      - media (added @xml:lang, @specific -use already there)
+      - preformat (already there)
+      - supplementary-material (already there)
+      - table-wrap (already there)
+      - table-wrap-group (added @xml:lang, @specific -use
+          already there)
+
+  2. GRAPHIC MODEL - Removed the dependency which had both
+     <graphic> and <media> modeled with the same parameter
+     entity %graphic-model;. Created new PE for %media-model;
+     but set it (as the default) to %graphic-model; so that no
+     customization would break. NEW PE
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    ATTRIBUTES FOR MULTIPLE ELEMENTS           -->
+<!-- ============================================================= -->
+
+
+<!--                    DISPLAY ATTRIBUTES                         -->
+<!--                    Attributes used for several of the block
+                        display elements                           -->
+<!ENTITY % display-atts
+            "position   (anchor | background | float | margin)
+                                                          'float'
+             orientation
+                        (portrait | landscape)            'portrait'
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    SPECIFIC ATTRIBUTE LISTS                   -->
+<!-- ============================================================= -->
+
+
+<!--                    ARRAY ATTRIBUTES                           -->
+<!--                    Attributes for the <array> element         -->
+<!ENTITY % array-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             orientation
+                        (portrait | landscape)            'portrait'
+             xml:lang   NMTOKEN                           #IMPLIED" >
+
+
+<!--                    BOXED TEXT ATTRIBUTES                      -->
+<!--                    Attributes for the <boxed-text> element    -->
+<!ENTITY % boxed-text-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              content-type
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    CAPTION ATTRIBUTES                         -->
+<!--                    Attributes for <caption> element           -->
+<!--                    The attribute @style was added to make all
+                        JATS captions the same as XHTML table
+                        captions.                                  -->
+<!ENTITY % caption-atts
+            "%jats-common-atts;
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED 
+             style      CDATA                             #IMPLIED"  >
+
+<!--                    CHEMICAL STRUCTURE ATTRIBUTES              -->
+<!--                    Attributes for <chem-struct>, a wrapper
+                        around one (typically inline) chemical
+                        structure, or one of several structures in
+                        a <chem-struct-wrap>                       -->
+<!ENTITY % chem-struct-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    CHEMICAL STRUCTURE WRAPPER ATTRIBUTES      -->
+<!--                    Attributes for the <chem-struct-wrap>
+                        element, the outer wrapper around one or more
+                        block-level chemical structures            -->
+<!ENTITY % chem-struct-wrap-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              content-type
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                   CODE ATTRIBUTES                             -->
+<!--                   Attributes for the <code> element           -->
+<!ENTITY % code-atts
+            "%jats-common-atts;                                       
+             code-type          CDATA                     #IMPLIED
+             code-version       CDATA                     #IMPLIED
+             executable         (yes | no)                #IMPLIED
+             language           CDATA                     #IMPLIED
+             language-version   CDATA                     #IMPLIED
+             platforms          CDATA                     #IMPLIED
+             %display-atts;
+             xml:space (default | preserve)       #FIXED 'preserve'" >
+
+
+<!--                    FIGURE ATTRIBUTES                          -->
+<!--                    Attributes for Figures <fig>               -->
+<!ENTITY % fig-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              fig-type  CDATA                             #IMPLIED"  >
+
+
+<!--                    FIGURE GROUP ATTRIBUTES                    -->
+<!--                    Attributes for Figure Groups <fig-group>   -->
+<!ENTITY % fig-group-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              content-type
+                        CDATA                             #IMPLIED "  >
+
+
+<!--                    GRAPHIC ATTRIBUTES                         -->
+<!--                    Attributes for the <graphic> element       -->
+<!ENTITY % graphic-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              content-type
+                        CDATA                             #IMPLIED
+              mime-subtype
+                        CDATA                             #IMPLIED
+              mimetype  CDATA                             #IMPLIED
+              %link-atts;"                                           >
+
+
+<!--                    INLINE GRAPHIC ATTRIBUTES                  -->
+<!--                    Attributes for the <inline-graphic> element-->
+<!ENTITY % inline-graphic-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             baseline-shift
+                        CDATA                             #IMPLIED
+             mimetype   CDATA                             #IMPLIED
+             mime-subtype
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %link-atts;"                                            >
+
+
+<!--                    MEDIA ATTRIBUTES                           -->
+<!--                    Attributes for the <media> element         -->
+<!ENTITY % inline-media-atts
+            "%jats-common-atts;                                       
+              content-type
+                         CDATA                            #IMPLIED
+              mimetype   CDATA                            #IMPLIED
+              mime-subtype
+                         CDATA                            #IMPLIED
+              vocab      CDATA                            #IMPLIED
+              vocab-identifier
+                         CDATA                            #IMPLIED
+              vocab-term CDATA                            #IMPLIED
+              vocab-term-identifier
+                         CDATA                            #IMPLIED
+              specific-use
+                         CDATA                            #IMPLIED
+              xml:lang   NMTOKEN                          #IMPLIED
+              %link-atts;"                                           >
+
+
+<!--                    MEDIA ATTRIBUTES                           -->
+<!--                    Attributes for the <media> element         -->
+<!ENTITY % media-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              content-type
+                        CDATA                             #IMPLIED
+              mimetype  CDATA                             #IMPLIED
+              mime-subtype
+                        CDATA                             #IMPLIED
+              %link-atts;"                                           >
+
+
+<!--                   PREFORMATTED TEXT ATTRIBUTES                -->
+<!--                   Attributes for the <preformat> element      -->
+<!ENTITY % preformat-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              preformat-type
+                        CDATA                             #IMPLIED
+              xml:space (default | preserve)     #FIXED 'preserve'"  >
+
+
+<!--                    SUPPLEMENTARY INFORMATION ATTRIBUTES       -->
+<!--                    Attributes for Supplementary Material
+                        <supplementary-material>                   -->
+<!ENTITY % supplementary-material-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              content-type
+                        CDATA                             #IMPLIED
+              mimetype  CDATA                             #IMPLIED
+              mime-subtype
+                        CDATA                             #IMPLIED
+              %might-link-atts;"                                     >
+
+
+<!-- ============================================================= -->
+<!--                    TABLE ATTRIBUTES                           -->
+<!-- ============================================================= -->
+
+
+<!--                    TABLE WRAPPER ATTRIBUTES                   -->
+<!--                    Attributes to be added to the regular NLM
+                        table attributes, for example, when the
+                        Elsevier or OASIS Exchange table models are
+                        used.                                      -->
+<!ENTITY % other-table-wrap-atts
+            ""                                                       >                                       
+
+
+<!--                    TABLE GROUP ATTRIBUTES                     -->
+<!--                    Attributes for groups of <table-wrap>
+                        elements <table-wrap-group>                -->
+<!ENTITY % table-wrap-group-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              content-type
+                        CDATA                             #IMPLIED
+              %other-table-wrap-atts;"                               >
+
+
+<!--                    TABLE WRAPPER ATTRIBUTES                   -->
+<!--                    Attributes for the <table-wrap> element,
+                        the container for <table>s                 -->
+<!ENTITY % table-wrap-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              content-type
+                        CDATA                             #IMPLIED
+              %other-table-wrap-atts;"                               >
+
+
+<!--                    TABLE WRAP FOOT ATTRIBUTES                 -->
+<!--                    Attributes for the <table-wrap-foot> element
+                                                                   -->
+<!ENTITY % table-wrap-foot-atts
+            "%jats-common-atts;"                                     >                                       
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR CONTENT MODELS      -->
+<!-- ============================================================= -->
+
+
+<!--                    FIGURE-LIKE CONTENT MODEL                  -->
+<!--                    Content model for the Figure element and any
+                        similarly structured elements              -->
+<!ENTITY % fig-model    "((%id.class;)*, label?, (%caption.class;)*,
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          (%access.class; | %address-link.class;)*,
+                          (%block-math.class; |
+                           %chem-struct-wrap.class; |
+                           %intable-para.class; |
+                           %just-table.class; | %just-para.class; |
+                           %list.class; | %simple-display.class;)*,
+                          (%display-back-matter.class;)* )"          >
+
+
+<!-- ============================================================= -->
+<!--                    ARRAY ELEMENTS                             -->
+<!-- ============================================================= -->
+
+
+<!--                    ARRAY CONTENT MODEL                        -->
+<!--                    Content model for the <array> element      -->
+<!ENTITY % array-model  "(label?,
+                          (%access.class; | %address-link.class;)*,
+                          ( (%just-base-display.class;)* |
+                            %tbody.class; ),
+                          (%display-back-matter.class;)* )"          >
+
+
+<!--                    ARRAY (SIMPLE TABULAR ARRAY)               -->
+<!--                    Used to define in-text table-like (columnar)
+                        material.  Uses the XHTML table body element
+                        or a graphic to express the rows and columns.
+                        These have neither labels nor captions,
+                        arrays with labels and captions are table
+                        wrappers.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=array
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=array
+                                                                   -->
+<!ELEMENT  array        %array-model;                                >
+<!ATTLIST  array
+             %array-atts;                                            >
+
+
+<!-- ============================================================= -->
+<!--                    BOXED TEXT ELEMENTS                        -->
+<!-- ============================================================= -->
+
+
+<!--                    BOXED TEXT MODEL                           -->
+<!--                    Complete content model for the boxed text
+                        element <boxed-text>                       -->
+<!ENTITY % boxed-text-model
+                        "((%id.class;)*, sec-meta?, label?, caption?,
+                          (%para-level;)*, (%sec-level;)*,
+                          (%sec-back-matter-mix;)*,
+                          (%display-back-matter.class;)* )"          >
+
+
+<!--                    BOXED TEXT                                 -->
+<!--                    Textual material that is outside the flow
+                        of the narrative text, for example, a
+                        sidebar, marginalia, text insert, caution or
+                        note box, etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=boxed-text
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=boxed-text
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=boxed-text
+                                                                   -->
+<!ELEMENT  boxed-text   %boxed-text-model;                           >
+<!ATTLIST  boxed-text
+             %boxed-text-atts;                                       >
+
+
+<!-- ============================================================= -->
+<!--                    CHEMICAL STRUCTURE ELEMENTS                -->
+<!-- ============================================================= -->
+
+
+<!--                    CHEMICAL STRUCTURE WRAPPER MODEL           -->
+<!--                    Content model for the Chemical Structure
+                        Wrapper <chem-struct-wrap> element         -->
+<!ENTITY % chem-struct-wrap-model
+                        "((%id.class;)*, label?, (%caption.class;)?,
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          (%access.class; | %address-link.class;)*,
+                          (%inside-chem-struct-wrap.class;)+,
+                          (%display-back-matter.class;)* )"          >
+
+
+<!--                    CHEMICAL STRUCTURE WRAPPER                 -->
+<!--                    A chemical expression, reaction, equation,
+                        etc. that is set apart within the text.
+                        These may be numbered.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=chem-struct-wrap
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=chem-struct-wrap
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=chem-struct-wrap
+                                                                   -->
+<!ELEMENT  chem-struct-wrap
+                        %chem-struct-wrap-model;                     >
+<!ATTLIST  chem-struct-wrap
+             %chem-struct-wrap-atts;                                 >
+
+
+<!--                    CHEMICAL STRUCTURE ELEMENTS                -->
+<!--                    Those elements that may mix with the data
+                        characters inside a Chemical Structure
+                        <chem-struct>                              -->
+<!ENTITY % chem-struct-elements
+                        "| %access.class; | %address-link.class; |
+                         %break.class; |
+                         %emphasis.class; | %label.class; |
+                         %list.class; | %math.class; |
+                         %phrase-content.class; |
+                         %simple-display.class; |
+                         %simple-link.class; | %subsup.class; "      >
+
+
+<!--                    CHEMICAL STRUCTURE MODEL                   -->
+<!--                    A chemical expression, reaction, equation,
+                        etc. that is set apart within the text
+                                                                   -->
+<!ENTITY % chem-struct-model
+                        "(#PCDATA %chem-struct-elements;)* "         >
+
+
+<!--                    CHEMICAL STRUCTURE (DISPLAY)               -->
+<!--                    A chemical expression, reaction, equation,
+                        etc. that is set apart within the text.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=chem-struct
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=chem-struct
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=chem-struct
+                                                                   -->
+<!ELEMENT  chem-struct  %chem-struct-model;                          >
+<!ATTLIST  chem-struct
+             %chem-struct-atts;                                      >
+
+
+<!-- ============================================================= -->
+<!--                    FIGURE ELEMENTS                            -->
+<!-- ============================================================= -->
+
+
+<!--                    FIGURE GROUP MODEL                         -->
+<!--                    Content model for a Figure Group element   -->
+<!ENTITY % fig-group-model
+                        "(label?, (%caption.class;)?,
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          (%access.class; | %address-link.class;)*,
+                          (%fig-display.class; |
+                           %just-base-display.class;)* )"            >
+
+
+<!--                    FIGURE GROUP                               -->
+<!--                    Used for a group of figures that must be
+                        displayed together
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=fig-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=fig-group
+                                                                   -->
+<!ELEMENT  fig-group    %fig-group-model;                            >
+<!ATTLIST  fig-group
+             %fig-group-atts;                                        >
+
+
+<!--                    FIGURE                                     -->
+<!--                    A block of graphic or textual material that
+                        is identified as a "Figure", usually with
+                        a caption and a label such as "Figure" or
+                        "Figure 3.".The content of a Figure need not
+                        be graphical in nature,.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=fig
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=fig
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=fig
+                                                                   -->
+<!ELEMENT  fig          %fig-model;                                  >
+<!ATTLIST  fig
+             %fig-atts;                                              >
+
+
+<!--                    CAPTION BODY PARTS                         -->
+<!--                    Elements that may be included in the body of
+                        the <caption> element                      -->
+<!ENTITY % caption-body-parts
+                        "(%just-para.class;)*"                       >
+
+
+<!--                    CAPTION MODEL                              -->
+<!--                    Content model for the <caption> element    -->
+<!ENTITY % caption-model
+                        "(title?, %caption-body-parts;)"             >
+
+
+<!--                    CAPTION OF A FIGURE, TABLE, ETC.           -->
+<!--                    Wrapper element for the textual description
+                        associated with a figure, table, etc. In
+                        some source document captions, the first
+                        sentence is set off from the rest as a title.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=caption
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=caption
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=caption
+                                                                   -->
+<!ELEMENT  caption      %caption-model;                              >
+<!ATTLIST  caption
+             %caption-atts;                                          >
+
+
+<!--ELEM  title        Defined in %common.ent;                     -->
+<!--ELEM  p            Defined in %common.ent;                     -->
+
+
+<!-- ============================================================= -->
+<!--                    THE GRAPHIC AND MEDIA OBJECT ELEMENTS      -->
+<!-- ============================================================= -->
+
+
+<!--                    GRAPHIC MODEL                              -->
+<!--                    Content model for the <graphic> element    -->
+<!ENTITY % graphic-model
+                        "(%access.class; | %abstract.class; | 
+                          %address-link.class; | %caption.class; |
+                          %id.class; | %kwd-group.class; | 
+                          %label.class; |
+                          %display-back-matter.class;)* "            >
+
+
+<!--                    GRAPHIC                                    -->
+<!--                    An external file that holds a picture,
+                        illustration, etc., usually as some form of
+                        binary object. The "content" of the <graphic>
+                        element is not the object, but merely
+                        information about the object. The "href"
+                        attribute points to the file containing
+                        the object.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=graphic
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=graphic
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=graphic
+                                                                   -->
+<!ELEMENT  graphic      %graphic-model;                              >
+<!ATTLIST  graphic
+             %graphic-atts;                                          >
+
+
+<!--                    INLINE MEDIA MODEL                         -->
+<!--                    Content model for the <inline-media> element
+                                                                   -->
+<!ENTITY % inline-media-elements  
+                        "| %access.class; | %address-link.class; |
+                         %emphasis.class; |
+                         %phrase-content.class; | %subsup.class;"    >
+
+
+<!--                    INLINE MEDIA OBJECT                        -->
+<!--                    An external file that holds a media object
+                        to be used inline, such as a pronunciation
+                        file. "content" of the <media> element is not 
+                        the object, but merely information about the
+                        object or the word to be linked. The "href" 
+                        attribute points to the file containing the 
+                        object.
+                        Details at:                      http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=inline-media
+                      http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=inline-media
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=inline-media
+                                                                   -->
+<!ELEMENT  inline-media (#PCDATA %inline-media-elements;)*           >
+<!ATTLIST  inline-media
+             %inline-media-atts;                                     >
+
+
+<!--                    MEDIA MODEL                                -->
+<!--                    Content model for the <media> element      -->
+<!ENTITY % media-model  "(%access.class; | %abstract.class; | 
+                          %address-link.class; |
+                          %caption.class; | %id.class; | 
+                          %kwd-group.class; | %label.class; | 
+                          %display-back-matter.class;)* "            >
+
+
+<!--                    MEDIA OBJECT                               -->
+<!--                    An external file that holds a media object,
+                        such as an animation or a movie. The
+                        "content" of the <media> element is not the
+                        object, but merely information about the
+                        object. The "href" attribute points to the
+                        file containing the object.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=media
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=media
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=media
+                                                                   -->
+<!ELEMENT  media        %media-model;                                >
+<!ATTLIST  media
+             %media-atts;                                            >
+
+
+<!-- ============================================================= -->
+<!--                    INLINE GRAPHIC                             -->
+<!-- ============================================================= -->
+
+
+<!--                    INLINE GRAPHIC MODEL                       -->
+<!--                    Content model for the <inline-graphic>
+                        element                                    -->
+<!ENTITY % inline-graphic-model
+                        "((%access.class;)*)"                        >
+
+
+<!--                    INLINE GRAPHIC                             -->
+<!--                    A small graphic such as an icon or a small
+                        picture symbol that is displayed or set
+                        in the same line as the text.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=inline-graphic
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=inline-graphic
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=inline-graphic
+                                                                   -->
+<!ELEMENT  inline-graphic
+                        %inline-graphic-model;                       >
+<!ATTLIST  inline-graphic
+             %inline-graphic-atts;                                   >
+
+
+<!-- ============================================================= -->
+<!--                    PRESERVE THE WHITESPACE TEXT               -->
+<!-- ============================================================= -->
+
+
+<!--                    PREFORMATTED TEXT ELEMENTS                 -->
+<!--                    Elements that may be used, along with data
+                        characters, inside the content model for the
+                        <preformat> element                        -->
+<!ENTITY % preformat-elements
+                        "| %access.class; | %address-link.class; |
+                         %display-back-matter.class; |
+                         %emphasis.class; | %id.class; |
+                         %phrase.class; | %subsup.class;"            >
+
+
+<!--                    PREFORMAT MODEL                            -->
+<!--                    Content model for the <preformat> element  -->
+<!ENTITY % preformat-model
+                        "(#PCDATA %preformat-elements;)*"            >
+
+
+<!--                    PREFORMATTED TEXT                          -->
+<!--                    Used for preformatted text such as
+                        computer code in which whitespace, such as
+                        tabs, line feeds, and spaces, should be
+                        preserved.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=preformat
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=preformat
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=preformat
+                                                                   -->
+<!ELEMENT  preformat    %preformat-model;                            >
+<!ATTLIST  preformat
+             %preformat-atts;                                        >
+
+
+<!--                    CODE ELEMENTS                              -->
+<!--                    Elements that may be used, along with data
+                        characters, inside the content model for the
+                        <code> element                             -->
+<!ENTITY % code-elements
+                        "| %address-link.class; |  %emphasis.class; | 
+                         %inline-display-noalt.class; | 
+                         %phrase.class; |  %simple-link.class; |
+                         %subsup.class;"                             >
+
+
+<!--                    CODE TEXT                                  -->
+<!--                    A container element for technical content
+                        such as programming language code, 
+                        pseudo-code, schemas, or a markup fragment.
+                          This material may be preformatted text, with
+                        or without emphasis, or it may be an external
+                        link to a binary executable file.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=code
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=code
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=code
+                                                                   -->
+<!ELEMENT  code         (#PCDATA %code-elements;)*                   >
+<!ATTLIST  code
+             %code-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    SUPPLEMENTARY MATERIAL                     -->
+<!-- ============================================================= -->
+
+
+<!--                    SUPPLEMENTARY MATERIAL MODEL               -->
+<!--                    Content model for the
+                        <supplementary-material> element           -->
+<!ENTITY % supplementary-material-model
+                        "%fig-model;"                                >
+
+
+<!--                    SUPPLEMENTARY MATERIAL                     -->
+<!--                    Additional data files that contain
+                        information directly supportive of the item,
+                        for example, an audio clip, movie, database,
+                        spreadsheet, applet, or other external file.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=supplementary-material
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=supplementary-material
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=supplementary-material
+                                                                   -->
+<!ELEMENT  supplementary-material
+                        %supplementary-material-model;               >
+<!ATTLIST  supplementary-material
+             %supplementary-material-atts;                           >
+
+
+<!-- ============================================================= -->
+<!--                    TABLE ELEMENTS                             -->
+<!-- ============================================================= -->
+
+
+<!--                    TABLE WRAPPER GROUP MODEL                  -->
+<!--                    Content model for the <table-wrap-group>
+                        element                                    -->
+<!ENTITY % table-wrap-group-model
+                        "(label?, caption?,
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          (%access.class; | %address-link.class;)*,
+                          (%just-table.class;)+ )"                   >
+
+
+<!--                    TABLE WRAPPER GROUP                        -->
+<!--                    Used as a wrapper tag to contain a group of
+                        tables that must be displayed together
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=table-wrap-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=table-wrap-group
+                                                                   -->
+<!ELEMENT  table-wrap-group
+                        %table-wrap-group-model;                     >
+<!ATTLIST  table-wrap-group
+             %table-wrap-group-atts;                                 >
+
+
+<!--                    TABLE WRAPPER CONTENT MODEL                -->
+<!--                    Content model for the container element that
+                        surrounds the standard table models for row
+                        and columns.                               -->
+<!ENTITY % table-wrap-model
+                        "((%id.class;)*, label?, (%caption.class;)?,
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          (%access.class; | %address-link.class;)*,
+                          (%inside-table-wrap;)*,
+                          (%table-foot.class; |
+                           %display-back-matter.class;)* )"          >
+
+
+<!--                    TABLE WRAPPER                              -->
+<!--                    Used to hold a complete table, that is, not
+                        only the rows and columns that make up a
+                        table, but also the table captions, list
+                        of table footnotes, alternative descriptions
+                        for accessibility, etc.  Within the Table
+                        Wrapper element, the row and column tags that
+                        describe the table cells are defined by one
+                        of the popular "standard" table models, for
+                        example the XHTML table model, OASIS Exchange
+                        (CALS) table model, of the Elsevier Science
+                        Full Length Article table body <tblbody>
+                        model, et al.)
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=table-wrap
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=table-wrap
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=table-wrap
+                                                                   -->
+<!ELEMENT  table-wrap   %table-wrap-model;                           >
+<!ATTLIST  table-wrap
+             %table-wrap-atts;                                       >
+
+
+<!--                    TABLE WRAP FOOTER MODEL                    -->
+<!--                    Content model for the <table-wrap-foot>
+                        element                                    -->
+<!ENTITY % table-wrap-foot-model
+                        "(title?,
+                          (%just-para.class; |  %fn-group.class; |
+                           %fn-link.class; |
+                           %display-back-matter.class;)+ )"          >
+
+
+<!--                    TABLE WRAP FOOTER                          -->
+<!--                    Wrapper element to hold a group of footnotes
+                        or other notes or general paragraphs at the
+                        end of a table.  Not the same as the
+                        Table Foot <tfoot>, which contains rows
+                        and columns like the rest of the table.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=table-wrap-foot
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=table-wrap-foot
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=table-wrap-foot
+                                                                   -->
+<!ELEMENT  table-wrap-foot
+                        %table-wrap-foot-model;                      >
+<!ATTLIST  table-wrap-foot
+             %table-wrap-foot-atts;                                  >
+
+
+<!-- ================== End Display Class Module ================= -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-format1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-format1.ent
@@ -1,0 +1,944 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Formatting Element Classes                        -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+ "-//NLM//DTD JATS (Z39.96) JATS DTD Suite Formatting Element Classes v1.2 20190208//EN"
+  Delivered as file "JATS-format1.ent"                             -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Elements concerned with rendition of output, for  -->
+<!--             example printing on a page or display on a screen -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 19. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 18. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+ 17. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 16. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+     
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+ 15. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 14. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 13. JATS became version "1.1d3" and "v1.1 20150301//EN"
+ 
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  12. RUBY MODEL CHANGED TO MATCH HTML5
+      - changed the Ruby content model to allow only a single
+        Ruby annotation on a single Ruby base:
+            (rb, rt+)
+        The Ruby textual annotation may NOT take a pair of
+        Ruby parentheses. This is a simplification of the
+        HTML5 model:
+           (rb, (rt | (rp, rt, rp)) )
+        The simplification does not allow Ruby parenthesis.
+        Archiving and BITS both use the full model above.
+
+  11. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 10. RUBY ANNOTATIONS - Added new elements for:
+      - <ruby> The Ruby wrapper element, which contains the base
+          text and the annotation.
+      - <rb> Ruby Base text, acts in the same manner as face markup,
+        surrounding some text in the narrative.
+      - <rt> Ruby Text, the annotation that modifies a piece of
+         the narrative text, frequently typeset above the text.
+
+  9. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added a new attribute list to:
+      - break 
+      - hr      
+      - rp               
+
+  8. ADDED NEW ELEMENT <fixed-case> 
+     - defined as meaning that the case of the content is not to
+       change, even if the content around it is styled to all
+       upper case or all lower. For example "PhD".
+
+  7. ADDED NEW ATTRIBUTE - @toggle added to:
+     - bold, italic (default="yes"), monospace, overline, 
+       roman (default="no"), sans-serif, sc, strike, and underline.
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+  
+  6. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  5. Updated the DTD-version attribute to "0.4" 
+   
+  4. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+           http://jats.nlm.nih.gov/0.4.
+
+  3. @SPECIAL-USE - Added the attribute @special-use to the
+     all 14 formatting (emphasis) elements. This includes all the
+     ones listed in 2. below as well as:
+       - sub             sub-atts  
+       - sup             sup-atts
+       - overline        overline-atts
+       - overline-start  overline-start-atts
+       - overline-end    overline-end-atts
+       - underline       underline-atts
+       - underline-start underline-start-atts
+       - underline-end   underline-end-atts
+
+  2. PEs FOR ATTLISTS - Added parameter entity redefinitions for the
+     attribute lists of the following elements: (no attributes or
+     values were changed)
+       - bold            bold-atts       NEW PE
+       - italic          italic-atts     NEW PE
+       - monospace       monospace-atts  NEW PE
+       - roman           roman-atts      NEW PE
+       - sans-serif      sans-serif-atts NEW PE
+       - sc              sc-atts         NEW PE
+       - strike          strike-atts     NEW PE
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    BOLD ATTRIBUTES                            -->
+<!--                    Attributes for the <bold> element          -->
+<!ENTITY % bold-atts
+            "%jats-common-atts;                                       
+             toggle     (yes | no)                        #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    BREAK ATTRIBUTES                           -->
+<!--                    Attributes for the <break> element         -->
+<!ENTITY % break-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    FIXED CASE ATTRIBUTES                      -->
+<!--                    Attributes for the <fixed-case> element    -->
+<!ENTITY % fixed-case-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    HORIZONTAL RULE ATTRIBUTES                 -->
+<!--                    Attributes for the <hr> element            -->
+<!ENTITY % hr-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    ITALIC ATTRIBUTES                          -->
+<!--                    Attributes for the <italic> element        -->
+<!ENTITY % italic-atts
+            "%jats-common-atts;                                       
+             toggle     (yes | no)                        'yes'
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    MONOSPACE ATTRIBUTES                       -->
+<!--                    Attributes for the <bold> element          -->
+<!ENTITY % monospace-atts
+            "%jats-common-atts;                                       
+             toggle     (yes | no)                        #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    OVERLINE START ATTRIBUTES                  -->
+<!--                    Attributes for the <overline> element      -->
+<!ENTITY % overline-atts
+            "%jats-common-atts;                                       
+             toggle     (yes | no)                        #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    OVERLINE START ATTRIBUTES                  -->
+<!--                    Attributes for the <overline-start> element-->
+<!ENTITY % overline-start-atts
+            "%jats-common-atts-id-required;                                       
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    OVERLINE END ATTRIBUTES                    -->
+<!--                    Attributes for the <overline-end> element  -->
+<!ENTITY % overline-end-atts
+            "%jats-common-atts;                                       
+             rid        IDREF                             #REQUIRED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    ROMAN ATTRIBUTES                           -->
+<!--                    Attributes for the <roman> element         -->
+<!ENTITY % roman-atts
+            "%jats-common-atts;                                       
+             toggle     (yes | no)                        'no'
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    RUBY BASE ATTRIBUTES                       -->
+<!--                    Attributes for the <rb> element            -->
+<!ENTITY % rb-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    RUBY PARENTHESIS ATTRIBUTES                -->
+<!--                    Attributes for the <rp> element            -->
+<!ENTITY % rp-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    RUBY TEXTUAL ANNOTATION ATTRIBUTES         -->
+<!--                    Attributes for the <rt> element            -->
+<!ENTITY % rt-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    RUBY ATTRIBUTES                            -->
+<!--                    Attributes for the <ruby> element          -->
+<!ENTITY % ruby-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    SANS SERIF ATTRIBUTES                      -->
+<!--                    Attributes for the <sans-serif> element    -->
+<!ENTITY % sans-serif-atts
+            "%jats-common-atts;                                       
+             toggle     (yes | no)                        #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    SMALL CAPS ATTRIBUTES                      -->
+<!--                    Attributes for the <sc> element            -->
+<!ENTITY % sc-atts
+            "%jats-common-atts;                                       
+             toggle     (yes | no)                        #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    STRIKE THROUGH ATTRIBUTES                  -->
+<!--                    Attributes for the <strike> element        -->
+<!ENTITY % strike-atts
+            "%jats-common-atts;                                       
+             toggle     (yes | no)                        #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    SUBSCRIPT ATTRIBUTES                       -->
+<!--                    Attributes for the subscript <sub> element -->
+<!ENTITY % sub-atts
+            "%jats-common-atts;                                       
+             arrange    (stack | stagger)                 #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    SUPERSCRIPT ATTRIBUTES                     -->
+<!--                    Attributes for the superscript <sup>
+                        element                                    -->
+<!ENTITY % sup-atts
+            "%jats-common-atts;                                       
+             arrange    (stack | stagger)                 #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    UNDERLINE ATTRIBUTES                       -->
+<!--                    Attributes for the <underline> element     -->
+<!ENTITY % underline-atts
+            "%jats-common-atts;                                       
+             toggle     (yes | no)                        #IMPLIED
+             underline-style
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    UNDERLINE START ATTRIBUTES                 -->
+<!--                    Attributes for the <underline-start>
+                        element                                    -->
+<!ENTITY % underline-start-atts
+            "%jats-common-atts-id-required;                                       
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    UNDERLINE END ATTRIBUTES                   -->
+<!--                    Attributes for the <underline-end> element -->
+<!ENTITY % underline-end-atts
+            "%jats-common-atts;                                       
+             rid        IDREF                             #REQUIRED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    APPEARANCE CLASS ELEMENTS                  -->
+<!-- ============================================================= -->
+
+
+<!--                    HORIZONTAL RULE                            -->
+<!--                    Defined to allow the user to specify an
+                        explicit (non machine-generated) rule.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=hr
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=hr
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=hr
+                                                                   -->
+<!ELEMENT  hr           EMPTY                                        >
+<!ATTLIST  hr 
+             %hr-atts;                                               >
+
+
+<!-- ============================================================= -->
+<!--                    BREAK CLASS ELEMENTS                       -->
+<!-- ============================================================= -->
+
+
+<!--                    LINE BREAK                                 -->
+<!--                    Defined to allow the user to specify an
+                        explicit (non machine-generated) line break.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=break
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=break
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=break
+                                                                   -->
+<!ELEMENT  break        EMPTY                                        >
+<!ATTLIST  break
+             %break-atts;                                            >
+
+
+<!-- ============================================================= -->
+<!--                    EMPHASIS/RENDITION CLASS ELEMENTS          -->
+<!-- ============================================================= -->
+
+
+<!--                    BOLD                                       -->
+<!--                    Used to mark text that should appear in bold
+                        face type for print or display
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=bold
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=bold
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=bold
+                                                                   -->
+<!ELEMENT  bold         (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  bold
+             %bold-atts;                                             >
+
+
+<!--                    FIXED CASE                                 -->
+<!--                    Used to mark text in which the case of the 
+                        content should not be changed, even if the 
+                        content around it is styled to all
+                        upper case or all lower. For example "PhD".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=fixed-case
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=fixed-case
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=fixed-case
+                                                                   -->
+<!ELEMENT  fixed-case   (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  fixed-case
+             %fixed-case-atts;                                       >
+
+
+<!--                    ITALIC                                     -->
+<!--                    Used to mark text that should appear in
+                        italic type on output.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=italic
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=italic
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=italic
+                                                                   -->
+<!ELEMENT  italic       (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  italic
+             %italic-atts;                                           >
+
+
+<!--                    MONOSPACE TEXT (TYPEWRITER TEXT)           -->
+<!--                    Used to mark text that should appear in
+                        a non-proportional font, such as courier
+                        for display or print.  This is common for
+                        computer code examples, man-machine
+                        dialogues, etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=monospace
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=monospace
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=monospace
+                                                                   -->
+<!ELEMENT  monospace    (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  monospace
+             %monospace-atts;                                        >
+
+
+<!--                    ROMAN                                      -->
+<!--                    Used to mark text that should remain in
+                        roman script no matter what style the
+                        surrounding text takes on.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=roman
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=roman
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=roman
+                                                                   -->
+<!ELEMENT  roman        (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  roman
+             %roman-atts;                                            >
+
+
+
+<!--                    SANS SERIF                                 -->
+<!--                    Used to mark text that should appear in a
+                        special sans-serif font, typically used in
+                        math or chemistry
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=sans-serif
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=sans-serif
+                                                                   -->
+<!ELEMENT  sans-serif   (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  sans-serif
+             %sans-serif-atts;                                       >
+
+
+<!--                    SMALL CAPS                                 -->
+<!--                    Used to mark text that should appear in a
+                        font which creates smaller capital letters
+                        on output.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=sc
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=sc
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=sc
+                                                                   -->
+<!ELEMENT  sc           (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  sc
+             %sc-atts;                                               >
+
+
+<!--                    OVERLINE                                   -->
+<!--                    Used to mark text that should appear with a
+                        horizontal line above each character in
+                        display or print. There is no PE for
+                        override because this was added to handle
+                        a specific publisher tag set and should not
+                        grow beyond what they need.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=overline
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=overline
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=overline
+                                                                   -->
+<!ELEMENT  overline     (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  overline
+             %overline-atts;                                         >
+
+
+<!--                    STRIKE THROUGH                             -->
+<!--                    Used to mark text that should appear with
+                        a line through it so as to appear "struck out"
+                        on display or print
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=strike
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=strike
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=strike
+                                                                   -->
+<!ELEMENT  strike       (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  strike
+             %strike-atts;                                           >
+
+
+<!--                    SUBSCRIPT                                  -->
+<!--                    A number or expression that is set lower
+                        than the baseline and slightly smaller,
+                        to act as an inferior or subscript
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=sub
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=sub
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=sub
+                                                                   -->
+<!ELEMENT  sub          (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  sub
+             %sub-atts;                                              >
+
+
+<!--                    SUPERSCRIPT                                -->
+<!--                    A number or expression that is set higher
+                        than the baseline and slightly smaller,
+                        to act as a superior or superscript
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=sup
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=sup
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=sup
+                                                                   -->
+<!ELEMENT  sup          (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  sup
+             %sup-atts;                                              >
+
+
+<!--                    UNDERLINE                                  -->
+<!--                    Used to mark text that should appear with a
+                        horizontal line below each character in
+                        display or print.
+                        Details at:
+                         http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=underline
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=underline
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=underline
+                                                                   -->
+<!ELEMENT  underline    (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  underline
+             %underline-atts;                                        >
+
+
+<!-- ============================================================= -->
+<!--                    ADVANCED UNDERLINE AND OVERLINE ELEMENTS
+                        (From the Elsevier DTD, used mostly within
+                        mathematics, when ordinary MathML underline
+                        and overline functions are inadequate. The
+                        elements act as milestone tags marking the
+                        start and end of over or underlining that
+                        may extend across element boundaries.)     -->
+<!-- ============================================================= -->
+
+
+<!--                    OVERLINE START                             -->
+<!--                    The start of a milestone-created overline, the
+                        end of ornament will be marked by an
+                        Overline End element.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=overline-start
+                                                                   -->
+<!ELEMENT  overline-start
+                        EMPTY                                        >
+<!ATTLIST  overline-start
+             %overline-start-atts;                                   >
+
+
+<!--                    OVERLINE END                               -->
+<!--                    The end of a milestone-created overline, the
+                        start of ornament will be marked by an
+                        Overline Start element.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=overline-end
+                                                                   -->
+<!ELEMENT  overline-end EMPTY                                        >
+<!ATTLIST  overline-end
+             %overline-end-atts;                                     >
+
+
+<!--                    UNDERLINE START                            -->
+<!--                    The start of a milestone-created underline,
+                        the end of ornament will be marked by an
+                        Underline End element
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=underline-start
+                                                                   -->
+<!ELEMENT  underline-start
+                        EMPTY                                        >
+<!ATTLIST  underline-start
+             %underline-start-atts;                                  >
+
+
+<!--                    UNDERLINE END                              -->
+<!--                    The end of a milestone-created underline, the
+                        start of ornament will be marked by an
+                        Underline Start element.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=underline-end
+                                                                   -->
+<!ELEMENT  underline-end
+                        EMPTY                                        >
+<!ATTLIST  underline-end
+             %underline-end-atts;                                    >
+
+
+<!-- ============================================================= -->
+<!--                    RUBY MARKUP                                -->
+<!-- ============================================================= -->
+
+
+<!--                    RUBY WRAPPER Model                         -->
+<!--                    Content model for the <ruby> element       -->
+<!ENTITY % ruby-model   "(rb, rt)"                                   >
+
+
+<!--                    RUBY WRAPPER                               -->
+<!--                    A Ruby textual annotation is an annotation,
+                        typically short, applied to a letter, word,
+                        phrase, or name that appears in the narrative
+                        text. Ruby annotations can indicate,
+                        for example, pronunciation advice, notes for 
+                        translation, semantic annotations, et al.
+                          The <ruby> element is an inline wrapper  
+                        element that contains some of the document 
+                        narrative text (inside a Ruby Base <rb> 
+                        element) and one or more Ruby textual 
+                        annotations (inside <rt> elements) that are
+                        associated with the base text.
+                          In display or print, the characters of the
+                        Ruby annotation are frequently placed above 
+                        the characters they modify, in parenthesis 
+                        after the characters they modify, or to the
+                        right of vertically set text.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=ruby
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=ruby
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=ruby
+                                                                   -->
+<!ELEMENT  ruby         %ruby-model;                                 >
+<!ATTLIST  ruby
+             %ruby-atts;                                             >
+
+
+<!--                    RUBY BASE ELEMENTS                         -->
+<!--                    Those elements that may mix with the data
+                        characters inside a Ruby Base <rb>.        -->
+<!ENTITY % rb-elements  "| %face-markup.class;"                      >
+
+
+<!--                    RUBY BASE                                  -->
+<!--                    The <rb> element is one half of a Ruby 
+                        Annotation <ruby>, and it contains the 
+                        narrative text to which a Ruby textual 
+                        annotation <rt> should be applied.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=rb
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=rb
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=rb
+                                                                   -->
+<!ELEMENT  rb           (#PCDATA %rb-elements;)*                     >
+<!ATTLIST  rb
+             %rb-atts;                                               >
+
+
+<!--                    RUBY TEXTUAL ANNOTATION ELEMENTS           -->
+<!--                    Those elements that may mix with the data
+                        characters inside a Ruby Textual Annotation
+                        <rt>.                                      -->
+<!ENTITY % rt-elements  ""                                           >
+
+
+<!--                    RUBY TEXTUAL ANNOTATION                    -->
+<!--                    The <rt> element is one half of a Ruby 
+                        Annotation <ruby>, and it contains the 
+                        Ruby textual annotation that is applied to
+                        the Ruby Base text <rb>.
+                        Details at:
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=rt
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=rt
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=rt
+                                                                   -->
+<!ELEMENT  rt           (#PCDATA %rt-elements;)*                     >
+<!ATTLIST  rt
+             %rt-atts;                                               >
+
+
+
+<!--                    RUBY PARENTHESIS                           -->
+<!--                    The <rp> element is an optional element used
+                        to provide spacing and a parenthesis to 
+                        surround Ruby Text <rt>, for older systems 
+                        that do not handle Ruby properly.
+                        Remarks. This optional element never holds
+                        any text except a space, an open 
+                        parenthesis, or a close parenthesis:
+                          <ruby><rb>text</rb>
+                          <rp> (</rp><rt>annotation</rt><rp>) </rp>
+                          </ruby>
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=rp
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=rp
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=rp
+                                                                   -->
+<!ELEMENT  rp           (#PCDATA)                                    >
+<!ATTLIST  rp
+             %rp-atts;                                               >
+
+
+<!-- ================== End Format Class Module ================== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-funding1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-funding1.ent
@@ -1,0 +1,963 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Funding Elements                                  -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Funding Elements v1.2 20190208//EN"
+     Delivered as file "JATS-funding1.ent"                         -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Defines the elements which describe funding for   -->
+<!--             the research reported in a work or the open       -->
+<!--             access funding for the work                       -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             February 2008                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 21. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 20. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 19. NON-MONETARY SUPPORT - Previous support descriptions in JATS
+     used the <funding-group> element, which could only be used to
+     describe monetary support for the research described in the
+     article.
+       Added new element <contributed-resource-group> to hold 
+     descriptions of non-monetary support (such as data, facilities, 
+     or any in-kind support) for the research described in the
+     article.
+     
+     This changed the JATS models in several ways:
+      - Inside <article-meta>, added a new element <support-group>
+        to hold both <funding-group> and <contributed-resource-group>.
+        For backwards compatibility, <support-group> is a 
+        peer to <funding-group> inside <article-meta>, and (as the 
+        path going forward) <support-group> also contains 
+        <funding-group> as a child.
+      - New elements inside <contributed-resource-group> (as its 
+        children or descendants) include:
+          - support-description
+          - resource-group
+          - resource-name
+          - resource-wrap
+          - resource-id
+      - Inside <award-group>, added a new element <support-source>
+        to describe the source of a non-monetary award. The
+        element <support-source> is as an alternative to 
+        <funding-source> (which describes the source of a monetary
+        award).  
+         
+ 18. AWARD ID ATTRIBUTES - Made the award-id attributes match 
+     Green and BITS, adding @award-type and the might link
+     attributes.
+ 
+ 17. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 16. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+ 15. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 14. JATS became version "1.1" and "v1.1 20151215"
+
+      =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 13. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  12. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 11. INSTITUTION WRAP ADDED
+     Added the elements <institution-wrap> to the following elements
+     through the institution-wrap.class:
+      - funding-source
+
+ 10. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  9. PRINCIPAL-AWARD-RECIPIENT MODEL - Added "contrib-id.class" to 
+     the <principal-award-recipient> through 
+     principal-award-recipient-elements, to hold identifiers for 
+     people, such as publishers-specific IDs, ORCIDs, etc..
+
+  8. PRINCIPAL INVESTIGATOR MODEL - Added "contrib-id.class" to 
+     the <principal-investigator> through 
+     principal-investigator-elements, to hold identifiers for 
+     people, such as publishers-specific IDs, ORCIDs, etc..
+   
+  7. Updated the public identifier to "v1.0 20120330//EN", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "1".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  6. Updated the DTD-version attribute to "0.4" 
+   
+  5. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+           http://jats.nlm.nih.gov/0.4.
+
+  4. FUNDING GROUP- Allowed <open-access> to repeat within
+     <funding-group>
+
+  3. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+
+      - award-group through award-group-atts (both)
+      - award-id through award-id-atts (both)
+      - funding-group through funding-group-atts (both) NEW PE
+      - funding-source through funding-source-atts (both)
+      - funding-statement through funding-statement-atts (both)
+      - open-access through open-access-atts (both) NEW PE
+      - principal-award-recipient through
+          principal-award-recipient-atts (both) NEW PE
+      - principal-investigator through principal-investigator-atts
+          (both) NEW PE
+
+  2. OPEN ACCESS MODEL - Changed the model from
+         "(p+)"
+     to
+          "(%just-para.class;+)"
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    AWARD GROUP ATTRIBUTES                     -->
+<!--                    Attributes for the <award-group> element   -->
+<!ENTITY % award-group-atts
+            "%jats-common-atts;                                       
+             rid        IDREFS                            #IMPLIED
+             award-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    AWARD IDENTIFIER ATTRIBUTES                -->
+<!--                    Attributes for the <award-id> element      -->
+<!ENTITY % award-id-atts
+            "%jats-common-atts;                                       
+             rid        IDREFS                            #IMPLIED
+             award-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    CONTRIBUTED RESOURCE GROUP ATTRIBUTES      -->
+<!--                    Attributes for the 
+                        <contributed-resource-group> element       -->
+<!ENTITY % contributed-resource-group-atts
+            "%jats-common-atts;
+             resource-type
+                        CDATA                             #IMPLIED                                       
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    FUNDING GROUP ATTRIBUTES                   -->
+<!--                    Attributes for the <funding-group>
+                        element                                    -->
+<!ENTITY % funding-group-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    FUNDING SOURCE ATTRIBUTES                  -->
+<!--                    Attributes for the <funding-source> element-->
+<!ENTITY % funding-source-atts
+            "%jats-common-atts;                                       
+             rid        IDREFS                            #IMPLIED
+             source-type
+                        CDATA                             #IMPLIED
+             country    CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    FUNDING STATEMENT ATTRIBUTES               -->
+<!--                    Attributes for the <funding-statement>
+                        element                                    -->
+<!ENTITY % funding-statement-atts
+            "%jats-common-atts;                                       
+             rid        IDREFS                            #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    OPEN ACCESS ATTRIBUTES                     -->
+<!--                    Attributes for the <open-access>
+                        element                                    -->
+<!ENTITY % open-access-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PRINCIPAL AWARD RECIPIENT ATTRIBUTES       -->
+<!--                    Attributes for the <principal-award-recipient>
+                        element                                    -->
+<!ENTITY % principal-award-recipient-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PRINCIPAL INVESTIGATOR ATTRIBUTES          -->
+<!--                    Attributes for the <principal-investigator>
+                        element                                    -->
+<!ENTITY % principal-investigator-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    RESOURCE GROUP ATTRIBUTES                  -->
+<!--                    Attributes for the <resource-group>
+                        element                                    -->
+<!ENTITY % resource-group-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+
+<!--                    RESOURCE WRAPPER ATTRIBUTES                -->
+<!--                    Attributes for the <institution-wrap>
+                        element                                    -->
+<!ENTITY % resource-wrap-atts
+            "%jats-common-atts;"                                     >                                        
+
+
+<!--                    RESOURCE IDENTIFIER ATTRIBUTES             -->
+<!--                    Attribute list for <resource-id>           -->
+<!ENTITY % resource-id-atts
+            "%jats-common-atts;                                        
+             resource-id-type
+                        CDATA                             #IMPLIED
+             vocab      CDATA                             #IMPLIED
+             vocab-identifier
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    RESOURCE NAME ATTRIBUTES                   -->
+<!--                    Attribute list for <resource-name>         -->
+<!ENTITY % resource-name-atts
+            "%jats-common-atts;
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    SUPPORT DESCRIPTION ATTRIBUTES             -->
+<!--                    Attributes for the <support-description>
+                        element                                    -->
+<!ENTITY % support-description-atts
+            "%jats-common-atts;                                       
+             rid        IDREFS                            #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SUPPORT GROUP ATTRIBUTES                   -->
+<!--                    Attributes for the <support-group>
+                        element                                    -->
+<!ENTITY % support-group-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SUPPORT SOURCE ATTRIBUTES                  -->
+<!--                    Attributes for the <support-source> element-->
+<!ENTITY % support-source-atts
+            "%jats-common-atts;                                       
+             rid        IDREFS                            #IMPLIED
+             support-type
+                        CDATA                             #IMPLIED
+             country    CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!-- ============================================================= -->
+<!--                    FUNDING ELEMENTS                           -->
+<!-- ============================================================= -->
+
+
+<!--                    FUNDING GROUP MODEL                        -->
+<!--                    Model for the <funding-group> element      -->
+<!ENTITY % funding-group-model
+                        "(award-group*, funding-statement*,
+                         open-access*)"                              >
+
+
+<!--                    FUNDING GROUP                              -->
+<!--                    Container element for information concerning
+                        grants, contracts, sponsors, or other
+                        funding for the research reported in the
+                        work (typically an article), as well as for
+                        material on the open access funding for the
+                        work, for example, which model of open access
+                        funding was used or who paid the open access
+                        charges.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=funding-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=funding-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=funding-group
+                                                                   -->
+<!ELEMENT  funding-group
+                        %funding-group-model;                        >
+<!ATTLIST  funding-group
+             %funding-group-atts;                                    >
+
+
+<!--                    FUNDING STATEMENT ELEMENTS                 -->
+<!--                    Elements that may be mixed with text inside  
+                        the <funding-statement> element            -->
+<!ENTITY % funding-statement-elements
+                        "| %address-link.class; | %emphasis.class; |
+                         %phrase-content.class; |
+                         %subsup.class;"                             >
+
+
+<!--                    FUNDING STATEMENT                          -->
+<!--                    A displayable prose statement that describes
+                        the funding for the research on which a work
+                        was based. Such a statement is required, for
+                        example, by research funded in whole or part
+                        by the Wellcome Trust. The statement may
+                        mention (and therefore repeat) the funding
+                        source, PI, or other funding information.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=funding-statement
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=funding-statement
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=funding-statement
+                                                                   -->
+<!ELEMENT  funding-statement
+                        (#PCDATA %funding-statement-elements;)*      >
+<!ATTLIST  funding-statement
+             %funding-statement-atts;                                >
+
+
+<!--                    OPEN ACCESS MODEL                          -->
+<!--                    Model for the <open-access> element        -->
+<!ENTITY % open-access-model
+                        "((%just-para.class;)+)"                     >
+
+
+<!--                    OPEN ACCESS                                -->
+<!--                    A container element to hold metadata
+                        concerning the open access provisions that
+                        apply to a work, for example which model
+                        of charging was used or who paid the open
+                        access charges for a journal article.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=open-access
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=open-access
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=open-access
+                                                                   -->
+<!ELEMENT  open-access  %open-access-model;                          >
+<!ATTLIST  open-access
+             %open-access-atts;                                      >
+
+
+<!-- ============================================================= -->
+<!--                    NON-MONETARY SUPPORT ELEMENTS              -->
+<!-- ============================================================= -->
+
+
+<!--                    SUPPORT GROUP MODEL                        -->
+<!--                    Model for the <support-group> element      -->
+<!ENTITY % support-group-model
+                        "(funding-group*, 
+                          contributed-resource-group*)"              >
+
+
+<!--                    SUPPORT GROUP                              -->
+<!--                    Container element for information concerning
+                        both funding and non-monetary support for the 
+                        research reported in the work (typically an 
+                        article). This includes both monetary awards,
+                        grants,investigators, etc. but also facilities
+                        computer resources, data acquisition or 
+                        donation, and other non-monetary support 
+                        (including in-kind support).
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=support-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=support-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=support-group
+                                                                   -->
+<!ELEMENT  support-group
+                        %support-group-model;                        >
+<!ATTLIST  support-group
+             %support-group-atts;                                    >
+
+
+<!--                    CONTRIBUTED RESOURCE GROUP MODEL           -->
+<!--                    Model for the <contributed-resource-group> 
+                        element                                    -->
+<!ENTITY % contributed-resource-group-model
+                        "(award-group*, support-description*, 
+                          resource-group*)"                          >
+
+
+<!--                    CONTRIBUTED RESOURCE GROUP                 -->
+<!--                    Container element for information concerning
+                        non-financial support for the research 
+                        reported in the work (typically an article). 
+                        This may include awards and investigators, 
+                        but also facilities, computer resources, data 
+                        acquisition or donation, and other 
+                        non-monetary support (including in-kind 
+                        support).
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=contributed-resource-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=contributed-resource-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=contributed-resource-group
+                                                                   -->
+<!ELEMENT  contributed-resource-group
+                        %contributed-resource-group-model;           >
+<!ATTLIST  contributed-resource-group
+             %contributed-resource-group-atts;                       >
+
+
+<!--                    SUPPORT DESCRIPTION ELEMENTS               -->
+<!--                    Model for the <support-description> element-->
+<!ENTITY % support-description-model
+                        "(p+)"                                       >
+
+
+<!--                    SUPPORT DESCRIPTION                        -->
+<!--                    A displayable prose statement that describes
+                        the non-financial support given for the 
+                        research on which a work was based. 
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=support-description
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=support-description
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=support-description
+                                                                   -->
+<!ELEMENT  support-description
+                        (%support-description-model;)                >
+<!ATTLIST  support-description
+             %support-description-atts;                              >
+
+
+<!--                    RESOURCE GROUP MODEL                       -->
+<!--                    Model for the <resource-group> element     -->
+<!ENTITY % resource-group-model
+                        "((resource-name | resource-wrap)+)"         >
+
+
+<!--                    RESOURCE GROUP                             -->
+<!--                    Container element to hold the descriptions of
+                        specific resources supplied in the 
+                        non-financial support of the work described 
+                        in this article.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=resource-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=resource-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=resource-group
+                                                                   -->
+<!ELEMENT  resource-group
+                        %resource-group-model;                       >
+<!ATTLIST  resource-group
+             %resource-group-atts;                                   >
+
+
+<!--                    RESOURCE WRAP MODEL                        -->
+<!--                    Model for the <resource-wrap> element      -->
+<!ENTITY % resource-wrap-model
+                        "(resource-name, resource-id*)"              >
+
+
+<!--                    RESOURCE WRAP                              -->
+<!--                    A wrapper element to hold together the name 
+                        of an resource (<resource-name>) and one or 
+                        more external identifiers for that resource 
+                        (<resource-id>, for example a Research 
+                        Resource Identifier).
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=resource-wrap
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=resource-wrap
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=resource-wrap
+                                                                   -->
+<!ELEMENT  resource-wrap
+                        %resource-wrap-model;                        >
+<!ATTLIST  resource-wrap
+             %resource-wrap-atts;                                    >
+
+
+<!--                    RESOURCE NAME MODEL                        -->
+<!--                    Elements that may be mixed with text inside  
+                        the <resource-name> element                -->
+<!ENTITY % resource-name-elements
+                        " | %face-markup.class; | %subsup.class;"    >
+
+
+<!--                    RESOURCE NAME                              -->
+<!--                    A displayable name of or description for a 
+                        specific resource provided in support of the 
+                        work described in this article.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=resource-name
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=resource-name
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=resource-name
+                                                                   -->
+<!ELEMENT  resource-name
+                        (#PCDATA %resource-name-elements;)*          >
+<!ATTLIST  resource-name
+             %resource-name-atts;                                    >
+
+
+<!--                    RESOURCE IDENTIFIER MODEL                  -->
+<!--                    Elements that may be mixed with text inside  
+                        the <resource-id> element                  -->
+<!ENTITY % resource-id-elements
+                        ""                                           >
+
+
+<!--                    RESOURCE IDENTIFIER                        -->
+<!--                    An external, ideally machine-readable, 
+                        identifier such as a Research Resource 
+                        Identifier, for a specific resource provided
+                        in support of the work described in this 
+                        article.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=resource-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=resource-id
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=resource-id
+                                                                   -->
+<!ELEMENT  resource-id
+                        (#PCDATA %resource-id-elements;)*            >
+<!ATTLIST  resource-id
+             %resource-id-atts;                                      >
+
+
+<!-- ============================================================= -->
+<!--                    AWARD GROUP ELEMENTS                       -->
+<!-- ============================================================= -->
+
+
+<!--                    AWARD GROUP MODEL                          -->
+<!--                    Model for the <award-group> element        -->
+<!ENTITY % award-group-model
+                        "((funding-source* | support-source*), 
+                          award-id*,
+                          principal-award-recipient*,
+                          principal-investigator*)"                  >
+
+
+<!--                    AWARD GROUP                                -->
+<!--                    Container element for information concerning
+                        one award that sponsored a work or the
+                        research on which the work was based. There
+                        may be more than source of funding, a grant
+                        or contract number, PI, etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=award-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=award-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=award-group
+                                                                   -->
+<!ELEMENT  award-group  %award-group-model;                          >
+<!ATTLIST  award-group
+             %award-group-atts;                                      >
+
+
+<!--                    FUNDING SOURCE ELEMENTS                    -->
+<!--                    Elements that may be mixed with text inside  
+                        the <funding-source> element               -->
+<!ENTITY % funding-source-elements
+                        "%simple-text; | %institution-wrap.class;"   >
+
+
+<!--                    FUNDING SOURCE                             -->
+<!--                    Agency or organization (such as a foundation,
+                        corporation, or an educational institution)
+                        that funded the research on which a work was
+                        based, for example, the Wellcome Trust, NIH,
+                        HHS, Princeton University, or Alcoa
+                        sponsoring the research for a journal
+                        article
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=funding-source
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=funding-source
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=funding-source
+                                                                   -->
+<!ELEMENT  funding-source
+                        (#PCDATA %funding-source-elements;)*         >
+<!ATTLIST  funding-source
+             %funding-source-atts;                                   >
+
+
+<!--                    AWARD IDENTIFIER ELEMENTS                  -->
+<!--                    Elements that may be mixed with text inside  
+                        the <award-id> element                     -->
+<!ENTITY % award-id-elements
+                        "%simple-text;"                              >
+
+
+<!--                    AWARD IDENTIFIER                           -->
+<!--                    An identifier that has been assigned to the
+                        award, for example, a grant number, a grant
+                        reference number, or a contract number.
+                        [Note, this is a real-world identifier not
+                        an XML ID.]
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=award-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=award-id
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=award-id
+                                                                   -->
+<!ELEMENT  award-id     (#PCDATA %award-id-elements;)*               >
+<!ATTLIST  award-id
+             %award-id-atts;                                         >
+
+
+<!--                    PRINCIPAL AWARD RECIPIENT ELEMENTS         -->
+<!--                    Elements that may be mixed with text inside  
+                        the <principal-award-recipient> element    -->
+<!ENTITY % principal-award-recipient-elements
+                        " | %contrib-id.class; | 
+                         %recipient-name.class;"                     >
+
+
+<!--                    PRINCIPAL AWARD RECIPIENT                  -->
+<!--                    The institution or individuals to whom the
+                        award was given, for example the principal
+                        grant holder
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=principal-award-recipient
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=principal-award-recipient
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=principal-award-recipient
+                                                                   -->
+<!ELEMENT  principal-award-recipient
+                        (#PCDATA
+                         %principal-award-recipient-elements;)*      >
+<!ATTLIST  principal-award-recipient
+             %principal-award-recipient-atts;                        >
+
+
+<!--                    PRINCIPAL INVESTIGATOR ELEMENTS            -->
+<!--                    Elements that may be mixed with text inside  
+                        the <principal-investigator> element       -->
+<!ENTITY % principal-investigator-elements
+                        " | %contrib-id.class; | 
+                         %investigator-name.class;"                  >
+
+
+<!--                    PRINCIPAL INVESTIGATOR RECIPIENT           -->
+<!--                    Individual responsible for the intellectual
+                        content of the work reported in the article.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=principal-investigator
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=principal-investigator
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=principal-investigator
+                                                                   -->
+<!ELEMENT  principal-investigator
+                        (#PCDATA
+                         %principal-investigator-elements;)*         >
+<!ATTLIST  principal-investigator
+             %principal-investigator-atts;                           >
+
+
+
+<!--                    SUPPORT SOURCE ELEMENTS                    -->
+<!--                    Elements that may be mixed with text inside  
+                        the  <support-source> element              -->
+<!ENTITY % support-source-elements
+                        "%simple-text; | %institution-wrap.class;"   >
+
+
+<!--                    SUPPORT SOURCE                             -->
+<!--                    Agency or organization (such as a foundation,
+                        corporation, or an educational institution)
+                        that provided non-monetary support (such as
+                        facilities or data) in support of the
+                        research on which a work was based.
+                        article
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=support-source
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=support-source
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=support-source
+                                                                   -->
+<!ELEMENT  support-source
+                        (#PCDATA %support-source-elements;)*         >
+<!ATTLIST  support-source
+             %support-source-atts;                                   >
+
+<!-- ================== End Funding Module ======================= -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-journalmeta1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-journalmeta1.ent
@@ -1,0 +1,540 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Journal Metadata Elements                         -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Journal Metadata Elements v1.2 20190208//EN"
+     Delivered as file "JATS-journalmeta1.ent"                     -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Names all elements used to describe the journal   -->
+<!--             in which the journal article is published.        -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 18. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 17. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+ 16. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 15. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+ 14. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 13. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 12. JATS became version "1.1d3" and "v1.1d3 20150301"
+  
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  11. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+ 
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 10. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added a new attribute list to:
+      - journal-meta
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  9. JOURNAL METADATA MODEL
+     - Added <issn-l> as an optional element to <journal-meta>
+     - Added contributors and affiliations to journal metadata through
+       contrib-group.class (which resolves to <contrib-group>) and 
+       aff-alternatives.class (which resolves to <aff> or
+       <aff-alternatives>), using the journal-meta-model.
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  8. Updated the DTD-version attribute to "0.4" 
+   
+  7. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  6. I18N - Changed the default for @xml:lang from "en" to
+     #IMPLIED, so that the @xml:lang would inherit properly and
+     not need to be over-ridden in
+      - <abbrev-journal-title> through %abbrev-journal-title-atts;
+      - <journal-title> through %journal-title-atts;
+      - <journal-subtitle> through %journal-subtitle-atts;
+
+  5. JOURNAL METADATA- Added <notes> to repeat within <journal-meta>
+     (through %journal-meta-model; and added @xml:lang and
+     @specific-use to the attributes of <notes> through %notes-atts;
+
+  4. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+      - abbrev-journal-title through abbrev-journal-title-atts
+          (@specific-use-only; @xml:lang already)
+      - journal-title through journal-title-atts
+          (@specific-use-only;
+      - journal-subtitle through journal-subtitle-atts
+          (@specific-use-only)
+
+  3. JOURNAL TITLE ELEMENTS - Removed the dependency which had both
+     <journal-title> and <journal-subtitle> modeled with the same
+     parameter entity %journal-title-elements;. Created new PE for
+     %journal-subtitle-elements; but set it (as the default) to
+     %journal-title-elements; so that no customization would break.
+
+  2. SELF URI - Added <self-uri> to <journal-meta> (directly
+     following <notes>) so that an XML document can point to the
+     journal home page.
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  2. Changed default @xml:lang from "EN" from "en" to match latest
+     RFC 4646/W3C/IANA Subtag Registry recommendations
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    DEFAULTS FOR ATTRIBUTE LISTS               -->
+<!-- ============================================================= -->
+
+<!--                    ABBREVIATED JOURNAL TITLE ATTRIBUTES       -->
+<!--                    Attribute list for Abbreviated Journal Title
+                        <abbrev-journal-title> element             -->
+<!ENTITY % abbrev-journal-title-atts
+            "%jats-common-atts;                                       
+             abbrev-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    JOURNAL METADATA ATTRIBUTES                -->
+<!--                    Attributes for the <journal-meta>
+                        element                                    -->
+<!ENTITY % journal-meta-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    JOURNAL TITLE ATTRIBUTES                   -->
+<!--                    Attributes for the <journal-title>
+                        element                                    -->
+<!ENTITY % journal-title-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    JOURNAL TITLE GROUP ATTRIBUTES             -->
+<!--                    Attributes for the <journal-title-group>
+                        element                                    -->
+<!ENTITY % journal-title-group-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                              #IMPLIED" >
+
+
+<!--                    JOURNAL SUBTITLE GROUP ATTRIBUTES          -->
+<!--                    Attributes for the <journal-subtitle>
+                        element                                    -->
+<!ENTITY % journal-subtitle-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                              #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang  NMTOKEN                            #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    JOURNAL METADATA                           -->
+<!-- ============================================================= -->
+
+
+<!--                    JOURNAL METADATA MODEL                     -->
+<!--                    Content model for the journal metadata
+                        element <journal-meta>                     -->
+<!ENTITY % journal-meta-model
+                        "(journal-id*, journal-title-group*,
+                          (%contrib-group.class; |
+                          %aff-alternatives.class;)*,
+                          issn*, issn-l?, isbn*, 
+                          publisher?, notes*, self-uri*,
+                          custom-meta-group?)"                       >
+
+
+<!--ELEM   journal-id   Defined in %common.ent;                    -->
+<!--ELEM   issn         Defined in %common.ent;                    -->
+<!--ELEM   issn-l       Defined in %common.ent;                    -->
+<!--ELEM   publisher    Defined in %common.ent;                    -->
+<!--ELEM   notes        Defined in %common.ent;                    -->
+<!--ELEM   custom-meta-group
+                        Defined in %common.ent;                    -->
+
+
+<!--                    JOURNAL METADATA                           -->
+<!--                    Metadata that identifies the journal in which
+                        the article was published
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=journal-meta
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=journal-meta
+                                                                   -->
+<!ELEMENT  journal-meta %journal-meta-model;                         >
+<!ATTLIST  journal-meta
+             %journal-meta-atts;                                     >
+
+
+<!-- ============================================================= -->
+<!--                    JOURNAL TITLE ELEMENTS                     -->
+<!-- ============================================================= -->
+
+
+<!--                    JOURNAL TITLE GROUP MODEL                  -->
+<!--                    Content model for the element
+                        <journal-title-group>                      -->
+<!ENTITY % journal-title-group-model
+                        "(journal-title*, journal-subtitle*,
+                          trans-title-group*, abbrev-journal-title*)">
+
+
+<!--ELEM   trans-title-group
+                        Defined in %common.ent;                    -->
+
+
+<!--                    JOURNAL TITLE GROUP                        -->
+<!--                    A container element to hold the title and
+                        its subtitle (if any) for the journal in which
+                        the article was published.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=journal-title-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=journal-title-group
+                                                                   -->
+<!ELEMENT  journal-title-group
+                        %journal-title-group-model;                  >
+<!ATTLIST  journal-title-group
+             %journal-title-group-atts;                              >
+
+
+<!--                    JOURNAL TITLE ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <journal-title>
+                        Design Note: This PE begins with an OR
+                        bar because %just-rendition; begins with an
+                        OR bar.                                    -->
+<!ENTITY % journal-title-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    JOURNAL TITLE (FULL)                       -->
+<!--                    The title of the journal in which the
+                        article is published.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=journal-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=journal-title
+                                                                   -->
+<!ELEMENT  journal-title
+                        (#PCDATA %journal-title-elements;)*          >
+<!ATTLIST  journal-title
+             %journal-title-atts;                                    >
+
+
+<!--                    JOURNAL SUBTITLE ELEMENTS                  -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <journal-subtitle>                       -->
+<!ENTITY % journal-subtitle-elements
+                        "%journal-title-elements;"                   >
+
+
+<!--                    JOURNAL SUBTITLE                           -->
+<!--                    The subtitle of the journal in which the
+                        article is published.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=journal-subtitle
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=journal-subtitle
+                                                                   -->
+<!ELEMENT  journal-subtitle
+                        (#PCDATA %journal-subtitle-elements;)*       >
+<!ATTLIST  journal-subtitle
+             %journal-subtitle-atts;                                 >
+
+
+<!--                    ABBREVIATED JOURNAL TITLE ELEMENTS         -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <abbrev-journal-title>
+                        Design Note: This PE begins with an OR
+                        bar because %just-rendition; begins with an
+                        OR bar.                                    -->
+<!ENTITY % abbrev-journal-title-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    ABBREVIATED JOURNAL TITLE                  -->
+<!--                    A short form of the title of the journal
+                        in which the article is published.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=abbrev-journal-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=abbrev-journal-title
+                                                                   -->
+<!ELEMENT  abbrev-journal-title
+                        (#PCDATA %abbrev-journal-title-elements;)*   >
+<!ATTLIST  abbrev-journal-title
+             %abbrev-journal-title-atts;                             >
+
+
+<!-- ================== End Journal Metadata Elements  =========== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-link1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-link1.ent
@@ -1,0 +1,511 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Link Element Classes                              -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Link Class Elements v1.2 20190208//EN"
+     Delivered as file "JATS-link1.ent"                            -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Names all elements in the link class. These are   -->
+<!--             elements that are links (internal or external)    -->
+<!--             by definition, such as URLs <uri> and             -->
+<!--             Cross(X)-references <xref>.                       -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd) 
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 17. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 16. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 15. XREF - Changed @ref-type from CDATA back to a fixed 
+     value list, reversing what was done in version 1.2d1.
+     Added new values "award" and "bio".
+
+ 14. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 13. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+     
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+ 12. XREF - Changed @ref-type from a fixed value list to CDATA
+ 
+ 11. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+      =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 10. JATS became version "1.1" and "v1.1 20151215"
+
+    =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  9. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  8. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+  7. REFERENCE TYPES
+      - Added "collab"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+           http://jats.nlm.nih.gov/1.1/
+
+  6. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  5. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  4. Updated the DTD-version attribute to "0.4" 
+   
+  3. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  2. ACCESSIBILITY - Added @alt to <xref> through %xref-atts;
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    DEFAULTS FOR ATTRIBUTE VALUES              -->
+<!-- ============================================================= -->
+
+
+<!--                    DEFAULT TYPE OF CROSS(X)-REFERENCE         -->
+<!--                    Used to say to what the reference is pointing.
+                        May be used for type-specific processing or
+                        validation. Values are, for example:
+                        Affiliation "aff" and Figure "fig", and
+                        Bibliographic ref (to a citation.          -->
+<!ENTITY % ref-types    "aff | app | author-notes | award | 
+                         bibr | bio | boxed-text | 
+                         chem | collab | contrib | corresp |
+                         disp-formula | fig | fn | kwd | list |
+                         plate | scheme | sec | statement |
+                         supplementary-material |
+                         table | table-fn |
+                         other"                                      >
+
+
+<!-- ============================================================= -->
+<!--                    DEFAULTS FOR ATTRIBUTE LISTS               -->
+<!-- ============================================================= -->
+
+
+<!--                    FOOTNOTE ATTRIBUTES                        -->
+<!--                    Attribute list for Footnote element        -->
+<!ENTITY % fn-atts
+            "%jats-common-atts;                                       
+             symbol     CDATA                             #IMPLIED
+             fn-type    CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    INLINE SUPPLEMENTARY MATERIAL              -->
+<!--                    Attribute list for inline supplementary
+                        material                                   -->
+<!ENTITY % inline-supplementary-material-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             mimetype   CDATA                             #IMPLIED
+             mime-subtype
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    TARGET ATTRIBUTES                          -->
+<!--                    Attribute list for <target> element        -->
+<!ENTITY % target-atts
+            "%jats-common-atts-id-required;                                       
+             target-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    X(CROSS) REFERENCE ATTRIBUTES              -->
+<!--                    Attribute list for cross references        -->
+<!ENTITY % xref-atts
+            "%jats-common-atts;                                       
+             alt        CDATA                             #IMPLIED
+             ref-type   (%ref-types;)                     #IMPLIED
+             rid        IDREFS                            #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    INTERNAL LINKS                             -->
+<!-- ============================================================= -->
+
+
+<!--                    FOOTNOTE MODEL                             -->
+<!--                    Content model for Footnote <fn>            -->
+<!ENTITY % fn-model     "(label?, (%just-para.class;)+ )"            >
+
+
+<!--                    FOOTNOTE                                   -->
+<!--                    Additional information concerning material in
+                        a particular location in the text. This
+                        material is not considered to be part of the
+                        body of the text, but in addition to or a
+                        commentary on the body.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=fn
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=fn
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=fn
+                                                                   -->
+<!ELEMENT  fn           %fn-model;                                   >
+<!ATTLIST  fn
+             %fn-atts;                                               >
+
+
+<!--                    TARGET ELEMENTS                            -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <target>
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %link-elements; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % target-elements
+                        "%link-elements;"                            >
+
+
+<!--                    TARGET OF AN INTERNAL LINK                 -->
+<!--                    May be placed anywhere within textual
+                        material such as a paragraph to provide a
+                        location (anchor) to which a cross reference
+                        can point
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=target
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=target
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=target
+                                                                   -->
+<!ELEMENT  target       (#PCDATA %target-elements;)*                 >
+<!ATTLIST  target
+             %target-atts;                                           >
+
+
+<!--                    X(CROSS) REFERENCE ELEMENTS                -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        an <xref>
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %link-elements; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % xref-elements
+                        "%link-elements;"                            >
+
+
+<!--                    X(CROSS) REFERENCE                         -->
+<!--                    Used for any kind of internal article
+                        referencing. The content of the reference
+                        (if present) will be displayed as the link.
+                        This element may be used to point to any
+                        element that takes an "id" attribute.
+                        The @ref-type attribute may be used to name
+                        the element or type of object to which the
+                        <xref> is pointing.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=xref
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=xref
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=xref
+                                                                   -->
+<!ELEMENT  xref         (#PCDATA %xref-elements;)*                   >
+<!ATTLIST  xref
+             %xref-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    EXTERNAL LINKS                             -->
+<!-- ============================================================= -->
+
+
+<!--                    INLINE SUPPLEMENTARY MATERIAL ELEMENTS     -->
+<!--                    Elements for use in the
+                        <inline-supplementary-material> element    -->
+<!ENTITY % inline-supplementary-material-elements
+                        "| %access.class; | %address-link.class; |
+                         %emphasis.class; |
+                         %phrase-content.class; | %subsup.class;"    >
+
+
+<!--                    INLINE SUPPLEMENTARY MATERIAL              -->
+<!--                    An in-text link to an external file that
+                        provides supplementary information for
+                        the document, for example, an audio clip
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=inline-supplementary-material
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=inline-supplementary-material
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=inline-supplementary-material
+                                                                   -->
+<!ELEMENT  inline-supplementary-material
+                        (#PCDATA
+                         %inline-supplementary-material-elements;)*  >
+<!ATTLIST  inline-supplementary-material
+             %inline-supplementary-material-atts;                    >
+
+
+<!-- ================== End Link Class Module ==================== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-list1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-list1.ent
@@ -1,0 +1,602 @@
+<!-- ============================================================= -->
+<!--  MODULE:    List Element Classes                              -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite List Class Elements v1.2 20190208//EN"
+     Delivered as file "JATS-list1.ent"                            -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Names all elements in the list class. These are   -->
+<!--             all lists except the lists of bibliographic       -->
+<!--             references (citations). Lists are considered      -->
+<!--             to be composed of items.                          -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 19. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 18. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 17. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 16. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+   
+ 15. TERM ATTRIBUTES - Added to <term> the following attributes:
+     - @term-type
+     - @term-status
+     - the four vocabulary attributes described below
+   
+ 14. VOCABULARY/TAXONOMY ATTRIBUTES - Added 4 new attributes for
+     naming (and possibly linking to) a general or controlled
+     taxonomy, vocabulary, index, database or other source of
+     terms: @vocab, @vocab-identifier, @vocab-term, and
+     @vocab-term-identifier
+      - All 4 added to <term>, to name a vocabulary 
+        as the source of the term being identified
+ 
+ 13. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 12. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 11. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+ 
+ 10. TITLE FOR LIST ITEMS
+     Added an optional <title> to the beginning of each <list-item>.
+
+  9. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  8. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added a new attribute list to:
+      - def-head
+      - term-head
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  7. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  6. Updated the DTD-version attribute to "0.4" 
+   
+  5. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  4. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+
+      - def-item through def-item-atts (both)
+      - def-list through def-list-atts (@xml:lang-only;
+          @specific-use already)
+      - list through list-atts (@xml:lang-only; @specific-use already)
+      - list-item through list-item-atts (both)
+      - term through term-atts (both)
+
+  3. DEFINITION LIST HEADS - Removed the dependency in which
+     <term-head> and <def-head> both used the parameter entity
+     %def-list-head-elements; One uses %term-head-elements; and
+     the other uses %def-head-elements; But the
+     %def-list-head-elements; was retained for backward
+     compatibility.
+
+  2. DEF LIST ATTRIBUTES - Removed the dependency whereby <def-list>
+     used both %def-list-atts; and %list-atts;. <def-list> now uses
+     only %def-list-atts; No documents need change.
+     *****Customization Alert: New parameter entity could break some
+     customizations. Check your <def-list> attributes.        *****
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    DEFAULT PE FOR ATTRIBUTE LISTS             -->
+<!-- ============================================================= -->
+
+
+<!--                    DEFINITION LIST: DEFINITION HEAD ATTRIBUTES-->
+<!--                    Attributes for the <def-head> element      -->
+<!ENTITY % def-head-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    DEFINITION LIST: DEFINITION ITEM ATTRIBUTES-->
+<!--                    Attributes for the <def-item> element      -->
+<!ENTITY % def-item-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DEFAULT DEFINITION LIST ATTRIBUTES         -->
+<!--                    Default attribute lists to be used for
+                        Definition (2-part) lists                  -->
+<!ENTITY % def-list-atts
+            "%jats-common-atts;                                       
+             list-type  CDATA                             #IMPLIED
+             prefix-word
+                        CDATA                             #IMPLIED
+             list-content
+                        CDATA                             #IMPLIED
+             continued-from
+                        IDREF                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DEFAULT LIST CLASS ATTRIBUTES              -->
+<!--                    Default attribute lists to be used for most
+                        of the types of lists.                     -->
+<!ENTITY % list-atts
+            "%jats-common-atts;                                       
+             list-type  CDATA                             #IMPLIED
+             prefix-word
+                        CDATA                             #IMPLIED
+             list-content
+                        CDATA                             #IMPLIED
+             continued-from
+                        IDREF                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DEFAULT LIST ITEM ATTRIBUTES               -->
+<!--                    Default attribute for list items           -->
+<!ENTITY % list-item-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DEFINITION LIST: TERM ATTRIBUTES           -->
+<!--                    Attributes for the <term> element          -->
+<!ENTITY % term-atts
+            "%jats-common-atts;                                       
+             rid        IDREFS                            #IMPLIED
+             term-status
+                        CDATA                             #IMPLIED
+             term-type  CDATA                             #IMPLIED
+             vocab      CDATA                             #IMPLIED
+             vocab-identifier
+                        CDATA                             #IMPLIED
+             vocab-term CDATA                             #IMPLIED
+             vocab-term-identifier
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DEFINITION LIST: TERM HEAD ATTRIBUTES      -->
+<!--                    Attributes for the <term-head> element     -->
+<!ENTITY % term-head-atts
+            "%jats-common-atts;"                                     >
+
+
+<!-- ============================================================= -->
+<!--                    DEFINITION LIST                            -->
+<!-- ============================================================= -->
+
+
+<!--                    DEFINITION LIST MODEL                      -->
+<!--                    Content model for the <def-list> element   -->
+<!ENTITY % def-list-model
+                        "(label?, title?, term-head?, def-head?,
+                          (%def-item.class;)*, (%def-list.class;)* )">
+
+
+<!--                    DEFINITION LIST                            -->
+<!--                    Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=def-list
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=def-list
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=def-list
+                                                                   -->
+<!ELEMENT  def-list     %def-list-model;                             >
+<!ATTLIST  def-list
+             %def-list-atts;                                         >
+
+
+<!--                    DEFINITION LIST HEAD ELEMENTS              -->
+<!--                    Elements for use in the <def-list> heading
+                        elements <term-head> and <def-head>.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % def-list-head-elements
+                        "%simple-phrase;"                            >
+
+
+<!--                    DEFINITION LIST TERM HEAD ELEMENTS         -->
+<!--                    Elements for use in the <term-head> element-->
+<!ENTITY % term-head-elements
+                        "%def-list-head-elements;"                   >
+
+
+<!--                    DEFINITION LIST DEFINITION HEAD ELEMENTS   -->
+<!--                    Elements for use in the <def-head> element -->
+<!ENTITY % def-head-elements
+                        "%def-list-head-elements;"                   >
+
+
+<!--                    DEFINITION LIST: TERM HEAD                 -->
+<!--                    Title over the first (term) column of a
+                        two-part list
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=term-head
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=term-head
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=term-head
+                                                                   -->
+<!ELEMENT  term-head    (#PCDATA %term-head-elements;)*              >
+<!ATTLIST  term-head
+             %term-head-atts;                                        >
+
+
+<!--                    DEFINITION LIST: DEFINITION HEAD           -->
+<!--                    Title over the second (definition) column
+                        of a two-part list
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=def-head
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=def-head
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=def-head
+                                                                   -->
+<!ELEMENT  def-head     (#PCDATA %def-head-elements;)*               >
+<!ATTLIST  def-head
+             %def-head-atts;                                         >
+
+
+<!--                    DEFINITION LIST: DEFINITION ITEM MODEL     -->
+<!--                    The content model of a <def-item>          -->
+<!ENTITY % def-item-model
+                        "(label?, term, def*)"                       >
+
+
+<!--                    DEFINITION LIST: DEFINITION ITEM           -->
+<!--                    A term and definition pair inside a
+                        definition or two-part list
+                        of a two-part list
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=def-item
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=def-item
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=def-item
+                                                                   -->
+<!ELEMENT  def-item     %def-item-model;                             >
+<!ATTLIST  def-item
+             %def-item-atts;                                         >
+
+
+<!--ELEM   def          Defined in %common.ent;                    -->
+
+
+<!--                    DEFINITION LIST: TERM ELEMENTS             -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <term>.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % term-elements
+                        "%simple-phrase; | %block-math.class; |
+                         %simple-display-noalt.class;"               >
+
+
+<!--                    DEFINITION LIST: TERM                      -->
+<!--                    The word, phrase, picture, or other noun
+                        being defined or description that occupies
+                        the first column of a definition or 2-part
+                        list and is the subject of the definition or
+                        description.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=term
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=term
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=term
+                                                                   -->
+<!ELEMENT  term         (#PCDATA %term-elements;)*                   >
+<!ATTLIST  term
+             %term-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    LIST ELEMENTS (PARAGRAPH-LEVEL ELEMENTS)   -->
+<!-- ============================================================= -->
+
+
+<!--                    LIST MODEL                                 -->
+<!--                    Content model for the <list> element       -->
+<!ENTITY % list-model   "(label?, title?, (%list-item.class;)+)"     >
+
+
+<!--                    LIST                                       -->
+<!--                    Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=list
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=list
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=list
+                                                                   -->
+<!ELEMENT  list         %list-model;                                 >
+<!ATTLIST  list
+             %list-atts;                                             >
+
+
+<!--                    LIST ITEM ELEMENTS                         -->
+<!--                    The content model of a <list-item>.        -->
+<!ENTITY % list-item-model
+                        "(label?, title?, 
+                          (%just-para.class; | %list.class;)+ )"     >
+
+
+<!--                    LIST ITEM                                  -->
+<!--                    One item in a list
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=list-item
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=list-item
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=list-item
+                                                                   -->
+<!ELEMENT  list-item    %list-item-model;                            >
+<!ATTLIST  list-item
+             %list-item-atts;                                        >
+
+
+<!-- ================== End List Class Module ==================== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-math1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-math1.ent
@@ -1,0 +1,492 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Math Class Elements                               -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Math Class Elements v1.2 20190208//EN"
+     Delivered as file "JATS-math1.ent"                            -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Names all elements in the math classes            -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 17. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 16. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 15. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 14. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+     
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 13. INLINE FORMULA - Added accessibility elements <alt-text> and
+     <long-desc> to the model of <inline-formula>, by adding the 
+     access.class PE.
+ 
+ 12. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 11. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 10. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  9. TEXT-MATH - Added @specific-use to the attributes for
+     <text-math>, primarily for use when <tex-math> is used
+     inside <alternatives>.
+
+  8. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+ 
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  7. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+
+  6. ABSTRACTS AND KEYWORDS ON NEW STRUCTURES
+     - Added <abstract> (through %abstract.class;) and <kwd-group> 
+       (through %kwd-group.class;) to the following elements:
+        - disp-formula (through %disp-formula-elements;)
+        - disp-formula-group (through %disp-formula-group-model;)
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  5. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  4. Updated the DTD-version attribute to "0.4" 
+   
+  3. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  2. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+
+      - disp-formula through disp-formula-atts (@xml:lang-only;
+          @specific-use already)
+      - disp-formula-group through disp-formula-group-atts
+          (@xml:lang-only; @specific-use already)
+      - inline-formula through inline-formula-atts
+          (@specific-use-only; @xml:lang already)
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    DISPLAY FORMULA ATTRIBUTES                 -->
+<!--                    Attributes for the <disp-formula> element  -->
+<!ENTITY % disp-formula-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DISPLAY FORMULA GROUP ATTRIBUTES           -->
+<!--                    Attributes for the <disp-formula-group>
+                        element                                    -->
+<!ENTITY % disp-formula-group-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    INLINE FORMULA ATTRIBUTES                  -->
+<!--                    Attribute list for the <inline-formula>
+                        element                                    -->
+<!ENTITY % inline-formula-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    TEX MATH ATTRIBUTES                        -->
+<!--                    Attributes for the <disp-formula> element  -->
+<!ENTITY % tex-math-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             notation   NOTATION (LaTeX | tex | TEX | TeX)
+                                                          #IMPLIED
+             version    CDATA                             #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    MATH ELEMENTS (INLINE LEVEL)               -->
+<!-- ============================================================= -->
+
+
+<!--                    FORMULA, INLINE ELEMENTS                   -->
+<!--                    Elements for use in the <inline-formula>
+                        element                                    -->
+<!ENTITY % inline-formula-elements
+                        "| %access.class; | %emphasis.class; |
+                         %inline-display.class; |
+                         %inline-math.class; | %math.class; |
+                         %phrase-content.class; | %subsup.class;"    >
+
+
+<!--                    FORMULA, INLINE MODEL                      -->
+<!--                    Content model for an <inline-formula>      -->
+<!ENTITY % inline-formula-model
+                        "(#PCDATA %inline-formula-elements;)*"       >
+
+
+<!--                    FORMULA, INLINE                            -->
+<!--                    Inline element for a mathematical
+                        equation, expression, or formula
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=inline-formula
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=inline-formula
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=inline-formula
+                                                                   -->
+<!ELEMENT  inline-formula
+                        %inline-formula-model;                       >
+<!ATTLIST  inline-formula
+             %inline-formula-atts;                                   >
+
+
+<!-- ============================================================= -->
+<!--                    MATH ELEMENTS (INLINE LEVEL)               -->
+<!-- ============================================================= -->
+
+
+<!--                    DISPLAY FORMULA ELEMENTS                   -->
+<!--                    Elements for use in the <disp-formula>
+                        element                                    -->
+<!ENTITY % disp-formula-elements
+                        "| %access.class; | %abstract.class; |
+                         %address-link.class; |
+                         %break.class; | %emphasis.class; |
+                         %inline-display-noalt.class; |
+                         %inline-math.class; | %kwd-group.class; |
+                         %label.class; | %phrase-content.class; |
+                         %math.class; |  %simple-display.class; |
+                         %subsup.class;"                             >
+
+
+<!--                    FORMULA, DISPLAY MODEL                     -->
+<!--                    Content model for an <disp-formula>        -->
+<!ENTITY % disp-formula-model
+                        "(#PCDATA %disp-formula-elements;)*"         >
+
+
+<!--                    FORMULA, DISPLAY                           -->
+<!--                    Block-level (callout) element for a
+                        mathematical equation, expression, or
+                        formula.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=disp-formula
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=disp-formula
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=disp-formula
+                                                                   -->
+<!ELEMENT  disp-formula %disp-formula-model;                         >
+<!ATTLIST  disp-formula
+             %disp-formula-atts;                                     >
+
+
+<!--                    FORMULA, DISPLAY GROUP MODEL               -->
+<!--                    Content model for an <disp-formula-group>  -->
+<!ENTITY % disp-formula-group-model
+                        "(label?, (%caption.class;)?,
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          (%access.class; | %address-link.class;)*,
+                          (%block-math.class;)* )"                   >
+
+
+<!--                    FORMULA, DISPLAY GROUP                     -->
+<!--                    Used for a group of equations or other
+                        mathematical expressions that are displayed
+                        together.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=disp-formula-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=disp-formula-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=disp-formula-group
+                                                                   -->
+<!ELEMENT  disp-formula-group
+                        %disp-formula-group-model;                   >
+<!ATTLIST  disp-formula-group
+             %disp-formula-group-atts;                               >
+
+
+<!--                    TEX MATH EQUATION                          -->
+<!--                    Used to hold encoded math, expressed in TeX
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=tex-math
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=tex-math
+                                                                   -->
+<!ELEMENT  tex-math     (#PCDATA)                                    >
+<!ATTLIST  tex-math
+             %tex-math-atts;                                         >
+
+
+<!-- ================== End Math Class Elements Module =========== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-mathmlsetup1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-mathmlsetup1.ent
@@ -1,0 +1,434 @@
+<!-- ============================================================= -->
+<!--  MODULE:    MathML DTD SETUP MODULE                           -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite MathML Setup Module v1.2 20190208//EN"
+     Delivered as file "JATS-mathmlsetup1.ent"                     -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Provides the organization for using the           -->
+<!--             MathML DTD:                                       -->
+<!--             1) Overrides the standard parameter entities used -->
+<!--                in the MathML 2.0 DTD                          -->
+<!--             2) Calls the MathML 2.0 DTD                       -->
+<!--                                                               -->
+<!-- MODULES REQUIRED:                                             -->
+<!--             1) mathml2.dtd  (MathML 2.0 DTD)                  -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 14. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 13. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 12. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 11. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+    
+ 10. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  9. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  8. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+    
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  6. OASIS TABLE NAMESPACE MODIFICATIONS - Added a new module
+     that sets up the namespace URI and namespace prefix for
+     the OASIS tables models.
+   
+  5. Updated the DTD-version attribute to "1.1d1" and the formal
+     public identifier to the date: "v1.1d1 20130915//EN".
+
+       =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    SET UP FOR THE MathML MODULE               -->
+<!-- ============================================================= -->
+
+
+<!--                    MathML DTD                                 -->
+<!--                    The official version of the MathML 2.0 can
+                        be found at: http://www.w3.org/TR/MathML2/
+
+                        See also Mathematical Markup Language
+                        (MathML) Version 2.0
+
+                        A. Parsing MathML
+                        A.6 The MathML DTD
+            http://www.w3.org/TR/MathML2/appendixa.html#parsing-dtd
+
+                        A zip file with entity declarations is
+                        available from
+            http://www.w3.org/TR/MathML2/DTD-MathML-20010221.zip   -->
+
+
+<!-- ============================================================= -->
+<!--                    SET UP W3C XML SCHEMA                      -->
+<!-- ============================================================= -->
+
+
+<!--                    MAKE PREFIX EQUAL "xsi" (same as MathML)   -->
+<!ENTITY % Schema.prefix
+                        "xsi"                                        >
+
+<!--                    SET UP NAMESPACE FOR SCHEMA
+                           (same as MathML)                        -->
+<!ENTITY % Schema.xmlns "http://www.w3.org/2001/XMLSchema-instance"  >
+
+
+<!--                    OVER-RIDE MATHML DTD TO MAKE EXPLICIT NS   -->
+<!--                    MathML sets this up but then lets the
+                        attribute be a CDATA one, not the real
+                        namespace URI                              -->
+<!ENTITY % Schema.xmlns.attrib
+     "xmlns:%Schema.prefix;  CDATA          #FIXED '%Schema.xmlns;'" >
+
+
+<!-- ============================================================= -->
+<!--                    SET UP "mml" AS THE MATH PREFIX            -->
+<!-- ============================================================= -->
+
+
+<!--                    MAKE MATH PREFIX PARAMETER ENTITY HAPPEN   -->
+<!ENTITY % MATHML.prefixed 
+                        "INCLUDE"                                    >
+
+
+<!--                    MAKE PREFIX EQUAL "mml"                    -->
+<!ENTITY % MATHML.prefix "mml"                                       >
+
+
+<!--                    SET UP "pfx"                               -->
+<![%MATHML.prefixed;[
+<!ENTITY % MATHML.pfx   "%MATHML.prefix;:"                           >
+]]>
+
+
+<!--                    USE "pfx" TO SET THE MATH ELEMENT NAME     -->
+<!ENTITY % math.qname   "%MATHML.pfx;math"                           >
+
+
+
+<!-- ============================================================= -->
+<!--                    CALL THE MATHML ENTITIES                   -->
+<!-- ============================================================= -->
+
+
+<!--                    MATHML CHARACTER ENTITIES                  -->
+<!--                    Set the "INCLUDE" or "IGNORE" marked section
+                        switch for the MATHML 2.0 DTD. This switch
+                        determines whether the math processing in
+                        the -%mathml.dtd; module or the
+                        -%xmlspecchars.ent; module in this DTD Suite
+                        will invoke the sets of special characters
+                        that are defined AND INVOKED in the
+                        -%xmlspecchars.ent; module.
+                        A value of "IGNORE" turns off the second
+                        invocation from the MathML DTD.            -->
+<!ENTITY % mathml-charent.module
+                        "IGNORE"                                     >
+
+
+<!--                    MATHML-SPECIFIC CHARACTER ENTITIES         -->
+<!--                    Because the MATHML invocation is canceled
+                        using the parameter entity just defined,
+                        the two external entities below must be
+                        invoked from here, as neither XMLspecchars
+                        nor the MathML DTD will invoke them.       -->
+
+<!--                    New characters defined by MathML           -->
+%ent-mmlextra;
+
+
+<!--                    MathML aliases for characters defined above-->
+%ent-mmlalias;
+
+
+<!-- ============================================================= -->
+<!--                    RESTRICT CONTENT OF ANNOTATION             -->
+<!-- ============================================================= -->
+
+<!--                    MATHML ANNOTATION MODEL                    -->
+<!--                    The MathML DTD establishes the content of the
+                        <mml:annotation-xml> element as ANY. This is
+                        unnecessarily broad, causing inconvenience for
+                        conversion. The model has been restricted to
+                        one or more paragraphs.                    -->
+<!ENTITY % Annotation-xml.content
+                        "(p+)"                                       >
+
+
+<!-- ============================================================= -->
+<!--                    MathML 2.0 INVOCATION                      -->
+<!-- ============================================================= -->
+
+%mathml.dtd;
+
+
+<!-- ================== End MATHML Setup Module ================== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-modules1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-modules1.ent
@@ -1,0 +1,696 @@
+<!-- ============================================================= -->
+<!--  MODULE:    JATS DTD Suite Module of Modules                  -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Module of Modules v1.2 20190208//EN"
+     Delivered as file "JATS-modules1.ent"                         -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    For naming all the external modules (except       -->
+<!--             this module itself and the customization modules) -->
+<!--             that are part of the JATS DTD Suite. A specific   -->
+<!--             DTD will select from these modules by referencing -->
+<!--             the external Parameter Entities defined below that-->
+<!--             name the modules of the suite. To include a set   -->
+<!--             of elements (such as all the lists or the MathML  -->
+<!--             elements), reference the external Parameter Entity-->
+<!--             of the module that contains these declarations,   -->
+<!--             then modify the classes or content models to use  -->
+<!--             the new elements.                                 -->
+<!--                                                               -->
+<!-- CONTAINS:   Entity declarations and public names for all the  -->
+<!--             JATS DTD Suite external modules. Note: The modules-->
+<!--             are NOT referenced (called/invoked) in this       -->
+<!--             module, they are merely DECLARED.  The DTD or     -->
+<!--             a setup module (such as for the XHTML tables)     -->
+<!--             will invoke the external parameter entity to      -->
+<!--             call each module.                                 -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 14. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 13. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 12. INLINE EMBEDDED INDEX - Added definition of BITS module that
+     defines inline (embedded) index terms.
+ 
+ 11. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 10. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+    
+  9. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  8. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  6. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based 
+     DTDs, XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  5. NLMCITATION - Added module for deprecated element <nlm-citation>
+     because the element is called in a default class 
+     (citation.class) that, for reasons of backwards compatibility,
+     will not be changed at this time.
+   
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    DEFAULT CLASSES AND MIXES                  -->
+<!-- ============================================================= -->
+
+
+<!--                    DEFAULT ELEMENT CLASSES MODULE             -->
+<!--                    Set up the Parameter Entities and element
+                        class definitions that will be used to
+                        establish the content models for the
+                        Archiving and Interchange DTD.             -->
+<!ENTITY % default-classes.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Default Element Classes Module v1.2 20190208//EN"
+"JATS-default-classes1.ent"                                          >
+
+
+<!--                    DEFAULT ELEMENT MIXES MODULE               -->
+<!--                    Set up the Parameter Entities and element
+                        mix definitions that will be used in
+                        content models for the Archiving and
+                        Interchange DTD.                           -->
+<!ENTITY % default-mixes.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Default Element Mixes Module v1.2 20190208//EN"
+"JATS-default-mixes1.ent"                                            >
+
+
+<!-- ============================================================= -->
+<!--                    COMMON ATTRIBUTES SHARED BY ALL ELEMENTS   -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON ATTRIBUTES SHARED BY ALL ELEMENTS   -->
+<!ENTITY % JATS-common-atts.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Common Attributes (for all elements) v1.2 20190208//EN"
+"JATS-common-atts1.ent"                                              >
+
+
+<!-- ============================================================= -->
+<!--                    COMMON ELEMENTS SHARED BY MANY MODULES     -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON (SHARED) ELEMENT DECLARATIONS       -->
+<!ENTITY % common.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Common (Shared) Elements Module v1.2 20190208//EN"
+"JATS-common1.ent"                                                   >
+
+
+<!-- ============================================================= -->
+<!--                    CLASS MODULES (ALPHABETICAL ORDER)         -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE METADATA ELEMENTS                  -->
+<!ENTITY % articlemeta.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Journal Article Metadata Elements v1.2 20190208//EN"
+"JATS-articlemeta1.ent"                                              >
+
+
+<!--                    BACK MATTER ELEMENTS                       -->
+<!ENTITY % backmatter.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Back Matter Elements v1.2 20190208//EN"
+"JATS-backmatter1.ent"                                               >
+
+
+<!--                    DISPLAY (GRAPHICAL) ELEMENTS INVOCATION    -->
+<!ENTITY % display.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Display Class Elements v1.2 20190208//EN"
+"JATS-display1.ent"                                                  >
+
+
+<!--                    FORMATTING ELEMENTS                        -->
+<!--                    Elements that change rendition/display. This
+                        module includes the Appearance Class, the
+                        Break Class, and the Emphasis Class        -->
+<!ENTITY % format.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Formatting Element Classes v1.2 20190208//EN"
+"JATS-format1.ent"                                                   >
+
+
+<!--                    FUNDING ELEMENTS                           -->
+<!--                    Elements that model open access, grant,
+                        sponsorship, or other funding information,
+                        for example the grant number (<award-id>)
+                        and the <principal-investigator>           -->
+<!ENTITY % funding.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Funding Elements v1.2 20190208//EN"
+"JATS-funding1.ent"                                                  >
+
+
+<!--                    JOURNAL METADATA ELEMENTS                  -->
+<!ENTITY % journalmeta.ent PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Journal Metadata Elements v1.2 20190208//EN"
+"JATS-journalmeta1.ent"                                              >
+
+
+<!--                    LINK ELEMENTS                              -->
+<!ENTITY % link.ent  PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Link Class Elements v1.2 20190208//EN"
+"JATS-link1.ent"                                                     >
+
+
+<!--                    LIST ELEMENTS                              -->
+<!ENTITY % list.ent  PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite List Class Elements v1.2 20190208//EN"
+"JATS-list1.ent"                                                          >
+
+
+<!--                    MATH ELEMENTS                              -->
+<!ENTITY % math.ent  PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Math Class Elements v1.2 20190208//EN"
+"JATS-math1.ent"                                                     >
+
+
+<!--                    PARAGRAPH-LEVEL ELEMENTS                   -->
+<!ENTITY % para.ent  PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Paragraph-Like Elements v1.2 20190208//EN"
+"JATS-para1.ent"                                                          >
+
+
+<!--                    PHRASE-LEVEL CONTENT ELEMENTS              -->
+<!ENTITY % phrase.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Subject Phrase Class Elements v1.2 20190208//EN"
+"JATS-phrase1.ent"                                                   >
+
+
+<!--                    BIBLIOGRAPHY REFERENCES (CITATION) ELEMENTS-->
+<!ENTITY % references.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Bibliographic Reference (Citation) Class Elements v1.2 20190208//EN"
+"JATS-references1.ent"                                               >
+
+
+<!--                    RELATED OBJECT ELEMENT                     -->
+<!--                    Defines the <related-object> element to
+                        describe a related object such as a
+                        related book or a dataset.                 -->
+<!ENTITY % related-object.ent
+                       PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Related Object Element v1.2 20190208//EN"
+"JATS-related-object1.ent"                                           >
+
+
+<!--                    SECTION ELEMENTS                           -->
+<!ENTITY % section.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Section Class Elements v1.2 20190208//EN"
+"JATS-section1.ent"                                                  >
+
+
+<!-- ============================================================= -->
+<!--                    TABLES: XHTML TABLE MODULES                -->
+<!-- ============================================================= -->
+
+
+<!--                    XHTML TABLE SETUP MODULE                   -->
+<!--                    Set all Parameter Entities needed by the
+                        HTML 4.0 (XHTML) table model, and then
+                        call the module containing that model.
+                        Authoring Note: If wanted, this module
+                        will be invoked in the DTD module          -->
+<!ENTITY % XHTMLtablesetup.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite XHTML Table Setup Module v1.2 20190208//EN"
+"JATS-XHTMLtablesetup1.ent"                                          >
+
+
+<!--                    XHTML TABLE MODEL                          -->
+<!--                    The public XML version of the XHTML 1.1
+                        table model. This module is invoked in the
+                         module %XHTMLtablesetup3.ent;             -->
+<!ENTITY % xhtml-table-1.mod
+                        PUBLIC
+"-//W3C//ELEMENTS XHTML Tables 1.0//EN"
+"xhtml-table-1.mod"                                                  >
+
+
+<!--                    XHTML TABLE INLINE STYLE MODULE            -->
+<!--                    The public XML version of the XHTML 1.1
+                        inline style module for use in XHTML tables.
+                        This module is invoked in the
+                         module %XHTMLtablesetup3.ent;             -->
+<!ENTITY % xhtml-inlstyle-1.mod
+                        PUBLIC
+"-//W3C//ENTITIES XHTML Inline Style 1.0//EN"
+"xhtml-inlstyle-1.mod"                                                  >
+
+
+<!-- ============================================================= -->
+<!--                    ALI: NISO ACCESS AND INDICATORS            -->
+<!-- ============================================================= -->
+
+
+<!--                    NISO ACCESS AND INDICATORS (RP-22-1015)    -->
+<!--                    Set all Parameter Entities needed by the
+                        NISO ALI licensing elements.
+                        This module is invoked by each DTD.        -->
+<!ENTITY % JATS-ali-namespace.ent
+                        PUBLIC
+"-//NLM//DTD JATS ALI Namespace Module v1.2 20190208//EN"
+"JATS-ali-namespace1.ent"                                            >
+
+
+<!-- ============================================================= -->
+<!--                    TABLES: OASIS EXCHANGE TABLE MODULES       -->
+<!-- ============================================================= -->
+
+
+<!--                    OASIS XML TABLE SETUP MODULE               -->
+<!--                    Set all Parameter Entities needed by the
+                        OASIS (CALS) Table Exchange table model.
+                        Authoring Note: If wanted, this module
+                        will be invoked in the DTD module          -->
+<!ENTITY % oasis-tablesetup.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Namespaced OASIS XML Table Setup Module v1.2 20190208//EN"
+"JATS-oasis-tablesetup1.ent"                                         >
+
+
+<!--                    OASIS XML TABLE MODEL                      -->
+<!--                    The OASIS (CALS) Table Exchange table model
+                        This module is invoked in
+                        %JATS-oasis-tablesetup1.ent;               -->
+<!ENTITY % oasis-exchange.ent
+                        PUBLIC
+"-//OASIS//DTD XML Exchange Table Model 19990315//EN"
+"oasis-exchange.ent"                                                 >
+
+
+<!-- ============================================================= -->
+<!--                    SPECIAL CHARACTER MODULES                  -->
+<!-- ============================================================= -->
+
+
+<!--                    SPECIAL CHARACTERS DECLARATIONS            -->
+<!--                    Declares any standard XML special character
+                        entities used in this DTD                  -->
+<!ENTITY % xmlspecchars.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite XML Special Characters Module v1.2 20190208//EN"
+"JATS-xmlspecchars1.ent"                                             >
+
+
+<!--                    CUSTOM SPECIAL CHARACTERS DECLARATIONS     -->
+<!--                    Declares any custom special character
+                        entities created for this Suite            -->
+<!ENTITY % chars.ent PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Custom Special Characters Module v1.2 20190208//EN"
+"JATS-chars1.ent"                                                    >
+
+
+<!-- ============================================================= -->
+<!--                    MATH: MATHML MODULES                       -->
+<!--                    Only one of the modules below may be       -->
+<!--                    invoked by a DTD.                          -->
+<!-- ============================================================= -->
+
+
+<!--                    MATHML 2.0 SETUP MODULE                    -->
+<!--                    Called from the DTD to include the MathML 2.0
+                        elements in the tag set.                   -->
+<!ENTITY % mathmlsetup.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite MathML Setup Module v1.2 20190208//EN"
+"JATS-mathmlsetup1.ent"                                              >
+
+
+<!--                    MATHML 3.0 SETUP MODULE                    -->
+<!--                    Called from the DTD to include the MathML 3.0
+                        elements in the tag set.                   -->
+<!ENTITY % mathml3-mathmlsetup.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite MathML 3.0 Setup Module v1.2 20190208//EN"
+"JATS-mathml3-mathmlsetup1.ent"                                      >
+
+
+<!-- ============================================================= -->
+<!--                     MATHML 2.0 MODULES (below for JATS V1)    -->
+<!--                     MATHML 3.0 modules are invoked in the DTD -->
+<!-- ============================================================= -->
+
+
+<!--                    MATHML 2.0 QUALIFIED NAMES                 -->
+<!ENTITY % mathml-qname.mod
+                        PUBLIC
+"-//W3C//ENTITIES MathML 2.0 Qualified Names 1.0//EN"
+"mathml2-qname-1.mod"                                                >
+
+
+<!--                    MATHML 2.0 DTD                             -->
+<!ENTITY % mathml.dtd   PUBLIC
+"-//W3C//DTD MathML 2.0//EN"
+"mathml2.dtd"                                                        >
+
+
+<!--                    MATHML 2.0 EXTRA ENTITIES                  -->
+<!ENTITY % ent-mmlextra
+                        PUBLIC
+"-//W3C//ENTITIES Extra for MathML 2.0//EN"
+"mathml/mmlextra.ent"                                               >
+
+
+<!--                    MATHML 2.0 ALIASES                         -->
+<!ENTITY % ent-mmlalias
+                        PUBLIC
+"-//W3C//ENTITIES Aliases for MathML 2.0//EN"
+"mathml/mmlalias.ent"                                               >
+
+
+<!-- ============================================================= -->
+<!--                     NOTATIONS MODULE                          -->
+<!-- ============================================================= -->
+
+
+<!--                    NOTATION DECLARATIONS MODULE               -->
+<!--                    Container module for the Notation Declarations
+                        to be used with this DTD suite.  Placed in
+                        their own module for easy expansion or
+                        replacement.                               -->
+<!ENTITY % notat.ent PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Notation Declarations v1.2 20190208//EN"
+"JATS-notat1.ent"                                                    >
+
+<!-- ============================================================= -->
+<!--                     NLM CITATION (DEPRECATED ELEMENT) MODULE  -->
+<!-- ============================================================= -->
+
+
+<!--                    NLM CITATION MODULE                        -->
+<!--                    The only new element created for the
+                        Publishing DTD, the highly structured NLM
+                        citation, to enforce a slightly loose version
+                        of an NLM-structured bibliographic reference.
+                        Sequence is enforced and interior punctuation
+                        is expected to be generated.               -->
+<!ENTITY % nlmcitation.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) NLM Citation v1.2 20190208//EN"
+"JATS-nlmcitation1.ent"                                              >
+
+<!-- ============================================================= -->
+<!--                     MODULES TO ADD BITS INLINE INDEX ELEMENTS -->
+<!-- ============================================================= -->
+
+
+<!--                    BITS EMBEDDED INDEX ELEMENTS MODULE        -->
+<!--                    Element declarations the index elements
+                        which are embedded in the document
+                        narrative.                                 -->
+<!ENTITY % index-term.ent
+                        PUBLIC
+"-//NLM//DTD BITS Embedded Index Element Module v2.1 20180401//EN"
+"BITS-embedded-index2.ent"                                           >
+
+
+<!-- ============================================================= -->
+<!--                     NAMESPACE FOR W3C XSI PREFIX FOR DTDS
+                         THAT DO NOT USE MATHML                    -->
+<!-- ============================================================= -->
+
+<!ENTITY % JATS-xsi-schema-namespace.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite XSI Namespace Setup Module v1.2 20190208//EN"
+"JATS-xsi-schema-namespace1.ent"                                     >
+
+<!-- =================== End Journal Article Module of Modules === -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-nlmcitation1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-nlmcitation1.ent
@@ -1,0 +1,371 @@
+<!-- ============================================================= -->
+<!--  MODULE:    NLM Citation                                      -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) NLM Citation v1.2 20190208//EN"
+Delivered as file "JATS-nlmcitation1.ent"                          -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Deprecated 2012                                   -->
+<!--             This DTD Suite module adds the model for the      -->
+<!--             NLM Structured bibliographic citation. This model -->
+<!--             The model loosely reflects NLM's style, in that   -->
+<!--             the model allows the tagging of all "legal" NLM   -->
+<!--             citations and enforces the sequence in which      -->
+<!--             content must appear if it is present. However,    -->
+<!--             this model does not provide guidance on what      -->
+<!--             information is required for each type of cited    -->
+<!--             content.                                          -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             September 2004                                    -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+ Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 14. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 13. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 12. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 11. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+    
+ 10. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+      =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  9. JATS became version "1.1" and "v1.1 20151215"
+
+    =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  8. JATS became version "1.1d3" and "v1.1d3 20150301"
+ 
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+  
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  6. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+  
+  5. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  4. Updated the DTD-version attribute to "0.4" 
+   
+  3. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  2. NLM CITATION ATTRIBUTES - Removed the dependency whereby
+     the NLM citation used the same attributes as the other types
+     of citation via %citation-atts;. <nlm-citation> now uses
+     only %nlm-citation-atts; No documents need change.
+     - added @xml:lang
+     - added @specific-use
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    NEW ELEMENT DECLARATIONS                   -->
+<!--                    Declarations of elements that are new to   -->
+<!--                    this DTD.                                  -->
+<!--                    NOTE: All new structures must be mappable  -->
+<!--                    to the archiving/interchange DTD and the   -->
+<!--                    mapping should be described when the new   -->
+<!--                    element is declared.                       -->
+<!-- ============================================================= -->
+
+
+<!--                    NLM CITATION ATTRIBUTES                    -->
+<!--                    Attributes for all three types of
+                        citations (<mixed-citation>,
+                        <element-citation>, and <nlm-citation>).   -->
+<!ENTITY % nlm-citation-atts
+            "%jats-common-atts;                                       
+             publication-type
+                        CDATA                             #IMPLIED
+             publisher-type
+                        CDATA                             #IMPLIED
+             publication-format
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    NLM CITATION MODEL                         -->
+<!--                    This structured citation model is loosely
+                        reflects the NLM's house style, in that
+                        it allows the tagging of all "legal" NLM
+                        citations and enforces the sequence in which
+                        content must appear if it is present.
+                        This model assumes that punctuation between
+                        the parts of a citation will be generated
+                        on display or on export.
+                        (Deprecated after Version 3.0)
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=nlm-citation
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=nlm-citation
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=nlm-citation
+                                                                   -->
+<!ELEMENT  nlm-citation
+                        ((person-group | collab)*,
+                         (article-title | trans-title)*,
+                         source?, patent?, trans-source?, year?,
+                         ((month?, day?, time-stamp?) | season?),
+                         access-date?, volume?, edition?,
+                         conf-name?, conf-date?, conf-loc?,
+                         (issue | supplement)*, publisher-loc?,
+                         publisher-name?, (fpage?, lpage?)*,
+                         page-count?, series?, comment*, pub-id*,
+                         annotation?)                                >
+
+<!ATTLIST  nlm-citation
+             %nlm-citation-atts;                                     >
+
+
+<!-- ================== End NLM Citation Module ================== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-notat1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-notat1.ent
@@ -1,0 +1,354 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Notation Declarations                             -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Notation Declarations v1.2 20190208//EN"
+     Delivered as file "JATS-notat1.ent"                           -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    To name all the allowable notations               -->
+<!--                                                               -->
+<!-- CONTAINS:   Notation Declarations                             -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 13. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 12. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 11. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 10. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+    
+  9. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  8. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  6. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  5. OASIS TABLE NAMESPACE MODIFICATIONS - Added a new module
+     that sets up the namespace URI and namespace prefix for
+     the OASIS tables models.
+ 
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+  
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--               NOTATION DECLARATIONS                           -->
+<!-- ============================================================= -->
+
+
+<!--               LATEX (for Mathematics)                         -->
+<!NOTATION  LaTeX  PUBLIC
+           "+//ISBN 3-893-196463::Goosens//NOTATION Der LaTeX Begleiter//DE"  >
+
+
+<!--               TEX (for Mathematics)                           -->
+<!NOTATION  TEX  PUBLIC
+           "+//ISBN 0-201-13448-9::Knuth//NOTATION The TeXbook//EN"  >
+<!NOTATION  tex  PUBLIC
+           "+//ISBN 0-201-13448-9::Knuth//NOTATION The TeXbook//EN"  >
+<!NOTATION  TeX  PUBLIC
+           "+//ISBN 0-201-13448-9::Knuth//NOTATION The TeXbook//EN"  >
+
+
+<!-- ============================================================= -->
+<!--               POTENTIAL NOTATION DECLARATIONS                 -->
+<!-- ============================================================= -->
+
+
+<!--               CGM (Computer Graphics Metafile)                -->
+<!NOTATION cgmchar PUBLIC
+"ISO 8632/2//NOTATION Character encoding//EN"
+                                                                     >
+<!NOTATION cgmclear PUBLIC
+"ISO 8632/4//NOTATION Clear text encoding//EN"
+                                                                     >
+
+
+<!--               GIF (Graphic Interchange Format)                -->
+<!NOTATION gif     PUBLIC
+"-//ISBN 0-7923-9432-1::Graphic Notation//NOTATION CompuServe
+Graphic Interchange Format//EN"
+                                                                     >
+
+<!--               EPS (Adobe's Encapsulate Postscript)            -->
+<!NOTATION eps     PUBLIC
+"+//ISBN 0-201-18127-4::Adobe//NOTATION PostScript Language Reference Manual//EN"
+                                                                     >
+
+
+<!--               JPEG (Joint Photographic Experts Group raster)  -->
+<!NOTATION jpeg    PUBLIC
+"+//ISBN 0-7923-9432-1::Graphic Notation//NOTATION Joint Photographic Experts Group raster//EN"
+                                                                     >
+
+<!--               TIFF (Uncompressed)                             -->
+<!NOTATION tiff    PUBLIC
+"+//ISBN 0-7923-9432-1::Graphic Notation//NOTATION Aldus/Microsoft
+Tagged Interchange File Format//EN"                                  >
+
+
+<!-- ================== End Notation Module ====================== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-para1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-para1.ent
@@ -1,0 +1,582 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Paragraph-Like Elements                           -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Paragraph-Like Elements v1.2 20190208//EN"
+     Delivered as file "JATS-para1.ent"                            -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Names structural elements that will appear in     -->
+<!--             the same places as a paragraph                    -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 20. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 19. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+     
+ 18. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 17. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+    
+ 16. NEW VERSE ATTRIBUTES
+     - Added @indent-level, @style, @style-type, and @style-detail 
+       to <verse-line>
+     - Added @style, @style-type, and @style-detail to <verse-group>      
+    
+ 15. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 14. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 13. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 12. STATEMENT - Added new statement.class inside the model
+     for <statement>, so that statements can be recursive.
+
+ 11. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 10. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+
+
+  9. ABSTRACTS AND KEYWORDS ON NEW STRUCTURES
+     - Added <abstract> (through %abstract.class;) and <kwd-group> 
+       (through %kwd-group.class;) to the following elements:
+        - statement (through statement-model PE)
+   
+     =============================================================
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  5. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  4. Updated the DTD-version attribute to "0.4" 
+   
+  3. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  2. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+      - speaker through speaker-atts (both)
+      - statement through statement-atts (@xml:lang only; already
+          @specific-use))
+      - verse-line through verse-line-atts (both)
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    DISPLAY QUOTE ATTRIBUTES                   -->
+<!--                    Attribute list for the <disp-quote> element-->
+<!ENTITY % disp-quote-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PARAGRAPH ATTRIBUTES                       -->
+<!--                    Attribute list for the <p> element         -->
+<!ENTITY % p-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SPEAKER ATTRIBUTES                         -->
+<!--                    Attribute list for the <speaker> element   -->
+<!ENTITY % speaker-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SPEECH ATTRIBUTES                          -->
+<!--                    Attribute list for the <speech> element    -->
+<!ENTITY % speech-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    STATEMENT ATTRIBUTES                       -->
+<!--                    Attribute list for the <statement> element -->
+<!ENTITY % statement-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    VERSE GROUP ATTRIBUTES                     -->
+<!--                    Attribute list for the <verse-group> element
+                                                                   -->
+<!ENTITY % verse-group-atts
+            "%jats-common-atts;                                       
+             style      CDATA                             #IMPLIED
+             style-detail
+                        CDATA                             #IMPLIED
+             style-type CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    VERSE LINE ATTRIBUTES                      -->
+<!--                    Attribute list for the <verse-line> element-->
+<!ENTITY % verse-line-atts
+            "%jats-common-atts;                                       
+             indent-level
+                        CDATA                             #IMPLIED
+             style      CDATA                             #IMPLIED
+             style-detail
+                        CDATA                             #IMPLIED
+             style-type CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    PARAGRAPH-LEVEL ELEMENTS                   -->
+<!-- ============================================================= -->
+
+
+<!--                    PARAGRAPH                                  -->
+<!--                    The basic block-unit of textual information
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=p
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=p
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=p
+                                                                   -->
+<!ELEMENT  p            (#PCDATA %p-elements;)*                      >
+<!ATTLIST  p
+             %p-atts;                                                >
+
+
+<!-- ============================================================= -->
+<!--                    THE REST OF THE PARAGRAPH ELEMENTS         -->
+<!-- ============================================================= -->
+
+
+<!--                    QUOTE, DISPLAYED MODEL                     -->
+<!--                    Content model for the Display Quote element-->
+<!ENTITY % disp-quote-model
+                        "(label?, title?, (%para-level;)*,
+                          (%display-back-matter.class;)* )"          >
+
+
+<!--                    QUOTE, DISPLAYED                           -->
+<!--                    Extract or extended quoted passage from
+                        another work, usually made typographically
+                        distinct from the surrounding text.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=disp-quote
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=disp-quote
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=disp-quote
+                                                                   -->
+<!ELEMENT  disp-quote   %disp-quote-model;                           >
+<!ATTLIST  disp-quote
+             %disp-quote-atts;                                       >
+
+
+<!--                    SPEECH MODEL                               -->
+<!--                    Content model for the <speech> element     -->
+<!ENTITY % speech-model "(speaker, (%just-para.class;)+ )"           >
+
+
+<!--                    SPEECH                                     -->
+<!--                    One exchange in a real or imaginary
+                        conversation between two or more entities,
+                        for example, between a an interviewer and the
+                        person being interviewed, between a nurse or
+                        doctor and a patient, between a person and a
+                        computer, etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=speech
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=speech
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=speech
+                                                                   -->
+<!ELEMENT  speech       %speech-model;                               >
+<!ATTLIST  speech
+             %speech-atts;                                           >
+
+
+<!--                    SPEAKER ELEMENTS                           -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a speaker.                                 -->
+<!ENTITY % speaker-elements
+                        "| %person-name.class; | %simple-link.class;">
+
+
+<!--                    SPEAKER                                    -->
+<!--                    One who utters a speech as part of a
+                        speech, for example the computer "HAL" in
+                        the exchange 'Hal: "Hi Dave"'.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=speaker
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=speaker
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=speaker
+                                                                   -->
+<!ELEMENT  speaker      (#PCDATA %speaker-elements;)*                >
+<!ATTLIST  speaker
+             %speaker-atts;                                          >
+
+
+<!--                    STATEMENT, FORMAL MODEL                    -->
+<!--                    Content model for the <statement> element  -->
+<!ENTITY % statement-model
+                        "(label?, title?, 
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          (%just-para.class; | %statement.class;)+,
+                          (%display-back-matter.class;)*)"           >
+
+
+<!--                    STATEMENT, FORMAL                          -->
+<!--                    A Theorem, Lemma, Proof, Postulate,
+                        Hypothesis, Proposition, Corollary, or
+                        other formal statement, identified as such
+                        with a label, usually made typographically
+                        distinct from the surrounding text
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=statement
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=statement
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=statement
+                                                                   -->
+<!ELEMENT  statement    %statement-model;                            >
+<!ATTLIST  statement
+             %statement-atts;                                        >
+
+
+<!--                    VERSE GROUP MODEL                          -->
+<!--                    Content model for the <verse-group> element-->
+<!ENTITY % verse-group-model
+                        "(label?, title?, subtitle?,
+                         (verse-line | verse-group)+,
+                         (%display-back-matter.class;)*) "           >
+
+
+<!--                    VERSE FORM FOR POETRY                      -->
+<!--                    A song, poem, or verse.
+                        Implementer's Note: No attempt has been made
+                        to retain the look or visual form of the
+                        original.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=verse-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=verse-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=verse-group
+                                                                   -->
+<!ELEMENT  verse-group  %verse-group-model;                          >
+<!ATTLIST  verse-group
+             %verse-group-atts;                                      >
+
+
+<!--                    VERSE-LINE ELEMENTS                        -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <verse-line>
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % verse-line-elements
+                        "%simple-text; | %simple-link.class;"        >
+
+
+<!--                    LINE OF A VERSE                            -->
+<!--                    One line of a poem or verse
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=verse-line
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=verse-line
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=verse-line
+                                                                   -->
+<!ELEMENT  verse-line   (#PCDATA %verse-line-elements;)*             >
+<!ATTLIST  verse-line
+             %verse-line-atts;                                       >
+
+
+<!-- ================== End Paragraph Class Module =============== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-phrase1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-phrase1.ent
@@ -1,0 +1,607 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Subject Phrase Class Elements                     -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Subject Phrase Class Elements v1.2 20190208//EN"
+     Delivered as file "JATS-phrase1.ent"                          -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Defines the phrase.class, that is, names the      -->
+<!--             inline, subject-specific elements                 -->
+<!--                                                               -->
+<!--             If more specific subject words (such as "gene")   -->
+<!--             are added to later version of this DTD, they      -->
+<!--             should be added to the %phrase.class; entity and  -->
+<!--             defined in this module or in %common.ent;         -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             the DTD suite should be sent in email to:         -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 20. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 19. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+     
+ 18. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 17. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+   
+ 16. STYLED CONTENT - Added new @style-detail attribute to
+     <styled-content>, to account for dots, sesamis, and
+     other non-western emphasis.
+   
+ 15. VOCABULARY/TAXONOMY ATTRIBUTES - Added 4 new attributes for
+     naming (and possibly linking to) a general or controlled
+     taxonomy, vocabulary, index, database or other source of
+     terms: @vocab, @vocab-identifier, @vocab-term, and
+     @vocab-term-identifier
+      - All 4 added to <named-content>, to name a vocabulary 
+        as the source of the content being identified
+ 
+ 14. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 13. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 12. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 11. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 10. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+      
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  9. NAMED CONTENT ATTRIBUTE - Added @rid to the attributes of
+     <named-content>.
+   
+  8. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  7. Updated the DTD-version attribute to "0.4" 
+   
+  6. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  5. MILESTONE END ATTRIBUTES - The new parameter entity
+     %milestone-end-atts; now uses %milestone-atts;, as it used to,
+     for compatibility purposes. This had not been done.
+
+  4. ACCESSIBILITY- Added @alt to
+     - <abbrev> through %abbrev-atts;
+     - <named-content> through %named-content-atts;
+     - <styled-content> through %styled-content-atts:
+
+  3. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+      - abbrev through abbrev-atts (both)
+      - milestone-start through milestone-atts (@xml:lang only;
+           @specific-use already)
+      - milestone-end through milestone-end-atts (both)
+      - named-content through named-content-atts (@xml:lang only;
+           @specific-use already)
+      - styled-content through styled-content-atts (@xml:lang only;
+           @specific-use already)
+
+  2. MILESTONE - The attribute list for <milestone-start> was
+     named milestone-atts not milestone-start-atts. Added the
+     new PE milestone-start-atts, but set it to the value of
+     milestone-atts so as not to break customizations.
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    ABBREVIATION ATTRIBUTES                    -->
+<!--                    Attributes for the <abbrev> element        -->
+<!ENTITY % abbrev-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             alt        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    MILESTONE ATTRIBUTES                       -->
+<!--                    Attributes for both the <milestone-start> 
+                        and <milestone-end> elements               -->
+<!ENTITY % milestone-atts
+            "%jats-common-atts;                                       
+             rid        IDREF                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             rationale  CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    MILESTONE START ATTRIBUTES                 -->
+<!--                    Attributes for the <milestone-start>
+                        element                                    -->
+<!ENTITY % milestone-start-atts
+            "%milestone-atts;"                                       >
+
+
+<!--                    MILESTONE END ATTRIBUTES                   -->
+<!--                    Attributes for the <milestone-end>
+                        element                                    -->
+<!ENTITY % milestone-end-atts
+            "%milestone-atts;"                                       >
+
+
+<!--                    NAMED CONTENT ATTRIBUTES                   -->
+<!--                    Attributes for the <named-content> element -->
+<!ENTITY % named-content-atts
+            "%jats-common-atts;                                       
+             rid        IDREFS                            #IMPLIED
+             alt        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #REQUIRED
+             vocab      CDATA                             #IMPLIED
+             vocab-identifier
+                        CDATA                             #IMPLIED
+             vocab-term CDATA                             #IMPLIED
+             vocab-term-identifier
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    STYLED CONTENT ATTRIBUTES                  -->
+<!--                    Attributes for the <styled-content> element-->
+<!ENTITY % styled-content-atts
+            "%jats-common-atts; 
+             toggle     (yes | no)                        #IMPLIED
+             style      CDATA                             #IMPLIED
+             style-type CDATA                             #IMPLIED
+             style-detail
+                        CDATA                             #IMPLIED
+             alt        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    PHRASE-LEVEL ELEMENTS                      -->
+<!-- ============================================================= -->
+
+
+<!--                    ABBREVIATION ELEMENTS                      -->
+<!--                    Elements for use in the <abbrev> element   -->
+<!ENTITY % abbrev-elements
+                        "| %def.class;"                              >
+
+
+<!--                    ABBREVIATION OR ACRONYM                    -->
+<!--                    Used to identify an abbreviation or acronym
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=abbrev
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=abbrev
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=abbrev
+                                                                   -->
+<!ELEMENT  abbrev       (#PCDATA %abbrev-elements;)*                 >
+<!ATTLIST  abbrev
+             %abbrev-atts;                                           >
+
+
+<!-- ============================================================= -->
+<!--                    MILESTONE ELEMENTS                         -->
+<!-- ============================================================= -->
+
+
+<!--                    MILESTONE MODEL                            -->
+<!--                    Model for both the <milestone-start> and
+                        <milestone-end> elements                   -->
+<!ENTITY % milestone-model
+                        "EMPTY"                                      >
+
+
+<!--                    MILESTONE START MODEL                      -->
+<!--                    Model for the both the <milestone-start>
+                        element                                    -->
+<!ENTITY % milestone-start-model
+                        "%milestone-model;"                          >
+
+
+<!--                    MILESTONE START                            -->
+<!--                    Used to mark the start of a non-hierarchically
+                        nested object, that is, a textual component
+                        which cannot be expressed in the normal
+                        non-overlapping, OCHO structure of an XML
+                        document. When this element is used, it is
+                        assumed that the end of the textual
+                        component will be marked with a
+                        <milestone-end> element.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=milestone-start
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=milestone-start
+                                                                   -->
+<!ELEMENT  milestone-start
+                        %milestone-start-model;                      >
+<!ATTLIST  milestone-start
+             %milestone-start-atts;                                  >
+
+
+<!--                    MILESTONE END MODEL                        -->
+<!--                    Model for the both the <milestone-end>
+                        element                                    -->
+<!ENTITY % milestone-end-model
+                        "%milestone-model;"                          >
+
+
+<!--                    MILESTONE END                              -->
+<!--                    Used to mark the end of a non-hierarchically
+                        nested object, that is, a textual component
+                        which cannot be expressed in the normal
+                        non-overlapping, OCHO structure of an XML
+                        document. When this element is used, it is
+                        assumed that the start of the textual
+                        component was marked with a <milestone-start>
+                        element.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=milestone-end
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=milestone-end
+                                                                   -->
+<!ELEMENT  milestone-end
+                        %milestone-end-model;                        >
+<!ATTLIST  milestone-end
+             %milestone-end-atts;                                    >
+
+
+<!-- ============================================================= -->
+<!--                    NAMED CONTENT ELEMENTS                     -->
+<!-- ============================================================= -->
+
+
+<!--                    NAMED CONTENT ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <named-content> element                -->
+<!ENTITY % named-content-elements
+                        "| %address-link.class; |
+                         %article-link.class; |
+                         %block-display.class; | %block-math.class;|
+                         %emphasis.class;  |
+                         %inline-display-noalt.class; |
+                         %inline-math.class; | %list.class; |
+                         %math.class; | %phrase.class; |
+                         %simple-link.class; |
+                         %subsup.class; | %rest-of-para.class;"      >
+
+
+<!--                    NAMED SPECIAL (SUBJECT) CONTENT            -->
+<!--                    A semantically distinct word or phrase
+                        within the text. Often such phrases are
+                        treated differently, for example, given a
+                        different typographic style or look, to call
+                        attention to the subject matter. For
+                        example, the word is a drug name or a
+                        gene or the phrase identifies an organism
+                        genus/species.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=named-content
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=named-content
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=named-content
+                                                                   -->
+<!ELEMENT  named-content
+                        (#PCDATA %named-content-elements;)*          >
+<!ATTLIST  named-content
+             %named-content-atts;                                    >
+
+
+<!-- ============================================================= -->
+<!--                    STYLED CONTENT ELEMENTS                    -->
+<!-- ============================================================= -->
+
+
+<!--                    STYLED CONTENT ELEMENTS                    -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <styled-content> element               -->
+<!ENTITY % styled-content-elements
+                        "| %address-link.class; |
+                         %article-link.class; |
+                         %block-display.class; | %block-math.class;|
+                         %emphasis.class; |
+                         %inline-display-noalt.class; |
+                         %inline-math.class; | %list.class; |
+                         %math.class; | %phrase.class; |
+                         %simple-link.class; |
+                         %subsup.class; | %rest-of-para.class;"      >
+
+
+<!--                    STYLED SPECIAL (SUBJECT) CONTENT           -->
+<!--                    A stylistically distinct word or phrase
+                        within the text, that cannot be tagged using
+                        any of the other mechanisms for such content.
+                        In other words: the content cannot be
+                        described with bold, italic, monospace or any
+                        of the other emphasis class elements and
+                        <named-content> is inappropriate because the
+                        semantic reason behind the typographic
+                        distinction is not clear.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=styled-content
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=styled-content
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=styled-content
+                                                                   -->
+<!ELEMENT  styled-content
+                        (#PCDATA %styled-content-elements;)*         >
+<!ATTLIST  styled-content
+             %styled-content-atts;                                   >
+
+
+<!-- ================== End Phrase Class Module ================== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-references1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-references1.ent
@@ -1,0 +1,1328 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Bibliographic Reference (Citation) Class Elements -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+ 
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Bibliographic Reference (Citation) Class Elements v1.2 20190208//EN"
+Delivered as file "JATS-references1.ent"                           -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Defines the bibliographic reference elements      -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 30. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 29. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 28. PUB-ID-TYPE - @pub-id-type changed back to a fixed list from 
+     CDATA, reversing the decision of Version 1.2d1. Although 
+     the value list is unchanged, best practice will be documented
+     as using @pub-id-type for type and @assigning-authority
+     for the responsible agency.
+         - <pub-id>
+
+ 27. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 26. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+ 
+ 25. INLINE-GRAPHIC and PRIVATE-CHAR - both <inline-graphic> and
+     <private-char> added to elements allowed in:
+      - <data-title>
+      - <std>
+ 
+ 24. PUB-ID-TYPE - @pub-id-type changed from a fixed list to
+     CDATA for all usages of the attribute.
+
+ 23. SOURCE/CHAPTER TITLE/PART TITLE - Added the following elements
+     to <source>, <chapter-title>, and <part-title> to more
+     closely mirror the model of <article-title>:
+        - abbrev class
+             abbrev
+        - inline-display class
+             alternatives | inline-graphic | private-char
+        - inline-math class 
+             chem-struct | inline-formula
+        - math class
+             tex-math | mml:math
+        - simple link class
+             fn | target | xref 
+     
+ 22. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 21. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 20. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 19. ATTRIBUTES FOR PUB-ID
+   - Added the linking attributes (optional version) to <pub-id> , 
+     so that a <pub-id> that is a DOI, for example, can carry the 
+     linking attributes and be made into a live link. In this use
+     of <pub-id>, the element is acting both as an identifier
+     and as a link.
+   - Added new attribute @assigning-authority to <pub-id>, to
+     carry new values such as "CrossRef" and to take some of the
+     semantic burden off the '@pub-id-type' attribute, when
+     values are organizations such as "Genbank" or "PDB".
+ 
+ 18. VERSION FOR DATASETS - Added new element <version>
+     for citing datasets and software. Similar to <edition>
+     for printed material.
+ 
+ 17. DATA TITLE FOR DATASETS - Added new element <data-title>
+     to name datasets and parts of datasets. Acts both as an
+     <article-title> equivalent and as a <source> equivalent,
+     since many levels of data may be cited.
+
+ 16. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 15. ACCESS DATE ELEMENT
+     Added attributes for @calendar and @iso-8601-date. The element is
+     deprecated but still in use.
+
+ 14. NEW <era> ELEMENT
+     Added <era> through date-parts.class to:
+      - <date-in-citation>
+
+ 13. INSTITUTIONS TO STANDARDS ORGANIZATIONS
+     Added the elements <institution-wrap> to the following elements
+     through the institution-wrap.class:
+      - <std-organization>
+
+ 12. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+ 11. EDITION 
+       a) Changed the long name of the <edition> element
+          ("Edition, Cited)") to "Edition Statement, Cited" to
+          indicate that element MAY contain more than just the
+          edition number.
+       b) Changed the definition of <edition> to include the full
+          edition statement and not just the edition number.
+       c) Added new element @designator to hold the edition
+          number, since the definition of edition is changing.
+          (through %edition-atts).
+   
+ 10. DATE IN CITATION ATTRIBUTES - Added to the attributes for
+     <date-in-citation> (through @date-in-citation-atts):
+       a) ISO 8601 standard date format attribute (@iso-8601-date) 
+          Format  YYYY-MM-DDThh:mm:ss 
+       b) Name of the calendar used (@calendar), to hold values
+          such as "Gregorian", "Japanese" (Emperor years), or
+          "Islamic".
+   
+  9. STANDARD ORGANIZATION - Added new element for the name of
+     the standards body that created or that promulgates a
+     standard. <std-organization> may be used as part of the
+     description of a cited standard inside a citation.
+     (New PEs: std-organization-atts; std-organization-elements)
+   
+  8. STANDARD MODEL - Updated the model for <std>, the description
+     of a cited standard in side a citation to include several
+     elements:
+         - <source> contains the name of the standard
+         - <pub-id> contains the standard designator
+         - date elements <month>, <day>, and <year> name the 
+              official date
+         - <std-organization> (new element) names the standards 
+             body
+         - <named-content> takes anything else a publisher/archive 
+             wishes to record, such as the standard status, et al.
+      The following elements were retained form the older model
+      and so will also be allowed inside <std:>
+
+         - <styled-content> because archives cannot always know the
+             reason behind a typographic change
+         - the emphasis elements (all face markup)
+         - <sub> and <sup>
+   
+ 7.  Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  6. Updated the DTD-version attribute to "0.4" 
+   
+  5. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  4. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+      - access-date through access-date-atts (only @specific-use)
+      - annotation through annotation-atts (both)
+      - chapter-title through chapter-title-atts (both) NEW PE
+      - comment through comment-atts (both)
+      - date-in-citation through date-in-citation-atts (both)
+      - edition through edition-atts (both)
+      - gov through gov-atts (both)
+      - note through note-atts (both)
+      - part-title through part-title-atts (both) NEW PE
+      - patent through patent-atts (both)
+      - person-group through person-group-atts (both)
+      - pub-id through pub-id-atts (@specific-use only)
+      - ref through ref-atts (both)
+      - ref-list through ref-list-atts (@specific-use only)
+      - series through series-atts (both)
+      - source through source-atts (@specific-use only;
+          @xml:lang already)
+      - std through std-atts (both)
+      - time-stamp through time-stamp-atts (@specific-use only)
+      - trans-source through trans-source-atts (@specific-use only;
+          @xml:lang already)
+
+  3. PERSON GROUP - Changed the model of <person-group> to mixed
+     content. This entailed: creating new PE %person-group-elements;
+     that contained the elements to be used and Changing PE
+     %person-group-model to (#PCDATA %person-group-elements;)*.
+     The PE person-group-model has been retained in this module for
+     compatibility, but has been set to the mixed model using
+     person-group-elements.
+
+  2. ANNOTATION - Changed to content model to use the parameter
+     entity %annotation-model; Content model unchanged.
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR #PCDATA MODELS      -->
+<!-- ============================================================= -->
+
+
+<!--                    SOURCE ELEMENTS                            -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <source> or <trans-source>.              -->
+<!ENTITY % source-elements
+                        "| %abbrev.class; |
+                         %address-link.class; |%emphasis.class; |
+                         %inline-display.class; |
+                         %inline-math.class; | %math.class; |
+                         %phrase-content.class; | 
+                         %simple-link.class; | %subsup.class;"       >
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    ACCESS DATE ATTRIBUTES                     -->
+<!--                    Attributes for the <access-date> element   -->
+<!ENTITY % access-date-atts
+            "%jats-common-atts;                                       
+             iso-8601-date
+                        CDATA                             #IMPLIED
+             calendar   CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    ANNOTATION ATTRIBUTES                      -->
+<!--                    Attributes for the <annotation> element    -->
+<!ENTITY % annotation-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    CHAPTER TITLE ATTRIBUTES                   -->
+<!--                    Attributes for the <chapter-title> element -->
+<!ENTITY % chapter-title-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    COMMENT ATTRIBUTES                         -->
+<!--                    Attributes for the <comment> element       -->
+<!ENTITY % comment-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DATA TITLE ATTRIBUTES                      -->
+<!--                    Attributes for the <data-title> element    -->
+<!ENTITY % data-title-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DATE IN CITATION ATTRIBUTES                -->
+<!--                    Attributes for the <date-in-citation>
+                                                         element   -->
+<!ENTITY % date-in-citation-atts
+            "%jats-common-atts;                                       
+             iso-8601-date
+                        CDATA                             #IMPLIED
+             calendar   CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    EDITION ATTRIBUTES                         -->
+<!--                    Attributes for the <edition> element       -->
+<!ENTITY % edition-atts
+            "%jats-common-atts;                                       
+             designator CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    GOVERNMENT ATTRIBUTES                      -->
+<!--                    Attributes for the <gov> element           -->
+<!ENTITY % gov-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    NOTE ATTRIBUTES                            -->
+<!--                    Attributes for the <note> element          -->
+<!ENTITY % note-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PART TITLE ATTRIBUTES                      -->
+<!--                    Attributes for the <part-title> element    -->
+<!ENTITY % part-title-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PATENT ATTRIBUTES                          -->
+<!--                    Attributes for the <patent> element        -->
+<!ENTITY % patent-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             country    CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PERSON GROUP ATTRIBUTES                    -->
+<!--                    Attributes for the <person-group> element  -->
+<!ENTITY % person-group-atts
+            "%jats-common-atts;                                       
+             person-group-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PUBLICATION IDENTIFIER ATTRIBUTES          -->
+<!--                    Attributes for the <pub-id> element        -->
+<!ENTITY % pub-id-atts
+            "%jats-common-atts;                                       
+             pub-id-type
+                        (%pub-id-types;)                  #IMPLIED
+             assigning-authority                
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    REFERENCE ATTRIBUTES                       -->
+<!--                    Attributes for the <ref> element           -->
+<!ENTITY % ref-atts
+            "%jats-common-atts;                                       
+              content-type
+                        CDATA                             #IMPLIED
+              specific-use
+                        CDATA                             #IMPLIED
+              xml:lang  NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    REFERENCE LIST ATTRIBUTES                  -->
+<!--                    Attributes for the <ref-list> element      -->
+<!ENTITY % ref-list-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SERIES ATTRIBUTES                          -->
+<!--                    Attributes for the <series> element        -->
+<!ENTITY % series-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SOURCE ATTRIBUTES                          -->
+<!--                    Attributes for the <source> element        -->
+<!ENTITY % source-atts
+            "%jats-common-atts;                                       
+             content-type
+                       CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    STANDARDS ATTRIBUTES                       -->
+<!--                    Attributes for the <std> element           -->
+<!ENTITY % std-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    STANDARDS ORGANIZATION ATTRIBUTES          -->
+<!--                    Attributes for the <std-organization> 
+                        element                                    -->
+<!ENTITY % std-organization-atts
+            "%jats-common-atts;                                       
+             content-type
+                       CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    TIME STAMP ATTRIBUTES                      -->
+<!--                    Attributes for the <time-stamp> element    -->
+<!ENTITY % time-stamp-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    TRANSLATED SOURCE ATTRIBUTES               -->
+<!--                    Attributes for the <trans-source> element  -->
+<!ENTITY % trans-source-atts
+            "%jats-common-atts;                                       
+             content-type
+                       CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    VERSION ATTRIBUTES                         -->
+<!--                    Attributes for the <version> element       -->
+<!ENTITY % version-atts
+            "%jats-common-atts;                                       
+             designator CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    BIBLIOGRAPHIC REFERENCE LIST ELEMENTS      -->
+<!-- ============================================================= -->
+
+
+<!--ELEM   article-title
+                        Defined in %common.ent;                    -->
+<!--ELEM   collab       Defined in %common.ent;                    -->
+<!--ELEM   conf-date    Defined in %common.ent;                    -->
+<!--ELEM   conf-loc     Defined in %common.ent;                    -->
+<!--ELEM   conf-name    Defined in %common.ent;                    -->
+<!--ELEM   day          Defined in %common.ent;                    -->
+<!--ELEM   elocation-id Defined in %common.ent;                    -->
+<!--ELEM   email        Defined in %common.ent;                    -->
+<!--ELEM   fpage        Defined in %common.ent;                    -->
+<!--ELEM   issn         Defined in %common.ent;                    -->
+<!--ELEM   issn-l       Defined in %common.ent;                    -->
+<!--ELEM   issue        Defined in %common.ent;                    -->
+<!--ELEM   lpage        Defined in %common.ent;                    -->
+<!--ELEM   month        Defined in %common.ent;                    -->
+<!--ELEM   publisher-loc
+                        Defined in %common.ent;                    -->
+<!--ELEM   publisher-name
+                        Defined in %common.ent;                    -->
+<!--ELEM   season       Defined in %common.ent;                    -->
+<!--ELEM   title        Defined in %common.ent;                    -->
+<!--ELEM   trans-title  Defined in %common.ent;                    -->
+<!--ELEM   volume       Defined in %common.ent;                    -->
+<!--ELEM   year         Defined in %common.ent;                    -->
+
+
+<!--                    REFERENCE LIST MODEL                       -->
+<!--                    Content model for the <ref-list> element   -->
+<!ENTITY % ref-list-model
+                        "(label?, title?, (%para-level;)*, ref*,
+                         (%ref-list.class;)* )"                      >
+
+
+<!--                    REFERENCE LIST (BIBLIOGRAPHIC REFERENCE LIST)
+                                                                   -->
+<!--                    List of references (citations) for the
+                        article.  Often called "References",
+                        "Bibliography", or "Additional Reading". No
+                        distinction is made between lists of cited
+                        references and lists of suggested references.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=ref-list
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=ref-list
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=ref-list
+                                                                   -->
+<!ELEMENT  ref-list     %ref-list-model;                             >
+<!ATTLIST  ref-list
+             %ref-list-atts;                                         >
+
+
+<!--                    REFERENCE ITEM MODEL                       -->
+<!--                    Content model for the <ref> element        -->
+<!ENTITY % ref-model    "(label?,
+                         (%citation.class; | %note.class;)+ )"       >
+
+
+<!--                    REFERENCE ITEM                             -->
+<!--                    One item in a bibliographic list, typically
+                        a citation describing a referenced work, but
+                        some journals may place notes in this list as
+                        well as citations.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=ref
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=ref
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=ref
+                                                                   -->
+<!ELEMENT  ref          %ref-model;                                  >
+<!ATTLIST  ref
+             %ref-atts;                                              >
+
+
+<!--ELEM   element-citation
+                        Defined in %common.ent;                    -->
+<!--ELEM   mixed-citation
+                        Defined in %common.ent;                    -->
+
+
+<!--                    NOTE IN A REFERENCE LIST MODEL             -->
+<!--                    Content model for a note in a reference
+                        list element                               -->
+<!ENTITY % note-model   "(label?,
+                          (%just-para.class; | %product.class;)+ )"  >
+
+
+<!--                    NOTE IN A REFERENCE LIST                   -->
+<!--                    Used to tag non-citation material that
+                        sometimes within a reference list, for
+                        example, used to tag end note material when
+                        such a note is placed within a reference
+                        list.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=note
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=note
+                                                                   -->
+<!ELEMENT  note         %note-model;                                 >
+<!ATTLIST  note
+             %note-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    BIBLIOGRAPHIC REFERENCE CLASS              -->
+<!-- ============================================================= -->
+
+
+<!--                    ACCESS DATE ELEMENTS                       -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the Access Date <access-date> element      -->
+<!ENTITY % access-date-elements
+                        ""                                           >
+
+
+<!--                    ACCESS DATE FOR CITED WORK                 -->
+<!--                    The date on which the work which is cited
+                        was examined. Some online resources are
+                        changing so quickly that a citation to the
+                        resource is not complete without the date
+                        on which the cited resource was examined,
+                        since a day before or a day later the
+                        relevant material might be different.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=access-date
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=access-date
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=access-date
+                                                                   -->
+<!ELEMENT  access-date  (#PCDATA %access-date-elements;)*            >
+<!ATTLIST  access-date
+             %access-date-atts;                                      >
+
+
+<!--                    ANNOTATION MODEL                           -->
+<!--                    The content model for the <annotation>
+                        element                                    -->
+<!ENTITY % annotation-model
+                        "((%just-para.class;)+)"                     >
+
+
+<!--                    ANNOTATION IN A CITATION                   -->
+<!--                    Most citations just provide the bibliographic
+                        information for a cited reference but a few
+                        describe or comment upon the nature or
+                        quality of the reference or summarize its
+                        findings.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=annotation
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=annotation
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=annotation
+                                                                   -->
+<!ELEMENT  annotation   %annotation-model;                           >
+<!ATTLIST  annotation
+             %annotation-atts;                                       >
+
+
+<!--                    CHAPTER TITLE ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <chapter-title> element                -->
+<!ENTITY % chapter-title-elements
+                        "%source-elements;"                          >
+
+
+<!--                    CHAPTER TITLE IN A CITATION                -->
+<!--                    Within a citation (such as a <mixed-citation>
+                        or an <element-citation>), the title of a
+                        cited book is tagged as <source> and the
+                        title of a chapter within that book is tagged
+                        as <chapter-title>.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=chapter-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=chapter-title
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=chapter-title
+                                                                   -->
+<!ELEMENT  chapter-title
+                        (#PCDATA %chapter-title-elements;)*          >
+<!ATTLIST  chapter-title
+             %chapter-title-atts;                                    >
+
+
+<!--                    COMMENT ELEMENTS                           -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the Comment in a Citation <comment> element.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % comment-elements
+                        "%simple-phrase;"                            >
+
+
+<!--                    COMMENT IN A CITATION                      -->
+<!--                    Used to mark unstructured text within an
+                        otherwise element structured reference.
+                        In an unstructured reference, this text would
+                        merely be data characters.
+                        Typical comments could include:
+                          <comment>[Abstract]</comment>
+                          <comment> translated from Russian</comment>
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=comment
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=comment
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=comment
+                                                                   -->
+<!ELEMENT  comment      (#PCDATA %comment-elements;)*                >
+<!ATTLIST  comment
+             %comment-atts;                                          >
+
+
+<!--                    DATA TITLE ELEMENTS                        -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <data-title>.                            -->
+<!ENTITY % data-title-elements
+                        "| %address-link.class; |      
+                           %inline-display-noalt.class; | 
+                           %emphasis.class; | 
+                           %phrase-content.class; | %subsup.class;"  >
+
+
+<!--                    DATA TITLE IN A CITATION                   -->
+<!--                    Within a citation (such as a <mixed-citation>
+                        or an <element-citation>), the title of a
+                        cited data source such as a dataset or
+                        spreadsheet. 
+                        REMARKS: Since datasets can contain very
+                        complex relationships, for citing data, this 
+                        element may describe different levels, taking
+                        the place of both <article-title> and <source>
+                        when citing data.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=data-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=data-title
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=data-title
+                                                                   -->
+<!ELEMENT  data-title
+                        (#PCDATA %data-title-elements;)*             >
+<!ATTLIST  data-title
+             %data-title-atts;                                       >
+
+<!--                    DATE IN CITATION ELEMENTS                  -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the Date Inside Citation <date-in-citation>
+                        element                                    -->
+<!ENTITY % date-in-citation-elements
+                        "| %date-parts.class;"                       >
+
+
+<!--                    DATE INSIDE CITATION                       -->
+<!--                    A container element for any date that may be
+                        referenced in a citation, other than the
+                        publication date of the cited work.
+                        The "content-type" attribute should be used
+                        to identify the purpose/type of date. For
+                        example, if the element contains the date
+                        on which the article contributor examined the
+                        cited work, the attribute might be
+                        "access-date".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=date-in-citation
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=date-in-citation
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=date-in-citation
+                                                                   -->
+<!ELEMENT  date-in-citation
+                        (#PCDATA %date-in-citation-elements;)*       >
+<!ATTLIST  date-in-citation
+             %date-in-citation-atts;                                 >
+
+
+<!--                    EDITION ELEMENTS                           -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <edition>
+                        Design Note: -%just-rendition; begins with
+                        an OR bar, so this inline mix begins with
+                        an OR bar.                                 -->
+<!ENTITY % edition-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    EDITION STATEMENT, CITED                   -->
+<!--                    The full edition statement for a cited or
+                        referenced publication. This may include
+                        textual words ("Third print edition revised"),
+                        ordinals ("3rd"), superscripted ordinals
+                        ("3<sup>rd</sup>), or simply the edition number
+                        ("3"). 
+                        Remarks: The @designator attribute may be used
+                        to record the alphabetic or numerical 
+                        edition number.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=edition
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=edition
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=edition
+                                                                   -->
+<!ELEMENT  edition      (#PCDATA %edition-elements;)*                >
+<!ATTLIST  edition
+             %edition-atts;                                          >
+
+
+<!--                    GOVERNMENT REPORT ELEMENTS                 -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <gov>
+                        Design Note: -%rendition-plus; begins with
+                        an OR bar, so this inline mix begins with
+                        an OR bar.                                 -->
+<!ENTITY % gov-elements "%rendition-plus;"                           >
+
+
+<!--                    GOVERNMENT REPORT, CITED                   -->
+<!--                    The identification information (typically the
+                        title and/or an identification number) for
+                        a cited governmental report or other
+                        government publication
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=gov
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=gov
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=gov
+                                                                   -->
+<!ELEMENT  gov          (#PCDATA %gov-elements;)*                    >
+<!ATTLIST  gov
+             %gov-atts;                                              >
+
+
+<!--                    PART TITLE ELEMENTS                        -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <part-title> element                   -->
+<!ENTITY % part-title-elements
+                        "%source-elements;"                          >
+
+
+<!--                    PART TITLE IN A CITATION                   -->
+<!--                    Within a citation (such as a
+                        <mixed-citation> or an <element-citation>),
+                        when books are divided into Parts (which
+                        may then contain smaller units such as
+                        chapters), this element can be used to
+                        record the title of the cited Part.
+                        The book is tagged as <source>.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=part-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=part-title
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=part-title
+                                                                   -->
+<!ELEMENT  part-title   (#PCDATA %part-title-elements;)*             >
+<!ATTLIST  part-title
+             %part-title-atts;                                       >
+
+
+<!--                    PATENT NUMBER ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <patent>
+                        Design Note: -%just-rendition; begins with
+                        an OR bar, so this inline mix begins with
+                        an OR bar.                                 -->
+<!ENTITY % patent-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    PATENT NUMBER, CITED                       -->
+<!--                    The identification information (typically the
+                        patent number or number and name) for a
+                        cited patent
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=patent
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=patent
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=patent
+                                                                   -->
+<!ELEMENT  patent       (#PCDATA %patent-elements;)*                 >
+<!ATTLIST  patent
+             %patent-atts;                                           >
+
+
+<!--                    PERSON GROUP ELEMENTS                      -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <person-group>                             -->
+<!ENTITY % person-group-elements
+                        "| %name.class; |
+                          %person-group-info.class;"                 >
+
+
+<!--                    PERSON GROUP MODEL                         -->
+<!--                    Content model for the Person Group element -->
+<!ENTITY % person-group-model
+                        "(#PCDATA %person-group-elements;)*"         >
+
+
+<!--                    PERSON GROUP FOR A CITED PUBLICATION       -->
+<!--                    Wrapper element for one or more authors,
+                        editors, translators, etc. named in a cited
+                        reference.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=person-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=person-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=person-group
+                                                                   -->
+<!ELEMENT  person-group %person-group-model;                         >
+<!ATTLIST  person-group
+             %person-group-atts;                                     >
+
+
+<!--                    PUBLICATION IDENTIFIER FOR A CITED PUBLICATION
+                                                                   -->
+<!--                    The identifier of a publication such as a
+                        related journal article that is listed
+                        within a citation (such as a <mixed-citation>
+                        or an <element-citation>) inside the
+                        bibliographic reference list <ref-list> of
+                        an article.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=pub-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=pub-id
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=pub-id
+                                                                   -->
+<!ELEMENT  pub-id       (#PCDATA)                                    >
+<!ATTLIST  pub-id
+             %pub-id-atts;                                           >
+
+
+<!--                    SERIES ELEMENTS                            -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <series>
+                        Design Note: -%rendition-plus; begins with
+                        an OR bar, so this inline mix begins with
+                        an OR bar.                                 -->
+<!ENTITY % series-elements
+                        "%rendition-plus;"                           >
+
+
+<!--                    SERIES                                     -->
+<!--                    Container element for any series information
+                        used in a citation (such as a <mixed-citation>
+                        or an <element-citation>). For example,
+                        within a citation to a non-journal item that
+                        spans multiple volumes, this element could
+                        contain the unique title of the entire series:
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=series
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=series
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=series
+                                                                   -->
+<!ELEMENT  series       (#PCDATA %series-elements;)*                 >
+<!ATTLIST  series
+             %series-atts;                                           >
+
+
+<!--                    STANDARD ELEMENTS                          -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <std>
+                        Design Note: -%rendition-plus; begins with
+                        an OR bar, so this inline mix begins with
+                        an OR bar.                                 -->
+<!ENTITY % std-elements "| %emphasis.class; | 
+                           %inline-display-noalt.class; |
+                           %phrase-content.class; | %std.class; | 
+                           %subsup.class;"                           >
+
+
+<!--                    STANDARD, CITED                            -->
+<!--                    The identification information (typically the
+                        standard number, organization, and name) for
+                        a cited standard, where "standard" is defined
+                        as a document produced by a recognized
+                        standards body such ISO, IEEE, OASIS, ANSI,
+                        etc.
+                        The elements that can be used in the mixed
+                        content model of a <std> include:
+                          <source> contains the name of the standard
+                          <pub-id> contains the standard designator
+                          date elements name the official date
+                          <std-organization> names the standards body
+                          <named-content> takes anything else a 
+                            publisher/archive needs.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=std
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=std
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=std
+                                                                   -->
+<!ELEMENT  std          (#PCDATA %std-elements;)*                    >
+<!ATTLIST  std
+             %std-atts;                                              >
+
+
+<!--                    STANDARDS ORGANIZATION ELEMENTS            -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <std-organization>.                        -->
+<!ENTITY % std-organization-elements 
+                        "| %emphasis.class; | 
+                         %institution-wrap.class; | %subsup.class;"  >
+
+
+<!--                    STANDARDS ORGANIZATION                     -->
+<!--                    The name of the standards body that created 
+                        or that promulgates a standard, such as
+                        NISO, ISO, ANSI, or industry standards
+                        organizations.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=std-organization
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=std-organization
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=std-organization
+                                                                   -->
+<!ELEMENT  std-organization
+                        (#PCDATA %std-organization-elements;)*       >
+<!ATTLIST  std-organization
+             %std-organization-atts;                                 >
+
+
+<!--                    SOURCE                                     -->
+<!--                    Within a citation, this is the title of a
+                        journal, book, conference proceedings, etc.
+                        that is the source of the cited material.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=source
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=source
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=source
+                                                                   -->
+<!ELEMENT  source       (#PCDATA %source-elements;)*                 >
+<!ATTLIST  source
+             %source-atts;                                           >
+
+
+<!--                    TIME STAMP ELEMENTS                        -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <time-stamp>.                            -->
+<!ENTITY % time-stamp-elements
+                        ""                                           >
+
+
+<!--                    TIME STAMP FOR CITED WORK                  -->
+<!--                    Used to record any time stamp that was
+                        found on the cited resource when it was
+                        examined, for resources such as databases
+                        that may use a time signature to identify
+                        different versions.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=time-stamp
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=time-stamp
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=time-stamp
+                                                                   -->
+<!ELEMENT  time-stamp   (#PCDATA %time-stamp-elements;)*             >
+<!ATTLIST  time-stamp
+             %time-stamp-atts;                                       >
+
+
+<!--                    TRANSLATED SOURCE                          -->
+<!--                    Within a citation, this is the title of a
+                        journal, book, conference proceedings, etc.
+                        that is the source of the cited material,
+                        but with the source name given in a different
+                        language from the source as given in the
+                        <source> element. For example, if an article
+                        is originally in French, the <source> name
+                        would be the French name and the
+                        <trans-source> might be in English.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=trans-source
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=trans-source
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=trans-source
+                                                                   -->
+<!ELEMENT  trans-source (#PCDATA %source-elements;)*                 >
+<!ATTLIST  trans-source
+             %trans-source-atts;                                     >
+
+
+<!--                    VERSION ELEMENTS                           -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <version>.
+                        Design Note: -%just-rendition; begins with
+                        an OR bar, so this inline mix begins with
+                        an OR bar.                                 -->
+<!ENTITY % version-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    VERSION STATEMENT, CITED                   -->
+<!--                    The version number for a cited dataset or
+                        software package. This is similar to an
+                        edition statement for a publication, in that it
+                        may include textual words ("9th"), superscripted 
+                        ordinals ("3<sup>rd</sup>), or simply the 
+                        version number ("16.2"). 
+                        Remarks: The @designator attribute may be used
+                        to record the alphabetic or numerical 
+                        version number, when the version number contains
+                        more than just a number, so the numeric version
+                        can be preserved for search and comparison.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=version
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=version
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=version
+                                                                   -->
+<!ELEMENT  version      (#PCDATA %version-elements;)*                >
+<!ATTLIST  version
+             %version-atts;                                          >
+
+
+<!-- ================== End Bibliographic Class Module =========== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-related-object1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-related-object1.ent
@@ -1,0 +1,369 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Related Object Element                            -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          -->
+<!--  DATE:      February 2019                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Related Object Element v1.2 20190208//EN"
+     Delivered as file "JATS-related-object1.ent"                  -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Define the element <related-object>. [This        -->
+<!--             module was previously part of the NLM Book Tag Set-->
+<!--             and named bookrelated-object.ent.]                -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             February 2008 (book modules Oct 2006)             -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION\CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 15. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 14. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 13. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 12. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+    
+ 11. JATS became version "1.2d1" and "v1.1d2 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 10. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  9. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  8. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  7. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+  
+  6. RELATED-OBJECT ATTRIBUTES - Added the attribute @ext-link-type
+   
+  5. RELATED-OBJECT ATTRIBUTES - Added the linking attribute to
+     <related-object> through the "might-link-atts".
+   
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    RELATED OBJECT ATTRIBUTES                  -->
+<!-- ============================================================= -->
+
+
+<!--                    RELATED OBJECT ATTRIBUTES                  -->
+<!--                    Attributes for <related-object>            -->
+<!ENTITY % related-object-atts
+            "%jats-common-atts;                                       
+             link-type  CDATA                             #IMPLIED
+             ext-link-type
+                        CDATA                             #IMPLIED
+             source-id  CDATA                             #IMPLIED
+             source-id-type
+                        CDATA                             #IMPLIED
+             source-type
+                        CDATA                             #IMPLIED
+             document-id
+                        CDATA                             #IMPLIED
+             document-id-type
+                        CDATA                             #IMPLIED
+             document-type
+                        CDATA                             #IMPLIED
+             object-id  CDATA                             #IMPLIED
+             object-id-type
+                        CDATA                             #IMPLIED
+             object-type
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!-- ============================================================= -->
+<!--                    RELATED OBJECT ELEMENT                     -->
+<!-- ============================================================= -->
+
+
+<!--                    RELATED OBJECT ELEMENTS                    -->
+<!--                    Elements allowed inside <related-object>   -->
+<!ENTITY % related-object-elements
+                        "| %emphasis.class; |
+                         %phrase-content.class; |
+                         %references.class; |  %subsup.class;"       >
+
+
+<!--                    RELATED OBJECT INFORMATION                 -->
+<!--                    Wrapper element, used as a container for
+                        text links to a related object, possibly
+                        accompanied by a very brief description of
+                        the object, for example a related book, a
+                        related chapter or figure in a book, a
+                        related dataset, etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=related-object
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=related-object
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=related-object
+                                                                   -->
+<!ELEMENT  related-object
+                        (#PCDATA %related-object-elements;)*         >
+<!ATTLIST  related-object
+             %related-object-atts;                                   >
+
+
+<!-- ================== End Related Object Element Module ======== -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-section1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-section1.ent
@@ -1,0 +1,410 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Section Class Elements                            -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          --> 
+<!--  DATE:      February 2019                                     --> 
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Section Class Elements v1.2 20190208//EN"
+     Delivered as file "JATS-section1.ent"                         -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->         
+<!--                                                               -->
+<!-- PURPOSE:    Defines the member of the sec.class, that is,     -->
+<!--             names all section-level elements in the           -->
+<!--             JATS DTD Suite                                    -->
+<!--                                                               -->
+<!--             At the time of the initial DTD creation           -->
+<!--             there is only one such element, Section itself    -->
+<!--             <sec>, but future expansion to named sections     -->
+<!--             (such as <methodology> or <materials> or any      -->
+<!--             new section-level structures would be added here. -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 13. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 12. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 11. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 10. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+    
+  9. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  8. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. JATS became version "1.1d3" and "v1.1 20150301//EN"
+ 
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+  6. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  5. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added an attribute list to:
+      - floats-group
+      - sec-meta
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    DEFAULTS FOR ATTRIBUTE LISTS               -->
+<!-- ============================================================= -->
+
+
+<!--                    FLOATS GROUP ATTRIBUTES                    -->
+<!--                    Attributes for the <floats-group> element  -->
+<!ENTITY % floats-group-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    SECTION ATTRIBUTES                         -->
+<!--                    Attribute list for Section element         -->
+<!ENTITY % sec-atts
+            "%jats-common-atts;                                       
+             xml:lang   NMTOKEN                            #IMPLIED
+             sec-type   CDATA                              #IMPLIED
+             disp-level CDATA                              #IMPLIED
+             specific-use
+                        CDATA                              #IMPLIED" >
+
+
+<!--                    SECTION METADATA ATTRIBUTES                -->
+<!--                    Attributes for the <sec-meta> element      -->
+<!ENTITY % sec-meta-atts
+            "%jats-common-atts;"                                     >
+
+
+<!-- ============================================================= -->
+<!--                    FLOATS GROUP ELEMENTS                      -->
+<!-- ============================================================= -->
+
+
+<!--                    FLOATS GROUP MODEL                         -->
+<!--                    Model for the container element
+                        <floats-group>, which can be used to hold all
+                        the floating elements such as tables and
+                        figures within an <article>.               -->
+<!ENTITY % floats-group-model
+                        "(%floats-display.class;)*"                  >
+
+
+<!--                    FLOATS GROUP                               -->
+<!--                    This container element is just a group to
+                        hold the floating objects that occur within
+                        an article. Some publishers like to
+                        collect all these floating objects (figures,
+                        tables, text boxes, graphics, etc.) together
+                        at the end  rather than interspersing them
+                        throughout the various parts of the document
+                        where they are referenced.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=floats-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=floats-group
+                                                                   -->
+<!ELEMENT  floats-group %floats-group-model;                         >
+<!ATTLIST  floats-group
+             %floats-group-atts;                                     >
+
+
+<!-- ============================================================= -->
+<!--                    SECTION ELEMENTS                           -->
+<!-- ============================================================= -->
+
+
+<!--                    SECTION                                    -->
+<!--                    A headed group of material; the basic
+                        structural unit of the article
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=sec
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=sec
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=sec
+                                                                   -->
+<!ELEMENT  sec          %sec-model;                                  >
+<!ATTLIST  sec
+             %sec-atts;                                              >
+
+
+<!--                    SECTION METADATA                           -->
+<!--                    In some articles, each section has a different
+                        author or some sections are authored by
+                        different contributors from the enclosing
+                        article. This container element for
+                        section-level metadata is used to capture
+                        information such as those contributors.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=sec-meta
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=sec-meta
+                                                                   -->
+<!ELEMENT  sec-meta     %sec-meta-model;                             >
+<!ATTLIST  sec-meta
+             %sec-meta-atts;                                         >
+
+
+<!-- ================== End Section Class Module ================= -->

--- a/src/main/resources/dtd/archiving/1.2/JATS-xmlspecchars1.ent
+++ b/src/main/resources/dtd/archiving/1.2/JATS-xmlspecchars1.ent
@@ -1,0 +1,475 @@
+<!-- ============================================================= -->
+<!--  MODULE:    XML Special Characters Module                     -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019)          --> 
+<!--  DATE:      February 2019                                     --> 
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite XML Special Characters Module v1.2 20190208//EN"
+     Delivered as file "JATS-xmlspecchars1.ent"                    -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    External Parameter Entities for calling in the    -->
+<!--             special character entities                        -->
+<!--                                                               -->
+<!-- MODULES REQUIRED:                                             -->
+<!--             The standard ISO special character entity sets    -->
+<!--             (see below)                                       -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for these purposes. -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 12. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+     
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 11. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+     JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     BITS is under continuous maintenance, and is modified at the
+     discretion of the working group.
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+ 10. BITS "2.0" and "v2.0 20151225" became
+     BITS "2.1" and "v2.1 20180401". 
+   
+     JATS "1.2d1" and "v1.2d1 20171231" became
+     JATS "1.2d2" and "v1.2d2 20180401". 
+
+     No module names were changed.
+ 
+    =============================================================
+     JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.2d1  (2017-12-31)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+  9. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d1" and "v1.2d1 20171231". 
+
+    =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+    
+  8. JATS became version "1.2d1" and "v1.2d1 20170631" 
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  7. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  6. JATS became version "1.1d3" and "v1.1 20150301//EN"
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  5. OASIS TABLE NAMESPACE MODIFICATIONS - Added a new module
+     that sets up the namespace URI and namespace prefix for
+     the OASIS tables models.
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    ENTITY SETS FROM INFORMATIVE ANNEX TO      -->
+<!--                       ISO 8879:1986 (SGML)                    -->
+<!-- ============================================================= -->
+
+
+<!--                    ISO STANDARD ADDED LATIN 1                 -->
+<!ENTITY % ISOlat1 PUBLIC
+"-//W3C//ENTITIES Added Latin 1 for MathML 2.0//EN"
+"iso8879/isolat1.ent"                                                >
+
+
+<!--                    ISO STANDARD ADDED LATIN 2                 -->
+<!ENTITY % ISOlat2 PUBLIC
+"-//W3C//ENTITIES Added Latin 2 for MathML 2.0//EN"
+"iso8879/isolat2.ent"                                                >
+
+
+<!--                    ISO BOX AND LINE DRAWING                   -->
+<!ENTITY % ISObox       PUBLIC
+"-//W3C//ENTITIES Box and Line Drawing for MathML 2.0//EN"
+"iso8879/isobox.ent"                                                 >
+
+
+<!--                    ISO STANDARD DIACRITICAL MARKS             -->
+<!ENTITY % ISOdia PUBLIC
+"-//W3C//ENTITIES Diacritical Marks for MathML 2.0//EN"
+"iso8879/isodia.ent"                                                 >
+
+
+<!--                    ISO STANDARD NUMERIC AND SPECIAL GRAPHIC   -->
+<!ENTITY % ISOnum PUBLIC
+"-//W3C//ENTITIES Numeric and Special Graphic for MathML 2.0//EN"
+"iso8879/isonum.ent"                                                 >
+
+
+<!--                    ISO STANDARD PUBLISHING                    -->
+<!ENTITY % ISOpub PUBLIC
+"-//W3C//ENTITIES Publishing for MathML 2.0//EN"
+"iso8879/isopub.ent"                                                 >
+
+
+<!--                    ISO STANDARD RUSSIAN CYRILLIC              -->
+<!ENTITY % ISOcyr1 PUBLIC
+"-//W3C//ENTITIES Russian Cyrillic for MathML 2.0//EN"
+"iso8879/isocyr1.ent"                                                >
+
+
+<!--                    ISO STANDARD NON-RUSSIAN CYRILLIC          -->
+<!ENTITY % ISOcyr2 PUBLIC
+"-//W3C//ENTITIES Non-Russian Cyrillic for MathML 2.0//EN"
+"iso8879/isocyr2.ent"                                                >
+
+
+<!-- ============================================================= -->
+<!--                    ISO 8879 NOT USED BY MATHML                -->
+<!-- ============================================================= -->
+
+
+<!--                    ISO STANDARD GREEK LETTERS                 -->
+<!ENTITY % ISOgrk1 PUBLIC
+"-//W3C//ENTITIES Greek Letters//EN"
+"xmlchars/isogrk1.ent"                                               >
+
+
+<!--                    ISO STANDARD MONOTONIKO GREEK              -->
+<!ENTITY % ISOgrk2 PUBLIC
+"-//W3C//ENTITIES Monotoniko Greek//EN"
+"xmlchars/isogrk2.ent"                                               >
+
+
+<!--                    ISO STANDARD ALTERNATIVE GREEK SYMBOLS     -->
+<!ENTITY % ISOgrk4 PUBLIC
+"-//W3C//ENTITIES Alternative Greek Symbols//EN"
+"xmlchars/isogrk4.ent"                                               >
+
+
+<!-- ============================================================= -->
+<!--                    ISO TECHNICAL REPORT 9573-13 ENTITY SETS   -->
+<!-- ============================================================= -->
+
+
+<!--                    ISO STANDARD GENERAL TECHNICAL             -->
+<!ENTITY % ISOtech PUBLIC
+"-//W3C//ENTITIES General Technical for MathML 2.0//EN"
+"iso9573-13/isotech.ent"                                             >
+
+
+<!--                    ISO STANDARD GREEK SYMBOLS                 -->
+<!ENTITY % ISOgrk3 PUBLIC
+"-//W3C//ENTITIES Greek Symbols for MathML 2.0//EN"
+"iso9573-13/isogrk3.ent"                                             >
+
+
+<!--                    ISO STANDARD MATH ALPHABETS (SCRIPT)       -->
+<!ENTITY % ISOmscr PUBLIC
+"-//W3C//ENTITIES Math Alphabets: Script for MathML 2.0//EN"
+"iso9573-13/isomscr.ent"                                             >
+
+
+<!--                    ISO STANDARD ADDED MATH SYMBOLS
+                           (ARROW RELATIONS)                       -->
+<!ENTITY % ISOamsa PUBLIC
+"-//W3C//ENTITIES Added Math Symbols: Arrow Relations for MathML 2.0//EN"
+"iso9573-13/isoamsa.ent"                                             >
+
+
+<!--                    ISO STANDARD ADDED MATH SYMBOLS
+                           (BINARY OPERATORS)                      -->
+<!ENTITY % ISOamsb PUBLIC
+"-//W3C//ENTITIES Added Math Symbols: Binary Operators for MathML 2.0//EN"
+"iso9573-13/isoamsb.ent"                                             >
+
+
+<!--                    ISO STANDARD ADDED MATH SYMBOLS
+                           (DELIMITERS)                            -->
+<!ENTITY % ISOamsc PUBLIC
+"-//W3C//ENTITIES Added Math Symbols: Delimiters for MathML 2.0//EN"
+"iso9573-13/isoamsc.ent"                                             >
+
+
+<!--                    ISO STANDARD ADDED MATH SYMBOLS
+                           (NEGATED RELATIONS)                     -->
+<!ENTITY % ISOamsn PUBLIC
+"-//W3C//ENTITIES Added Math Symbols: Negated Relations for MathML 2.0//EN"
+"iso9573-13/isoamsn.ent"                                             >
+
+
+<!--                    ISO STANDARD ADDED MATH SYMBOLS (ORDINARY) -->
+<!ENTITY % ISOamso PUBLIC
+"-//W3C//ENTITIES Added Math Symbols: Ordinary for MathML 2.0//EN"
+"iso9573-13/isoamso.ent"                                             >
+
+
+<!--                    ISO STANDARD ADDED MATH SYMBOLS
+                           (RELATIONS)                             -->
+<!ENTITY % ISOamsr PUBLIC
+"-//W3C//ENTITIES Added Math Symbols: Relations for MathML 2.0//EN"
+"iso9573-13/isoamsr.ent"                                             >
+
+
+<!--                    ISO STANDARD MATH ALPHABETS (FRAKTUR)      -->
+<!ENTITY % ISOmfrk PUBLIC
+"-//W3C//ENTITIES Math Alphabets: Fraktur for MathML 2.0//EN"
+"iso9573-13/isomfrk.ent"                                             >
+
+
+<!--                    ISO STANDARD MATH ALPHABETS (OPEN FACE)    -->
+<!ENTITY % ISOmopf PUBLIC
+"-//W3C//ENTITIES Math Alphabets: Open Face for MathML 2.0//EN"
+"iso9573-13/isomopf.ent"                                             >
+
+
+<!-- ============================================================= -->
+<!--                    ISO SPECIAL CHARACTER SETS INVOKED         -->
+<!-- ============================================================= -->
+
+
+%ISOlat1;
+%ISOlat2;
+%ISObox;
+%ISOdia;
+%ISOnum;
+%ISOpub;
+%ISOcyr1;
+%ISOcyr2;
+
+%ISOgrk1;
+%ISOgrk2;
+%ISOgrk4;
+
+%ISOtech;
+%ISOgrk3;
+%ISOamsa;
+%ISOamsb;
+%ISOamsc;
+%ISOamsn;
+%ISOamso;
+%ISOamsr;
+%ISOmscr;
+%ISOmfrk;
+%ISOmopf;
+
+
+<!--                    MAINTENANCE NOTE:
+                        Custom special characters are declared
+                        in a separate module %chars.ent;           -->
+
+
+<!-- ============ End of XML Special Characters Module =========== -->

--- a/src/main/resources/dtd/archiving/1.2/catalog-jats-v1-2-no-base.xml
+++ b/src/main/resources/dtd/archiving/1.2/catalog-jats-v1-2-no-base.xml
@@ -1,0 +1,1015 @@
+<?xml version="1.0"?>
+<!DOCTYPE catalog PUBLIC
+"-//OASIS//DTD Entity Resolution XML Catalog V3.0//EN"
+"http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
+
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+         prefer="public">
+
+<!-- ============================================================= -->
+<!--  MODULE:    An OASIS XML Catalog (not a DTD Suite module)     -->
+<!--             Version of the catalog without @xml:base          -->
+<!--  VERSION:   1.2                                               --> 
+<!--  DATE:      February 2019                                     --> 
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    To make the connection between PUBLIC identifiers -->
+<!--             for DTD Suite modules and their URIs              -->
+<!--                                                               -->
+<!-- CONTAINS:   1) Scope of Catalog                               -->
+<!--             2) Catalog organization comment                   -->
+<!--             3) How to set up a catalog                        -->
+<!--                  This catalog has been set up deliberately    -->
+<!--                  so that ALL users will need to modify the    -->
+<!--                  catalog before using it.                     -->
+<!--             4) PUBLIC/SYSTEM identifier map                   -->
+<!--                  a. NISO JATS Journal Publishing DTD (Blue)   -->
+<!--                        Blue with XHTML and MathML 3.0         -->
+<!--                        Blue with XHTML and MathML 2.0         -->
+<!--                        Blue with XHTML, CALS, and MathML 3.0  -->
+<!--                        Blue with XHTML, CALS, and MathML 2.0  -->
+<!--                  b. NISO JATS Archiving and Interchange       -->
+<!--                        DTD (Green)                            -->
+<!--                        Green with XHTML and MathML 3.0        -->
+<!--                        Green with XHTML and MathML 2.0        -->
+<!--                        Green with XHTML, CALS, and MathML 3.0 -->
+<!--                        Green with XHTML, CALS, and MathML 2.0 -->
+<!--                  c. NISO JATS Journal Authoring DTD (Pumpkin) -->
+<!--                        Pumpkin with XHTML and MathML 3.0      -->
+<!--                        Pumpkin with XHTML and MathML 2.0      -->
+<!--                  d. JATS DTD Suite common (shared) modules    -->
+<!--                  e. JATS DTD Suite common (shared) modules    -->
+<!--                       from external sources (table models,    -->
+<!--                       MATHML, general entity sets, etc.)      -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             June 2002                                         -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal JATS DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+     =============================================================
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 20. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 19. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+   =============================================================
+     JATS Version 1.2d2 (ANSI/NISO Z39.96-2015)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2d2  (2018-04-01)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 18. BITS "2.0" and "v1.2d1 20170631" became
+     BITS "2.1" and "v2.0 20180401". 
+     No module names were changed.
+ 
+  
+ 17. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d2" and "v1.2d2 20180101". 
+     No module names were changed.
+ 
+   =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+16. JATS became version "1.2d1" and "v1.2d1 20170631" 
+     No module names were changed.
+
+    =============================================================
+     JATS Version 1.1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.1d3  (2015-12-15)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.1 (ANSI/NISO Z39.96-2015).
+  
+ 15. JATS "1.1d3" and "v1.1d3 20150301" become
+     JATS 1.1 and "v1.1 20151215". No module names were changed.
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+  
+ 14. JATS became version "1.1d3" and "v1.1 20150301//EN"
+     BITS became version "2.0" and "v2.0 20150630//EN", and
+        BITS module names all changed to "2"
+
+     =============================================================
+     JATS Version 1.1d2             (DAL/BTU) v1.1d2  (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 13. Re-arranged catalog entries to make it more obvious which
+     files were needed by which DTDs.
+
+ 12. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+     =============================================================
+     JATS Version 1.1d1             (DAL/BTU) v1.1d1 (2013-12-15)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. The next
+     official version of NISO JATS will be either 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+     
+ 11. Replaced an incorrect formal public identifier for the 
+     Archiving DTD with XHTML and MathML3. Changed"-//NLM//DTD JATS 
+     (Z39.96) Journal Archiving and Interchange DTD v1.1d1 20130915//EN" 
+     to the fpi: "-//NLM//DTD JATS 
+     (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.1d1 
+     20130915//EN"
+
+ 10. Removed all mentions of BITS files
+
+  9. Removed duplicate declaration of JATS OASIS Table Setup Module
+
+     =============================================================
+     JATS Version 1.1d1 (prelim draft) (DAL/BTU) v1.1d1 (2013-11-15)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. The next
+     official version of NISO JATS will be either 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. Major DTD-fork to Add MathML 3.0 as an alternative to 
+     MathML 2.0. They must never be used together, always
+     one must be chosen. This added many more DTDs, as all
+     options needed to be able to choose which Math to use.
+
+  6. Modified comments to make it more obvious which modules are
+     used together and which may be commented out or
+     deleted. No catalog entries ever need to be commented
+     out or deleted.
+
+  5. Changed the filename to include "no-base" in the name.
+
+  4. JATS became version "1.1d1" and "v1.1d1 20130915//EN"
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-09-20)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  3. Replaced OASIS modules to enhance control of OASIS 
+     namespace and namespace prefix (v1.0 20120330//EN").
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become "NISO JATS
+     Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+
+  2. Updated the public identifiers to "v1.0 20120330//EN",
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://jats.nlm.nih.gov/3.0.
+
+  1. Updated public identifiers to "v1.2 20181130//EN"
+     fresh start.                                                   -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================== -->
+<!--                    SCOPE (JATS DTD Suite Version 1.1d1)        -->
+<!-- ============================================================== -->
+
+<!-- This catalog is made up of several groups, each with its own
+     xml:base attribute, for:
+
+       - NISO JATS Journal Publishing DTD (Blue)
+       - The additional modules for the NISO JATS Journal Publishing 
+           DTD (Blue) with OASIS and XHTML tables
+       - NISO JATS Archiving and Interchange DTD (Green)
+       - The additional modules for the NISO JATS Archiving and 
+           Interchange DTD (Green) with OASIS and XHTML tables
+       - NISO JATS Journal Authoring DTD (Pumpkin)
+       - JATS DTD Suite common (shared) modules
+       - JATS DTD Suite common (shared) modules from external 
+            sources (table models, MathML, general entity 
+            sets, etc.)                                         
+
+     To work with relative files (such as in the Oxygen XML Editor), 
+     use this catalog named "no-base", which has no @xml:base 
+     attributes.  To set up a system-level catalog specific to a
+     file system, set an @xml:base attribute on each <group> element 
+     to the appropriate URI, such as a filename or system path.     -->
+     
+<!-- ============================================================== -->
+<!--                    CATALOG ORGANIZATION                        -->
+<!-- ============================================================== -->
+
+<!--  GROUPS AND ENTRIES
+
+     Entries are grouped into logical clusters, organized by the
+     particular DTD variant.
+
+     Each catalog entry associates a PUBLIC identifier with a SYSTEM
+     identifier.
+
+     The @uri SYSTEM identifier is relative (resolved by the
+     application, such as the Oxygen XML editor), and contains the
+     filename of the DTD:
+
+     The XML looks like this:
+
+     <group>
+
+       <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v88.6 20160331//EN"
+               uri="journalpublishing88.dtd"/>
+       ...
+     </group>
+                                                                    -->
+
+
+<!-- ============================================================== -->
+<!--                    HOW TO SET UP                               -->
+<!-- ============================================================== -->
+
+<!-- The OASIS catalog and the NCBI Suite of Modules provide a wide
+     range of flexibility for setting up. Here are two easy ways to
+     do it:
+
+
+     1. WITHOUT an OASIS catalog (DTD components on a local system):
+
+        - unzip the DTD packages you want to use into a single
+          directory:
+
+            - the journal-publishing package
+            - the archive article package
+            - the journal-authoring package
+            - the book package
+
+        - create your own DTD customization, if you need to,
+          anywhere, using local (relative or absolute) SYSTEM
+          identifiers to reference DTD modules.
+
+        - create a document instance anywhere, and point its
+          SYSTEM identifier to your customized DTD or to the
+          package DTD you have chosen to use, using a local
+          (relative or absolute) SYSTEM identifier.
+
+        The SYSTEM identifiers used in the DTD modules are relative
+        to the directory in which you have placed the DTD package
+        and your customized DTD, and so your editor/processor will
+        find them when reading the DTD.
+
+     2. Using this OASIS catalog (DTD components on a local system):
+
+        - unzip the DTD packages you want to use into a single
+          directory, or into separate directories.
+          
+             - If you are using tools that work well with relative
+               path locations (e.g., The Oxygen XML Editor), you can
+               use this JATS catalog, named "no-base", that does
+               not use the @xml:base attributes.
+               
+             - If you need to establish an @XML:base attribute,
+               start from the other catalog, named "with-base"/
+
+        - create your own DTD customization, if you need to,
+          anywhere, using PUBLIC identifiers to reference the
+          DTD modules.
+
+        - tell your editor/processor about this OASIS catalog
+          (Note: many apps must be closed and relaunched when
+          a catalog file is first specified AND when it is changed)
+
+        - create a document instance anywhere, and point its
+          SYSTEM or PUBLIC identifier to the DTD you want to use,
+          giving a relative SYSTEM path.
+
+        Your editor/processor will map the PUBLIC identifiers
+        in the DTD to the SYSTEM identifiers specified in
+        this catalog.                                               -->
+
+
+<!-- ============================================================== -->
+<!--                    PUBLIC-SYSTEM IDENTIFIER MAP                -->
+<!-- ============================================================== -->
+
+<!-- ============================================================== -->
+<!--                    JOURNAL PUBLISHING DTD (BLUE)               -->
+<!--                    The following modules are used only for JATS-->
+<!--                    Journal Publishing DTDs (Blue).             -->
+<!--                    If you are not using Publishing (Blue), you -->
+<!--                    may delete the group below, or leave it     -->
+<!--                    here as these public definitions do no harm.-->
+<!-- ============================================================== -->
+
+<group prefer="public" >
+
+<!--                    The following modules are used for ALL of   -->
+<!--                    the Journal Publishing DTDs (Blue)          -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Mixes Module v1.2 20190208//EN"
+               uri="JATS-journalpubcustom-mixes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Content and Attributes Module v1.2 20190208//EN"
+               uri="JATS-journalpubcustom-models1.ent"/>
+
+<!--                    The following modules are used for all of   -->
+<!--                    the Journal Publishing DTDs (Blue) that use -->
+<!--                    ONLY the XHTML-based Table Model            -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Classes Module v1.2 20190208//EN"
+               uri="JATS-journalpubcustom-classes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD-Specific Modules v1.2 20190208//EN"
+               uri="JATS-journalpubcustom-modules1.ent"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Journal Publishing DTD (Blue), that uses    -->
+<!--                    XHTML tables with MathML 2.0                -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.2 20190208//EN"
+               uri="JATS-journalpublishing1.dtd"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Journal Publishing DTD (Blue), that uses    -->
+<!--                    XHTML tables with MathML 3.0                -->
+
+<public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with MathML3 v1.2 20190208//EN"
+               uri="JATS-journalpublishing1-mathml3.dtd"/>
+
+<!--                    The following modules are used only for all -->
+<!--                    Journal Publishing DTDs(Blue) that use the  -->
+<!--                    OASIS table model (namespace prefix "oasis")-->
+<!--                    and the XHTML table model.                  -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables DTD-Specific Modules v1.2 20190208//EN"
+               uri="JATS-journalpub-oasis-custom-modules1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables Customize Classes v1.2 20190208//EN"
+               uri="JATS-journalpub-oasis-custom-classes1.ent"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Journal Publishing DTD (Blue) that uses the -->
+<!--                    OASIS table model (namespace prefix "oasis")-->
+<!--                    and the XHTML table model with MathML 2.0   -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables v1.2 20190208//EN"
+               uri="JATS-journalpublishing-oasis-article1.dtd"/>
+
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Journal Publishing DTD (Blue) that uses the -->
+<!--                    OASIS table model (namespace prefix "oasis")-->
+<!--                    and the XHTML table model with MathML 3.0   -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables with MathML3 v1.2 20190208//EN"
+               uri="JATS-journalpublishing-oasis-article1-mathml3.dtd"/>
+
+</group>
+
+<!-- ============================================================== -->
+<!--                    ARCHIVING AND INTERCHANGE DTD (GREEN)       -->
+<!--                    The following modules are used only for JATS-->
+<!--                    Journal Archiving and Interchange DTDs      -->
+<!--                    (Green)                                     -->
+<!--                    If you are not using Archiving (Green), you -->
+<!--                    may delete the group below, or leave it     -->
+<!--                    here as these public definitions do no harm.-->
+<!-- ============================================================== -->
+
+<group prefer="public">
+
+<!--                    The following modules are used for ALL of   -->
+<!--                    the Archiving and Interchange DTDs (Green)  -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Mixes Module v1.2 20190208//EN"
+               uri="JATS-archivecustom-mixes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Content and Attributes Module v1.2 20190208//EN"
+               uri="JATS-archivecustom-models1.ent"/>
+ 
+<!--                    The following modules are used for all of   -->
+<!--                    the Archiving and Interchange DTDs (Green)  -->
+<!--                    that use ONLY the XHTML-based Table Model   -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Classes Module v1.2 20190208//EN" 
+               uri="JATS-archivecustom-classes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving DTD-Specific Modules v1.2 20190208//EN" 
+               uri="JATS-archivecustom-modules1.ent"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Archiving and Interchange DTDs (Green), that-->
+<!--                    uses XHTML tables with MathML 2.0           -->
+
+ <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2 20190208//EN" 
+               uri="JATS-archivearticle1.dtd"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Archiving and Interchange DTDs (Green), that-->
+<!--                    uses XHTML tables with MathML 3.0           -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.2 20190208//EN"
+               uri="JATS-archivearticle1-mathml3.dtd"/>
+
+
+<!--                    The following modules are used only for all -->
+<!--                    Archiving and Interchange DTDs (Green) that -->
+<!--                    use the OASIS table model (namespace prefix -->
+<!--                    "oasis") and the XHTML table model.         -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with OASIS Tables Customize Classes Module v1.2 20190208//EN"
+               uri="JATS-archive-oasis-custom-classes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with OASIS Tables DTD-Specific Modules v1.2 20190208//EN"
+               uri="JATS-archive-oasis-custom-modules1.ent"/>
+
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Archiving and Interchange DTDs (Green) that -->
+<!--                    use the OASIS table model (namespace prefix -->
+<!--                    "oasis") and the XHTML table model with     -->
+<!--                    MathML 2.0                                  -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with OASIS Tables v1.2 20190208//EN"
+               uri="JATS-archive-oasis-article1.dtd"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Archiving and Interchange DTDs (Green) that -->
+<!--                    use the OASIS table model (namespace prefix -->
+<!--                    "oasis") and the XHTML table model with     -->
+<!--                    MathML 3.0                                  -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with OASIS Tables with MathML3 v1.2 20190208//EN"
+               uri="JATS-archive-oasis-article1-mathml3.dtd"/>
+              
+</group>
+
+
+<!-- ============================================================== -->
+<!--                    ARTICLE AUTHORING DTD (PUMPKIN)             -->
+<!--                    The following modules are used only for JATS-->
+<!--                    Article Authoring DTD (Pumpkin).            -->
+<!--                    If you are not using Authoring (Pumpkin),   -->
+<!--                    may delete the group below, or leave it     -->
+<!--                    here as these public definitions do no harm.-->
+<!-- ============================================================== -->
+
+<group prefer="public">
+
+<!--                    The following modules are used for ALL of   -->
+<!--                    the Article Authoring DTDs (Pumpkin)        -->
+
+  <public publicId= "-//NLM//DTD JATS (Z39.96) Article Authoring DTD Over-ride Classes Module v1.2 20190208//EN"
+               uri="JATS-articleauthcustom-classes1.ent"/>
+
+  <public publicId= "-//NLM//DTD JATS (Z39.96) Article Authoring DTD Over-ride Mixes Module v1.2 20190208//EN"
+               uri="JATS-articleauthcustom-mixes1.ent"/>
+
+  <public publicId= "-//NLM//DTD JATS (Z39.96) Article Authoring DTD Over-ride Content and Attribute Module v1.2 20190208//EN"
+               uri="JATS-articleauthcustom-models1.ent"/>
+
+  <public publicId= "-//NLM//DTD JATS (Z39.96) Article Authoring DTD-Specific Modules v1.2 20190208//EN"
+               uri="JATS-articleauthcustom-modules1.ent"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    the Article Authoring DTDs (Pumpkin) that   -->
+<!--                    use the XHTML table model with MathML 2.0   -->
+           
+  <public publicId="-//NLM//DTD JATS (Z39.96) Article Authoring DTD v1.2 20190208//EN"
+               uri="JATS-articleauthoring1.dtd"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    the Article Authoring DTDs (Pumpkin) that   -->
+<!--                    use the XHTML table model with MathML 3.0   -->
+            
+  <public publicId="-//NLM//DTD JATS (Z39.96) Article Authoring DTD with MathML3 v1.2 20190208//EN"
+               uri="JATS-articleauthoring1-mathml3.dtd"/>
+
+</group>
+
+
+<!-- ============================================================== -->
+<!--                    JATS DTD SUITE                              -->
+<!--                    MODULAR LIBRARY                             -->
+<!--                    The following group is used by all of       -->
+<!--                    the JATS DTDS.                              -->
+<!--                    DO NOT DELETE OR COMMENT OUT THIS GROUP!    -->
+<!-- ============================================================== -->
+
+<group prefer="public" >
+
+<!--                    MODULE OF MODULES                           -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Module of Modules v1.2 20190208//EN"
+               uri="JATS-modules1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS MathML 3.0 Modules v1.2 20190208//EN"
+               uri="JATS-mathml3-modules1.ent"/>
+
+
+<!--                    CLASSES AND MIXES                           -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Default Element Classes Module v1.2 20190208//EN"
+               uri="JATS-default-classes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Default Element Mixes Module v1.2 20190208//EN"
+               uri="JATS-default-mixes1.ent"/>
+
+
+<!--                    ELEMENT COMMON (SHARED) ELEMENTS/CHARACTERS -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Common (Shared) Elements Module v1.2 20190208//EN"
+               uri="JATS-common1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Common Attributes (for all elements) v1.2 20190208//EN"
+               uri="JATS-common-atts1.ent"/>               
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Notation Declarations v1.2 20190208//EN"
+               uri="JATS-notat1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite XML Special Characters Module v1.2 20190208//EN"
+               uri="JATS-xmlspecchars1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Custom Special Characters Module v1.2 20190208//EN"
+               uri="JATS-chars1.ent"/>
+
+
+<!--                    CLASS MODULES                               -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Journal Article Metadata Elements v1.2 20190208//EN"
+               uri="JATS-articlemeta1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Back Matter Elements v1.2 20190208//EN"
+               uri="JATS-backmatter1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Display Class Elements v1.2 20190208//EN"
+               uri="JATS-display1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Formatting Element Classes v1.2 20190208//EN"
+               uri="JATS-format1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Funding Elements v1.2 20190208//EN"
+               uri="JATS-funding1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Journal Metadata Elements v1.2 20190208//EN"
+               uri="JATS-journalmeta1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Link Class Elements v1.2 20190208//EN"
+               uri="JATS-link1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite List Class Elements v1.2 20190208//EN"
+               uri="JATS-list1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Math Class Elements v1.2 20190208//EN"
+               uri="JATS-math1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) NLM Citation v1.2 20190208//EN"
+               uri="JATS-nlmcitation1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Paragraph-Like Elements v1.2 20190208//EN"
+               uri="JATS-para1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Subject Phrase Class Elements v1.2 20190208//EN"
+               uri="JATS-phrase1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Bibliographic Reference (Citation) Class Elements v1.2 20190208//EN"
+               uri="JATS-references1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Related Object Element v1.2 20190208//EN"
+               uri="JATS-related-object1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Section Class Elements v1.2 20190208//EN"
+               uri="JATS-section1.ent"/>
+
+
+<!--                    SET UP XHTML TABLES (OASIS below)          -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite XHTML Table Setup Module v1.2 20190208//EN"
+               uri="JATS-XHTMLtablesetup1.ent"/>
+
+<!--                    SET UP MATHML                              -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite MathML Setup Module v1.2 20190208//EN"
+               uri="JATS-mathmlsetup1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite MathML 3.0 Setup Module v1.2 20190208//EN"
+               uri="JATS-mathml3-mathmlsetup1.ent"/>
+
+</group>
+
+
+<!-- ============================================================== -->
+<!--                    COMMONLY-USED PUBLIC MODELS AND PUBLIC      -->
+<!--                    CHARACTER-ENTITY SETS USED IN THE SUITE     -->
+<!--                    The following group is used by all of       -->
+<!--                    the JATS DTDS.                              -->
+<!--                    DO NOT DELETE OR COMMENT OUT THIS GROUP!    -->
+<!-- ============================================================== -->
+
+<group prefer="public" >
+
+<!-- .............................................................. -->
+<!--                    NISO ACCESS AND INDICATOR NAMESPACE         -->
+<!-- .............................................................. -->
+
+  <public publicId="-//NLM//DTD JATS ALI Namespace Module v1.2 20190208//EN"
+               uri="JATS-ali-namespace1.ent"/>
+
+<!-- .............................................................. -->
+<!--                    TABLES: XHTML TABLE MODULES                 -->
+<!-- .............................................................. -->
+
+  <public publicId="-//W3C//ELEMENTS XHTML Tables 1.0//EN"
+               uri="xhtml-table-1.mod"/>
+
+  <public publicId="-//W3C//ENTITIES XHTML Inline Style 1.0//EN"
+               uri="xhtml-inlstyle-1.mod"/>
+
+
+<!-- .............................................................. -->
+<!--                    TABLES: OASIS EXCHANGE TABLE MODULES        -->
+<!-- .............................................................. -->
+
+  <public publicId="-//NLM//DTD JATS OASIS Table Namespace Module v1.2 20190208//EN"
+               uri="JATS-oasis-namespace1.ent"/>
+
+  <public publicId="-//OASIS//DTD XML Exchange Table Model 19990315//EN"
+               uri="oasis-exchange.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Namespaced OASIS XML Table Setup Module v1.2 20190208//EN"
+               uri="JATS-oasis-tablesetup1.ent"/>
+ 
+
+<!-- .............................................................. -->
+<!--                    MATHML MODULES                              -->
+<!-- .............................................................. -->
+
+  <public publicId="-//W3C//DTD MathML 2.0//EN"
+               uri="mathml2.dtd"/>
+  <public publicId="-//W3C//ENTITIES MathML 2.0 Qualified Names 1.0//EN"
+               uri="mathml2-qname-1.mod"/>
+  <public publicId="-//W3C//ENTITIES Extra for MathML 2.0//EN"
+               uri="mathml/mmlextra.ent"/>
+  <public publicId="-//W3C//ENTITIES Aliases for MathML 2.0//EN"
+               uri="mathml/mmlalias.ent"/>
+
+
+  <public publicId="-//W3C//DTD MathML 3.0//EN"
+               uri="mathml3.dtd"/>
+  <public publicId="-//W3C//ENTITIES MathML 3.0 Qualified Names 1.0//EN" 
+               uri="mathml3-qname1.mod"/>
+  <public publicId="-//W3C//ENTITIES Extra for MathML 3.0//EN" 
+               uri="mathml/mmlextra.ent"/>
+  <public publicId="-//W3C//ENTITIES Aliases for MathML 3.0//EN"
+               uri="mathml/mmlalias.ent"/>
+
+
+<!-- .............................................................. -->
+<!--                    ISO 8879 ENTITIES                           -->
+<!-- .............................................................. -->
+
+
+  <public publicId="-//W3C//ENTITIES Box and Line Drawing for MathML 2.0//EN"
+               uri="iso8879/isobox.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Russian Cyrillic for MathML 2.0//EN"
+               uri="iso8879/isocyr1.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Non-Russian Cyrillic for MathML 2.0//EN"
+               uri="iso8879/isocyr2.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Diacritical Marks for MathML 2.0//EN"
+               uri="iso8879/isodia.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Latin 1 for MathML 2.0//EN"
+               uri="iso8879/isolat1.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Latin 2 for MathML 2.0//EN"
+               uri="iso8879/isolat2.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Numeric and Special Graphic for MathML 2.0//EN"
+               uri="iso8879/isonum.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Publishing for MathML 2.0//EN"
+               uri="iso8879/isopub.ent"/>
+
+<!-- .............................................................. -->
+<!--                    ISO 9573-11 ENTITIES                        -->
+<!-- .............................................................. -->
+
+  <public publicId="-//W3C//ENTITIES General Technical for MathML 2.0//EN"
+               uri="iso9573-13/isotech.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Greek Symbols for MathML 2.0//EN"
+               uri="iso9573-13/isogrk3.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Math Alphabets: Script for MathML 2.0//EN"
+               uri="iso9573-13/isomscr.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Arrow Relations for MathML 2.0//EN"
+               uri="iso9573-13/isoamsa.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Binary Operators for MathML 2.0//EN"
+               uri="iso9573-13/isoamsb.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Delimiters for MathML 2.0//EN"
+               uri="iso9573-13/isoamsc.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Negated Relations for MathML 2.0//EN"
+               uri="iso9573-13/isoamsn.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Ordinary for MathML 2.0//EN"
+               uri="iso9573-13/isoamso.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Relations for MathML 2.0//EN"
+               uri="iso9573-13/isoamsr.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Math Alphabets: Fraktur for MathML 2.0//EN"
+               uri="iso9573-13/isomfrk.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Math Alphabets: Open Face for MathML 2.0//EN"
+               uri="iso9573-13/isomopf.ent"/>
+
+<!-- .............................................................. -->
+<!--                    NON-MATHML ENTITIES(backwards compatibility)-->
+<!-- .............................................................. -->
+
+  <public publicId="-//W3C//ENTITIES Greek Letters//EN"
+               uri="xmlchars/isogrk1.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Monotoniko Greek//EN"
+               uri="xmlchars/isogrk2.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Alternative Greek Symbols//EN"
+               uri="xmlchars/isogrk4.ent"/>
+
+</group>
+
+
+<!-- ============================================================== -->
+<!--                    BITS BOOK INTERCHANGE DTD                   -->
+<!--                    The following modules are used only for NLM -->
+<!--                    BITS (Book Interchange Tag Suite)[Chocolate]-->
+<!--                                                                -->
+<!--                    If you are not using BITS (Chocolate), you  -->
+<!--                    may delete the group below, or leave it     -->
+<!--                    here as these public definitions do no harm.-->
+<!-- ============================================================== -->
+<group prefer="public" >
+   
+<!--                    The following modules are used for all of   -->
+<!--                    the BITS DTDs (Chocolate)                   -->
+<!--                    that use ONLY the XHTML-based Table Model   -->
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD v2.1 20180401//EN"
+               uri="BITS-book2.dtd"/>
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD-Specific Modules v2.1 20180401//EN" 
+               uri="BITS-bookcustom-modules2.ent"/>
+ 
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD Customize Classes Module v2.1 20180401//EN" 
+               uri="BITS-bookcustom-classes2.ent"/>
+              
+  <public publicId="-//NLM//DTD BITS Book Part Wrapper v2.1 20180401//EN" 
+               uri="BITS-book-part-wrap2.ent" /> 
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    BITS DTDS that                              -->
+<!--                    use the OASIS table model (namespace prefix -->
+<!--                    "oasis") and the XHTML table model          -->
+             
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD with OASIS and XHTML Tables v2.1 20180401//EN"
+               uri="BITS-book-oasis2.dtd" />
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD-Specific Modules with OASIS and XHTML Tables v2.1 20180401//EN"
+               uri="BITS-book-oasis-custom-modules2.ent" />
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD with OASIS and XHTML Tables Customize Classes Module v2.1 20180401//EN"
+               uri="BITS-book-oasis-custom-classes2.ent" />
+               
+  <public publicId="-//NLM//DTD BITS Book Part OASIS and XHTML Tables Wrapper v2.1 20180401//EN"  
+               uri="BITS-book-part-oasis-wrap2.ent" /> 
+              
+<!--                    The following modules are used for ALL of   -->
+<!--                    the BITS DTDs (Chocolate)                 -->
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD Customize Mixes Module v2.1 20180401//EN"
+               uri="BITS-bookcustom-mixes2.ent"/>
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD Customize Content and Attributes Module v2.1 20180401//EN" 
+               uri="BITS-bookcustom-models2.ent"/>
+
+
+               
+  <public publicId="-//NLM//DTD BITS Add Attributes Module v2.1 20180401//EN"  
+               uri="BITS-add-attributes2.ent"  /> 
+
+  <public publicId="-//NLM//DTD BITS Book Metadata Elements Module v2.1 20180401//EN"  
+               uri="BITS-bookmeta2.ent"/>
+
+  <public publicId="-//NLM//DTD BITS Book Component Elements v2.1 20180401//EN"  
+               uri="BITS-book-part2.ent"/>
+               
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD Common Module v2.1 20180401//EN" 
+               uri="BITS-common2.ent" />  
+ 
+ 
+  <public publicId="-//NLM//DTD BITS Embedded Index Element Module v2.1 20180401//EN"
+               uri="BITS-embedded-index2.ent"/> 
+
+  <public publicId="-//NLM//DTD BITS Structural Index Elements Module v2.1 20180401//EN" 
+               uri="BITS-index2.ent"/> 
+
+  <public publicId="-//NLM//DTD BITS Structural Table of Contents Module v2.1 20180401//EN"
+               uri="BITS-toc2.ent"/> 
+               
+  <public publicId="-//NLM//DTD BITS Question and Answer Module v2.1 20180401//EN"  
+               uri="BITS-question-answer2.ent"  /> 
+
+  <public publicId="-//NLM//DTD BITS Table of Contents and Index Navigation Module v2.1 20180401//EN"
+               uri="BITS-toc-index-nav2.ent"/> 
+               
+  <public publicId="-//NLM//DTD BITS XInclude Setup Module v2.1 20180401//EN" 
+               uri="BITS-xinclude2.ent" /> 
+ 
+</group>
+
+<!-- ================ End WITH Base OASIS XML CATALOG ============= -->
+
+</catalog>

--- a/src/main/resources/dtd/archiving/1.2/catalog-jats-v1-2-with-base.xml
+++ b/src/main/resources/dtd/archiving/1.2/catalog-jats-v1-2-with-base.xml
@@ -1,0 +1,1018 @@
+<?xml version="1.0"?>
+<!DOCTYPE catalog PUBLIC
+"-//OASIS//DTD Entity Resolution XML Catalog V3.0//EN"
+"http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
+
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+         prefer="public">
+
+<!-- ============================================================= -->
+<!--  MODULE:    An OASIS XML Catalog (not a DTD Suite module)     -->
+<!--             Version of the catalog without @xml:base          -->
+<!--  VERSION:   1.2                                               --> 
+<!--  DATE:      February 2019                                     --> 
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    To make the connection between PUBLIC identifiers -->
+<!--             for DTD Suite modules and their URIs              -->
+<!--                                                               -->
+<!-- CONTAINS:   1) Scope of Catalog                               -->
+<!--             2) Catalog organization comment                   -->
+<!--             3) How to set up a catalog                        -->
+<!--                  This catalog has been set up deliberately    -->
+<!--                  so that ALL users will need to modify the    -->
+<!--                  catalog before using it.                     -->
+<!--             4) PUBLIC/SYSTEM identifier map                   -->
+<!--                  a. NISO JATS Journal Publishing DTD (Blue)   -->
+<!--                        Blue with XHTML and MathML 3.0         -->
+<!--                        Blue with XHTML and MathML 2.0         -->
+<!--                        Blue with XHTML, CALS, and MathML 3.0  -->
+<!--                        Blue with XHTML, CALS, and MathML 2.0  -->
+<!--                  b. NISO JATS Archiving and Interchange       -->
+<!--                        DTD (Green)                            -->
+<!--                        Green with XHTML and MathML 3.0        -->
+<!--                        Green with XHTML and MathML 2.0        -->
+<!--                        Green with XHTML, CALS, and MathML 3.0 -->
+<!--                        Green with XHTML, CALS, and MathML 2.0 -->
+<!--                  c. NISO JATS Journal Authoring DTD (Pumpkin) -->
+<!--                        Pumpkin with XHTML and MathML 3.0      -->
+<!--                        Pumpkin with XHTML and MathML 2.0      -->
+<!--                  d. JATS DTD Suite common (shared) modules    -->
+<!--                  e. JATS DTD Suite common (shared) modules    -->
+<!--                       from external sources (table models,    -->
+<!--                       MATHML, general entity sets, etc.)      -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             June 2002                                         -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal JATS DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+     =============================================================
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+   ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                   (DAL/BTU) v1.2     (2019-02-08)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+     Drafts as well as the draft version JATS 1.2 2018 (the version
+     submitted for vote), becoming NISO JATS v1.2 20190208 
+     (ANSI/NISO Z39.96-2019).
+  
+ 20. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+     "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+
+    ==============================================================
+     JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2     (2018-11-30)
+    
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+ 19. BITS "2.1" and "v2.0 20180401" remains unchanged.
+     JATS "1.2d2" and "v1.2d2 20180401" became
+     JATS "1.2" and "v1.2 20181130" 
+
+    =============================================================
+     JATS Version 1.2d2 (ANSI/NISO Z39.96-2015)
+     and BITS 2.1 (v2.0 20180401)
+                                   (DAL/BTU) v1.2d2  (2018-04-01)
+ 
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+  
+ 18. BITS "2.0" and "v1.2d1 20170631" became
+     BITS "2.1" and "v2.0 20180401". 
+     No module names were changed.
+ 
+  
+ 17. JATS "1.2d1" and "v1.2d1 20170631" became
+     JATS "1.2d2" and "v1.2d2 20171231". 
+     No module names were changed.
+   =============================================================
+     JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+
+     NISO JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+      
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee. This draft has not yet been given public review 
+     or voting. The formal public identifiers were changed in the 
+     modules and the catalogs.
+
+16. JATS became version "1.2d1" and "v1.2d1 20170631" 
+     No module names were changed.
+
+    =============================================================
+     JATS Version 1.1 (ANSI/NISO Z39.96-2015)
+                                   (DAL/BTU) v1.1d3  (2015-12-15)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.1 (ANSI/NISO Z39.96-2015).
+  
+ 15. JATS "1.1d3" and "v1.1d3 20150301" become
+     JATS 1.1 and "v1.1 20151215". No module names were changed.
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+  
+ 14. JATS became version "1.1d3" and "v1.1 20150301//EN"
+     BITS became version "2.0" and "v2.0 20150630//EN", and
+        BITS module names all changed to "2"
+
+     =============================================================
+     JATS Version 1.1d2             (DAL/BTU) v1.1d2  (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 13. Re-arranged catalog entries to make it more obvious which
+     files were needed by which DTDs.
+
+ 12. JATS became version "1.1d2" and "v1.1d2 20140930"
+
+     =============================================================
+     JATS Version 1.1d1             (DAL/BTU) v1.1d1 (2013-12-15)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. The next
+     official version of NISO JATS will be either 1.1 or 2.0.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+     
+ 11. Replaced an incorrect formal public identifier for the 
+     Archiving DTD with XHTML and MathML3. Changed "-//NLM//DTD JATS 
+     (Z39.96) Journal Archiving and Interchange DTD v1.1d1 20130915//EN" 
+     to the fpi: "-//NLM//DTD JATS 
+     (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.1d1 
+     20130915//EN"
+
+ 10. Removed all mentions of BITS files
+
+  9. Removed duplicate declaration of JATS OASIS Table Setup Module
+
+     =============================================================
+     JATS Version 1.1d1 (prelim draft) (DAL/BTU) v1.1d1 (2013-11-15)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. The next
+     official version of NISO JATS will be either 1.1 or 2.0.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. Major DTD-fork to Add MathML 3.0 as an alternative to 
+     MathML 2.0. They must never be used together, always
+     one must be chosen. This added many more DTDs, as all
+     options needed to be able to choose which Math to use.
+
+  6. Modified comments to make it more obvious which modules are
+     used together and which may be commented out or
+     deleted. No catalog entries ever need to be commented
+     out or deleted.
+
+  5. Changed the filename to include "no-base" in the name.
+
+  4. JATS became version "1.1d1" and "v1.1d1 20130915//EN"
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-09-20)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  3. Replaced OASIS modules to enhance control of OASIS 
+     namespace and namespace prefix (v1.0 20120330//EN").
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become "NISO JATS
+     Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+
+  2. Updated the public identifiers to "v1.0 20120330//EN",
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://jats.nlm.nih.gov/3.0.
+
+  1. Updated public identifiers to "v1.2 20181130//EN"
+     fresh start.                                                   -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================== -->
+<!--                    SCOPE (JATS DTD Suite Version 1.1d1)        -->
+<!-- ============================================================== -->
+
+<!-- This catalog is made up of several groups, each with its own
+     xml:base attribute, for:
+
+       - NISO JATS Journal Publishing DTD (Blue)
+       - The additional modules for the NISO JATS Journal Publishing 
+           DTD (Blue) with OASIS and XHTML tables
+       - NISO JATS Archiving and Interchange DTD (Green)
+       - The additional modules for the NISO JATS Archiving and 
+           Interchange DTD (Green) with OASIS and XHTML tables
+       - NISO JATS Journal Authoring DTD (Pumpkin)
+       - JATS DTD Suite common (shared) modules
+       - JATS DTD Suite common (shared) modules from external 
+            sources (table models, MathML, general entity 
+            sets, etc.)                                         
+
+     To work with relative files (such as in the Oxygen XML Editor), 
+     use this catalog named "no-base", which has no @xml:base 
+     attributes.  To set up a system-level catalog specific to a
+     file system, set an @xml:base attribute on each <group> element 
+     to the appropriate URI, such as a filename or system path.     -->
+     
+<!-- ============================================================== -->
+<!--                    CATALOG ORGANIZATION                        -->
+<!-- ============================================================== -->
+
+<!--  GROUPS AND ENTRIES
+
+     Entries are grouped into logical clusters, organized by the
+     particular DTD variant.
+
+     Each catalog entry associates a PUBLIC identifier with a SYSTEM
+     identifier.
+
+     The @uri SYSTEM identifier is relative (resolved by the
+     application, such as the Oxygen XML editor), and contains the
+     filename of the DTD:
+
+     The XML looks like this:
+
+     <group>
+
+       <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v88.6 20160331//EN"
+               uri="journalpublishing88.dtd"/>
+       ...
+     </group>
+                                                                    -->
+
+
+<!-- ============================================================== -->
+<!--                    HOW TO SET UP                               -->
+<!-- ============================================================== -->
+
+<!-- The OASIS catalog and the NCBI Suite of Modules provide a wide
+     range of flexibility for setting up. Here are two easy ways to
+     do it:
+
+
+     1. WITHOUT an OASIS catalog (DTD components on a local system):
+
+        - unzip the DTD packages you want to use into a single
+          directory:
+
+            - the journal-publishing package
+            - the archive article package
+            - the journal-authoring package
+            - the book package
+
+        - create your own DTD customization, if you need to,
+          anywhere, using local (relative or absolute) SYSTEM
+          identifiers to reference DTD modules.
+
+        - create a document instance anywhere, and point its
+          SYSTEM identifier to your customized DTD or to the
+          package DTD you have chosen to use, using a local
+          (relative or absolute) SYSTEM identifier.
+
+        The SYSTEM identifiers used in the DTD modules are relative
+        to the directory in which you have placed the DTD package
+        and your customized DTD, and so your editor/processor will
+        find them when reading the DTD.
+
+     2. Using this OASIS catalog (DTD components on a local system):
+
+        - unzip the DTD packages you want to use into a single
+          directory, or into separate directories.
+          
+             - If you are using tools that work well with relative
+               path locations (e.g., The Oxygen XML Editor), you can
+               use this JATS catalog, named "no-base", that does
+               not use the @xml:base attributes.
+               
+             - If you need to establish an @XML:base attribute,
+               start from the other catalog, named "with-base"/
+
+        - create your own DTD customization, if you need to,
+          anywhere, using PUBLIC identifiers to reference the
+          DTD modules.
+
+        - tell your editor/processor about this OASIS catalog
+          (Note: many apps must be closed and relaunched when
+          a catalog file is first specified AND when it is changed)
+
+        - create a document instance anywhere, and point its
+          SYSTEM or PUBLIC identifier to the DTD you want to use,
+          giving a relative SYSTEM path.
+
+        Your editor/processor will map the PUBLIC identifiers
+        in the DTD to the SYSTEM identifiers specified in
+        this catalog.                                               -->
+
+
+<!-- ============================================================== -->
+<!--                    PUBLIC-SYSTEM IDENTIFIER MAP                -->
+<!-- ============================================================== -->
+
+<!-- ============================================================== -->
+<!--                    JOURNAL PUBLISHING DTD (BLUE)               -->
+<!--                    The following modules are used only for JATS-->
+<!--                    Journal Publishing DTDs (Blue).             -->
+<!--                    If you are not using Publishing (Blue), you -->
+<!--                    may delete the group below, or leave it     -->
+<!--                    here as these public definitions do no harm.-->
+<!-- ============================================================== -->
+
+<group prefer="public" 
+       xml:base="put a real base here, such as 'file:///C:/MyWork/OurTasks/DTDs-for-JATS/'">
+
+<!--                    The following modules are used for ALL of   -->
+<!--                    the Journal Publishing DTDs (Blue)          -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Mixes Module v1.2 20190208//EN"
+               uri="JATS-journalpubcustom-mixes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Content and Attributes Module v1.2 20190208//EN"
+               uri="JATS-journalpubcustom-models1.ent"/>
+
+<!--                    The following modules are used for all of   -->
+<!--                    the Journal Publishing DTDs (Blue) that use -->
+<!--                    ONLY the XHTML-based Table Model            -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Classes Module v1.2 20190208//EN"
+               uri="JATS-journalpubcustom-classes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD-Specific Modules v1.2 20190208//EN"
+               uri="JATS-journalpubcustom-modules1.ent"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Journal Publishing DTD (Blue), that uses    -->
+<!--                    XHTML tables with MathML 2.0                -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.2 20190208//EN"
+               uri="JATS-journalpublishing1.dtd"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Journal Publishing DTD (Blue), that uses    -->
+<!--                    XHTML tables with MathML 3.0                -->
+
+<public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with MathML3 v1.2 20190208//EN"
+               uri="JATS-journalpublishing1-mathml3.dtd"/>
+
+<!--                    The following modules are used only for all -->
+<!--                    Journal Publishing DTDs(Blue) that use the  -->
+<!--                    OASIS table model (namespace prefix "oasis")-->
+<!--                    and the XHTML table model.                  -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables DTD-Specific Modules v1.2 20190208//EN"
+               uri="JATS-journalpub-oasis-custom-modules1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables Customize Classes v1.2 20190208//EN"
+               uri="JATS-journalpub-oasis-custom-classes1.ent"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Journal Publishing DTD (Blue) that uses the -->
+<!--                    OASIS table model (namespace prefix "oasis")-->
+<!--                    and the XHTML table model with MathML 2.0   -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables v1.2 20190208//EN"
+               uri="JATS-journalpublishing-oasis-article1.dtd"/>
+
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Journal Publishing DTD (Blue) that uses the -->
+<!--                    OASIS table model (namespace prefix "oasis")-->
+<!--                    and the XHTML table model with MathML 3.0   -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables with MathML3 v1.2 20190208//EN"
+               uri="JATS-journalpublishing-oasis-article1-mathml3.dtd"/>
+
+</group>
+
+<!-- ============================================================== -->
+<!--                    ARCHIVING AND INTERCHANGE DTD (GREEN)       -->
+<!--                    The following modules are used only for JATS-->
+<!--                    Journal Archiving and Interchange DTDs      -->
+<!--                    (Green)                                     -->
+<!--                    If you are not using Archiving (Green), you -->
+<!--                    may delete the group below, or leave it     -->
+<!--                    here as these public definitions do no harm.-->
+<!-- ============================================================== -->
+
+<group prefer="public" 
+       xml:base="put a real base here, such as 'file:///C:/MyWork/OurTasks/DTDs-for-JATS/'">
+
+<!--                    The following modules are used for ALL of   -->
+<!--                    the Archiving and Interchange DTDs (Green)  -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Mixes Module v1.2 20190208//EN"
+               uri="JATS-archivecustom-mixes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Content and Attributes Module v1.2 20190208//EN"
+               uri="JATS-archivecustom-models1.ent"/>
+ 
+<!--                    The following modules are used for all of   -->
+<!--                    the Archiving and Interchange DTDs (Green)  -->
+<!--                    that use ONLY the XHTML-based Table Model   -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Classes Module v1.2 20190208//EN" 
+               uri="JATS-archivecustom-classes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving DTD-Specific Modules v1.2 20190208//EN" 
+               uri="JATS-archivecustom-modules1.ent"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Archiving and Interchange DTDs (Green), that-->
+<!--                    uses XHTML tables with MathML 2.0           -->
+
+ <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2 20190208//EN" 
+               uri="JATS-archivearticle1.dtd"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Archiving and Interchange DTDs (Green), that-->
+<!--                    uses XHTML tables with MathML 3.0           -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.2 20190208//EN"
+               uri="JATS-archivearticle1-mathml3.dtd"/>
+
+
+<!--                    The following modules are used only for all -->
+<!--                    Archiving and Interchange DTDs (Green) that -->
+<!--                    use the OASIS table model (namespace prefix -->
+<!--                    "oasis") and the XHTML table model.         -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with OASIS Tables Customize Classes Module v1.2 20190208//EN"
+               uri="JATS-archive-oasis-custom-classes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with OASIS Tables DTD-Specific Modules v1.2 20190208//EN"
+               uri="JATS-archive-oasis-custom-modules1.ent"/>
+
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Archiving and Interchange DTDs (Green) that -->
+<!--                    use the OASIS table model (namespace prefix -->
+<!--                    "oasis") and the XHTML table model with     -->
+<!--                    MathML 2.0                                  -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with OASIS Tables v1.2 20190208//EN"
+               uri="JATS-archive-oasis-article1.dtd"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Archiving and Interchange DTDs (Green) that -->
+<!--                    use the OASIS table model (namespace prefix -->
+<!--                    "oasis") and the XHTML table model with     -->
+<!--                    MathML 3.0                                  -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with OASIS Tables with MathML3 v1.2 20190208//EN"
+               uri="JATS-archive-oasis-article1-mathml3.dtd"/>
+              
+</group>
+
+
+<!-- ============================================================== -->
+<!--                    ARTICLE AUTHORING DTD (PUMPKIN)             -->
+<!--                    The following modules are used only for JATS-->
+<!--                    Article Authoring DTD (Pumpkin).            -->
+<!--                    If you are not using Authoring (Pumpkin),   -->
+<!--                    may delete the group below, or leave it     -->
+<!--                    here as these public definitions do no harm.-->
+<!-- ============================================================== -->
+
+<group prefer="public" 
+       xml:base="put a real base here, such as 'file:///C:/MyWork/OurTasks/DTDs-for-JATS/'">
+
+<!--                    The following modules are used for ALL of   -->
+<!--                    the Article Authoring DTDs (Pumpkin)        -->
+
+  <public publicId= "-//NLM//DTD JATS (Z39.96) Article Authoring DTD Over-ride Classes Module v1.2 20190208//EN"
+               uri="JATS-articleauthcustom-classes1.ent"/>
+
+  <public publicId= "-//NLM//DTD JATS (Z39.96) Article Authoring DTD Over-ride Mixes Module v1.2 20190208//EN"
+               uri="JATS-articleauthcustom-mixes1.ent"/>
+
+  <public publicId= "-//NLM//DTD JATS (Z39.96) Article Authoring DTD Over-ride Content and Attribute Module v1.2 20190208//EN"
+               uri="JATS-articleauthcustom-models1.ent"/>
+
+  <public publicId= "-//NLM//DTD JATS (Z39.96) Article Authoring DTD-Specific Modules v1.2 20190208//EN"
+               uri="JATS-articleauthcustom-modules1.ent"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    the Article Authoring DTDs (Pumpkin) that   -->
+<!--                    use the XHTML table model with MathML 2.0   -->
+           
+  <public publicId="-//NLM//DTD JATS (Z39.96) Article Authoring DTD v1.2 20190208//EN"
+               uri="JATS-articleauthoring1.dtd"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    the Article Authoring DTDs (Pumpkin) that   -->
+<!--                    use the XHTML table model with MathML 3.0   -->
+            
+  <public publicId="-//NLM//DTD JATS (Z39.96) Article Authoring DTD with MathML3 v1.2 20190208//EN"
+               uri="JATS-articleauthoring1-mathml3.dtd"/>
+
+</group>
+
+
+<!-- ============================================================== -->
+<!--                    JATS DTD SUITE                              -->
+<!--                    MODULAR LIBRARY                             -->
+<!--                    The following group is used by all of       -->
+<!--                    the JATS DTDS.                              -->
+<!--                    DO NOT DELETE OR COMMENT OUT THIS GROUP!    -->
+<!-- ============================================================== -->
+
+<group prefer="public" 
+       xml:base="put a real base here, such as 'file:///C:/MyWork/OurTasks/DTDs-for-JATS/'">
+
+<!--                    MODULE OF MODULES                           -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Module of Modules v1.2 20190208//EN"
+               uri="JATS-modules1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS MathML 3.0 Modules v1.2 20190208//EN"
+               uri="JATS-mathml3-modules1.ent"/>
+
+
+<!--                    CLASSES AND MIXES                           -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Default Element Classes Module v1.2 20190208//EN"
+               uri="JATS-default-classes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Default Element Mixes Module v1.2 20190208//EN"
+               uri="JATS-default-mixes1.ent"/>
+
+
+<!--                    ELEMENT COMMON (SHARED) ELEMENTS/CHARACTERS -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Common (Shared) Elements Module v1.2 20190208//EN"
+               uri="JATS-common1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Common Attributes (for all elements) v1.2 20190208//EN"
+               uri="JATS-common-atts1.ent"/>               
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Notation Declarations v1.2 20190208//EN"
+               uri="JATS-notat1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite XML Special Characters Module v1.2 20190208//EN"
+               uri="JATS-xmlspecchars1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Custom Special Characters Module v1.2 20190208//EN"
+               uri="JATS-chars1.ent"/>
+
+
+<!--                    CLASS MODULES                               -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Journal Article Metadata Elements v1.2 20190208//EN"
+               uri="JATS-articlemeta1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Back Matter Elements v1.2 20190208//EN"
+               uri="JATS-backmatter1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Display Class Elements v1.2 20190208//EN"
+               uri="JATS-display1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Formatting Element Classes v1.2 20190208//EN"
+               uri="JATS-format1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Funding Elements v1.2 20190208//EN"
+               uri="JATS-funding1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Journal Metadata Elements v1.2 20190208//EN"
+               uri="JATS-journalmeta1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Link Class Elements v1.2 20190208//EN"
+               uri="JATS-link1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite List Class Elements v1.2 20190208//EN"
+               uri="JATS-list1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Math Class Elements v1.2 20190208//EN"
+               uri="JATS-math1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) NLM Citation v1.2 20190208//EN"
+               uri="JATS-nlmcitation1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Paragraph-Like Elements v1.2 20190208//EN"
+               uri="JATS-para1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Subject Phrase Class Elements v1.2 20190208//EN"
+               uri="JATS-phrase1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Bibliographic Reference (Citation) Class Elements v1.2 20190208//EN"
+               uri="JATS-references1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Related Object Element v1.2 20190208//EN"
+               uri="JATS-related-object1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Section Class Elements v1.2 20190208//EN"
+               uri="JATS-section1.ent"/>
+
+
+<!--                    SET UP XHTML TABLES (OASIS below)          -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite XHTML Table Setup Module v1.2 20190208//EN"
+               uri="JATS-XHTMLtablesetup1.ent"/>
+
+<!--                    SET UP MATHML                              -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite MathML Setup Module v1.2 20190208//EN"
+               uri="JATS-mathmlsetup1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite MathML 3.0 Setup Module v1.2 20190208//EN"
+               uri="JATS-mathml3-mathmlsetup1.ent"/>
+
+</group>
+
+
+<!-- ============================================================== -->
+<!--                    COMMONLY-USED PUBLIC MODELS AND PUBLIC      -->
+<!--                    CHARACTER-ENTITY SETS USED IN THE SUITE     -->
+<!--                    The following group is used by all of       -->
+<!--                    the JATS DTDS.                              -->
+<!--                    DO NOT DELETE OR COMMENT OUT THIS GROUP!    -->
+<!-- ============================================================== -->
+
+<group prefer="public" 
+       xml:base="put a real base here, such as 'file:///C:/MyWork/OurTasks/DTDs-for-JATS/'">
+
+<!-- .............................................................. -->
+<!--                    NISO ACCESS AND INDICATOR NAMESPACE         -->
+<!-- .............................................................. -->
+
+  <public publicId="-//NLM//DTD JATS ALI Namespace Module v1.2 20190208//EN"
+               uri="JATS-ali-namespace1.ent"/>
+
+<!-- .............................................................. -->
+<!--                    TABLES: XHTML TABLE MODULES                 -->
+<!-- .............................................................. -->
+
+  <public publicId="-//W3C//ELEMENTS XHTML Tables 1.0//EN"
+               uri="xhtml-table-1.mod"/>
+
+  <public publicId="-//W3C//ENTITIES XHTML Inline Style 1.0//EN"
+               uri="xhtml-inlstyle-1.mod"/>
+
+
+<!-- .............................................................. -->
+<!--                    TABLES: OASIS EXCHANGE TABLE MODULES        -->
+<!-- .............................................................. -->
+
+  <public publicId="-//NLM//DTD JATS OASIS Table Namespace Module v1.2 20190208//EN"
+               uri="JATS-oasis-namespace1.ent"/>
+
+  <public publicId="-//OASIS//DTD XML Exchange Table Model 19990315//EN"
+               uri="oasis-exchange.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Namespaced OASIS XML Table Setup Module v1.2 20190208//EN"
+               uri="JATS-oasis-tablesetup1.ent"/>
+ 
+
+<!-- .............................................................. -->
+<!--                    MATHML MODULES                              -->
+<!-- .............................................................. -->
+
+  <public publicId="-//W3C//DTD MathML 2.0//EN"
+               uri="mathml2.dtd"/>
+  <public publicId="-//W3C//ENTITIES MathML 2.0 Qualified Names 1.0//EN"
+               uri="mathml2-qname-1.mod"/>
+  <public publicId="-//W3C//ENTITIES Extra for MathML 2.0//EN"
+               uri="mathml/mmlextra.ent"/>
+  <public publicId="-//W3C//ENTITIES Aliases for MathML 2.0//EN"
+               uri="mathml/mmlalias.ent"/>
+
+
+  <public publicId="-//W3C//DTD MathML 3.0//EN"
+               uri="mathml3.dtd"/>
+  <public publicId="-//W3C//ENTITIES MathML 3.0 Qualified Names 1.0//EN" 
+               uri="mathml3-qname1.mod"/>
+  <public publicId="-//W3C//ENTITIES Extra for MathML 3.0//EN" 
+               uri="mathml/mmlextra.ent"/>
+  <public publicId="-//W3C//ENTITIES Aliases for MathML 3.0//EN"
+               uri="mathml/mmlalias.ent"/>
+
+<!-- .............................................................. -->
+<!--                    ISO 8879 ENTITIES                           -->
+<!-- .............................................................. -->
+
+
+  <public publicId="-//W3C//ENTITIES Box and Line Drawing for MathML 2.0//EN"
+               uri="iso8879/isobox.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Russian Cyrillic for MathML 2.0//EN"
+               uri="iso8879/isocyr1.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Non-Russian Cyrillic for MathML 2.0//EN"
+               uri="iso8879/isocyr2.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Diacritical Marks for MathML 2.0//EN"
+               uri="iso8879/isodia.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Latin 1 for MathML 2.0//EN"
+               uri="iso8879/isolat1.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Latin 2 for MathML 2.0//EN"
+               uri="iso8879/isolat2.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Numeric and Special Graphic for MathML 2.0//EN"
+               uri="iso8879/isonum.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Publishing for MathML 2.0//EN"
+               uri="iso8879/isopub.ent"/>
+
+<!-- .............................................................. -->
+<!--                    ISO 9573-11 ENTITIES                        -->
+<!-- .............................................................. -->
+
+  <public publicId="-//W3C//ENTITIES General Technical for MathML 2.0//EN"
+               uri="iso9573-13/isotech.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Greek Symbols for MathML 2.0//EN"
+               uri="iso9573-13/isogrk3.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Math Alphabets: Script for MathML 2.0//EN"
+               uri="iso9573-13/isomscr.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Arrow Relations for MathML 2.0//EN"
+               uri="iso9573-13/isoamsa.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Binary Operators for MathML 2.0//EN"
+               uri="iso9573-13/isoamsb.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Delimiters for MathML 2.0//EN"
+               uri="iso9573-13/isoamsc.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Negated Relations for MathML 2.0//EN"
+               uri="iso9573-13/isoamsn.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Ordinary for MathML 2.0//EN"
+               uri="iso9573-13/isoamso.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Relations for MathML 2.0//EN"
+               uri="iso9573-13/isoamsr.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Math Alphabets: Fraktur for MathML 2.0//EN"
+               uri="iso9573-13/isomfrk.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Math Alphabets: Open Face for MathML 2.0//EN"
+               uri="iso9573-13/isomopf.ent"/>
+
+<!-- .............................................................. -->
+<!--                    NON-MATHML ENTITIES(backwards compatibility)-->
+<!-- .............................................................. -->
+
+  <public publicId="-//W3C//ENTITIES Greek Letters//EN"
+               uri="xmlchars/isogrk1.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Monotoniko Greek//EN"
+               uri="xmlchars/isogrk2.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Alternative Greek Symbols//EN"
+               uri="xmlchars/isogrk4.ent"/>
+
+</group>
+
+
+<!-- ============================================================== -->
+<!--                    BITS BOOK INTERCHANGE DTD                   -->
+<!--                    The following modules are used only for NLM -->
+<!--                    BITS (Book Interchange Tag Suite)[Chocolate]-->
+<!--                                                                -->
+<!--                    If you are not using BITS (Chocolate), you  -->
+<!--                    may delete the group below, or leave it     -->
+<!--                    here as these public definitions do no harm.-->
+<!-- ============================================================== -->
+<group prefer="public" 
+       xml:base="put a real base here, such as 'file:///C:/MyWork/OurTasks/DTDs-for-JATS/'">
+   
+<!--                    The following modules are used for all of   -->
+<!--                    the BITS DTDs (Chocolate)                   -->
+<!--                    that use ONLY the XHTML-based Table Model   -->
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD v2.1 20180401//EN"
+               uri="BITS-book2.dtd"/>
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD-Specific Modules v2.1 20180401//EN" 
+               uri="BITS-bookcustom-modules2.ent"/>
+ 
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD Customize Classes Module v2.1 20180401//EN" 
+               uri="BITS-bookcustom-classes2.ent"/>
+              
+  <public publicId="-//NLM//DTD BITS Book Part Wrapper v2.1 20180401//EN" 
+               uri="BITS-book-part-wrap2.ent" /> 
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    BITS DTDs that -->
+<!--                    use the OASIS table model (namespace prefix -->
+<!--                    "oasis") and the XHTML table model          -->
+             
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD with OASIS and XHTML Tables v2.1 20180401//EN"
+               uri="BITS-book-oasis2.dtd" />
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD-Specific Modules with OASIS and XHTML Tables v2.1 20180401//EN"
+               uri="BITS-book-oasis-custom-modules2.ent" />
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD with OASIS and XHTML Tables Customize Classes Module v2.1 20180401//EN"
+               uri="BITS-book-oasis-custom-classes2.ent" />
+               
+  <public publicId="-//NLM//DTD BITS Book Part OASIS and XHTML Tables Wrapper v2.1 20180401//EN"  
+               uri="BITS-book-part-oasis-wrap2.ent" /> 
+              
+<!--                    The following modules are used for ALL of   -->
+<!--                    the BITS DTDs (Chocolate)                 -->
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD Customize Mixes Module v2.1 20180401//EN"
+               uri="BITS-bookcustom-mixes2.ent"/>
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD Customize Content and Attributes Module v2.1 20180401//EN" 
+               uri="BITS-bookcustom-models2.ent"/>
+
+
+               
+  <public publicId="-//NLM//DTD BITS Add Attributes Module v2.1 20180401//EN"  
+               uri="BITS-add-attributes2.ent"  /> 
+
+  <public publicId="-//NLM//DTD BITS Book Metadata Elements Module v2.1 20180401//EN"  
+               uri="BITS-bookmeta2.ent"/> 
+
+  <public publicId="-//NLM//DTD BITS Book Component Elements v2.1 20180401//EN"  
+               uri="BITS-book-part2.ent"/> 
+                
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD Common Module v2.1 20180401//EN" 
+               uri="BITS-common2.ent" /> 
+ 
+  <public publicId="-//NLM//DTD BITS Embedded Index Element Module v2.1 20180401//EN"
+               uri="BITS-embedded-index2.ent"/> 
+
+  <public publicId="-//NLM//DTD BITS Structural Index Elements Module v2.1 20180401//EN" 
+               uri="BITS-index2.ent"/> 
+
+  <public publicId="-//NLM//DTD BITS Structural Table of Contents Module v2.1 20180401//EN"
+               uri="BITS-toc2.ent"/> 
+               
+  <public publicId="-//NLM//DTD BITS Question and Answer Module v2.1 20180401//EN"  
+               uri="BITS-question-answer2.ent"  /> 
+
+  <public publicId="-//NLM//DTD BITS Table of Contents and Index Navigation Module v2.1 20180401//EN"
+               uri="BITS-toc-index-nav2.ent"/> 
+               
+  <public publicId="-//NLM//DTD BITS XInclude Setup Module v2.1 20180401//EN" 
+               uri="BITS-xinclude2.ent" /> 
+ 
+</group>
+
+<!-- ================ End WITH Base OASIS XML CATALOG ============= -->
+
+</catalog>

--- a/src/main/resources/dtd/archiving/1.2/iso8879/isobox.ent
+++ b/src/main/resources/dtd/archiving/1.2/iso8879/isobox.ent
@@ -1,0 +1,61 @@
+
+<!--
+     File isobox.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY boxDL            "&#x02557;" ><!--lower left quadrant -->
+<!ENTITY boxDl            "&#x02556;" ><!--lower left quadrant -->
+<!ENTITY boxdL            "&#x02555;" ><!--lower left quadrant -->
+<!ENTITY boxdl            "&#x02510;" ><!--lower left quadrant -->
+<!ENTITY boxDR            "&#x02554;" ><!--lower right quadrant -->
+<!ENTITY boxDr            "&#x02553;" ><!--lower right quadrant -->
+<!ENTITY boxdR            "&#x02552;" ><!--lower right quadrant -->
+<!ENTITY boxdr            "&#x0250C;" ><!--lower right quadrant -->
+<!ENTITY boxH             "&#x02550;" ><!--horizontal line -->
+<!ENTITY boxh             "&#x02500;" ><!--horizontal line  -->
+<!ENTITY boxHD            "&#x02566;" ><!--lower left and right quadrants -->
+<!ENTITY boxHd            "&#x02564;" ><!--lower left and right quadrants -->
+<!ENTITY boxhD            "&#x02565;" ><!--lower left and right quadrants -->
+<!ENTITY boxhd            "&#x0252C;" ><!--lower left and right quadrants -->
+<!ENTITY boxHU            "&#x02569;" ><!--upper left and right quadrants -->
+<!ENTITY boxHu            "&#x02567;" ><!--upper left and right quadrants -->
+<!ENTITY boxhU            "&#x02568;" ><!--upper left and right quadrants -->
+<!ENTITY boxhu            "&#x02534;" ><!--upper left and right quadrants -->
+<!ENTITY boxUL            "&#x0255D;" ><!--upper left quadrant -->
+<!ENTITY boxUl            "&#x0255C;" ><!--upper left quadrant -->
+<!ENTITY boxuL            "&#x0255B;" ><!--upper left quadrant -->
+<!ENTITY boxul            "&#x02518;" ><!--upper left quadrant -->
+<!ENTITY boxUR            "&#x0255A;" ><!--upper right quadrant -->
+<!ENTITY boxUr            "&#x02559;" ><!--upper right quadrant -->
+<!ENTITY boxuR            "&#x02558;" ><!--upper right quadrant -->
+<!ENTITY boxur            "&#x02514;" ><!--upper right quadrant -->
+<!ENTITY boxV             "&#x02551;" ><!--vertical line -->
+<!ENTITY boxv             "&#x02502;" ><!--vertical line -->
+<!ENTITY boxVH            "&#x0256C;" ><!--all four quadrants -->
+<!ENTITY boxVh            "&#x0256B;" ><!--all four quadrants -->
+<!ENTITY boxvH            "&#x0256A;" ><!--all four quadrants -->
+<!ENTITY boxvh            "&#x0253C;" ><!--all four quadrants -->
+<!ENTITY boxVL            "&#x02563;" ><!--upper and lower left quadrants -->
+<!ENTITY boxVl            "&#x02562;" ><!--upper and lower left quadrants -->
+<!ENTITY boxvL            "&#x02561;" ><!--upper and lower left quadrants -->
+<!ENTITY boxvl            "&#x02524;" ><!--upper and lower left quadrants -->
+<!ENTITY boxVR            "&#x02560;" ><!--upper and lower right quadrants -->
+<!ENTITY boxVr            "&#x0255F;" ><!--upper and lower right quadrants -->
+<!ENTITY boxvR            "&#x0255E;" ><!--upper and lower right quadrants -->
+<!ENTITY boxvr            "&#x0251C;" ><!--upper and lower right quadrants -->

--- a/src/main/resources/dtd/archiving/1.2/iso8879/isocyr1.ent
+++ b/src/main/resources/dtd/archiving/1.2/iso8879/isocyr1.ent
@@ -1,0 +1,88 @@
+
+<!--
+     File isocyr1.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY Acy              "&#x00410;" ><!--=capital A, Cyrillic -->
+<!ENTITY acy              "&#x00430;" ><!--=small a, Cyrillic -->
+<!ENTITY Bcy              "&#x00411;" ><!--=capital BE, Cyrillic -->
+<!ENTITY bcy              "&#x00431;" ><!--=small be, Cyrillic -->
+<!ENTITY CHcy             "&#x00427;" ><!--=capital CHE, Cyrillic -->
+<!ENTITY chcy             "&#x00447;" ><!--=small che, Cyrillic -->
+<!ENTITY Dcy              "&#x00414;" ><!--=capital DE, Cyrillic -->
+<!ENTITY dcy              "&#x00434;" ><!--=small de, Cyrillic -->
+<!ENTITY Ecy              "&#x0042D;" ><!--=capital E, Cyrillic -->
+<!ENTITY ecy              "&#x0044D;" ><!--=small e, Cyrillic -->
+<!ENTITY Fcy              "&#x00424;" ><!--=capital EF, Cyrillic -->
+<!ENTITY fcy              "&#x00444;" ><!--=small ef, Cyrillic -->
+<!ENTITY Gcy              "&#x00413;" ><!--=capital GHE, Cyrillic -->
+<!ENTITY gcy              "&#x00433;" ><!--=small ghe, Cyrillic -->
+<!ENTITY HARDcy           "&#x0042A;" ><!--=capital HARD sign, Cyrillic -->
+<!ENTITY hardcy           "&#x0044A;" ><!--=small hard sign, Cyrillic -->
+<!ENTITY Icy              "&#x00418;" ><!--=capital I, Cyrillic -->
+<!ENTITY icy              "&#x00438;" ><!--=small i, Cyrillic -->
+<!ENTITY IEcy             "&#x00415;" ><!--=capital IE, Cyrillic -->
+<!ENTITY iecy             "&#x00435;" ><!--=small ie, Cyrillic -->
+<!ENTITY IOcy             "&#x00401;" ><!--=capital IO, Russian -->
+<!ENTITY iocy             "&#x00451;" ><!--=small io, Russian -->
+<!ENTITY Jcy              "&#x00419;" ><!--=capital short I, Cyrillic -->
+<!ENTITY jcy              "&#x00439;" ><!--=small short i, Cyrillic -->
+<!ENTITY Kcy              "&#x0041A;" ><!--=capital KA, Cyrillic -->
+<!ENTITY kcy              "&#x0043A;" ><!--=small ka, Cyrillic -->
+<!ENTITY KHcy             "&#x00425;" ><!--=capital HA, Cyrillic -->
+<!ENTITY khcy             "&#x00445;" ><!--=small ha, Cyrillic -->
+<!ENTITY Lcy              "&#x0041B;" ><!--=capital EL, Cyrillic -->
+<!ENTITY lcy              "&#x0043B;" ><!--=small el, Cyrillic -->
+<!ENTITY Mcy              "&#x0041C;" ><!--=capital EM, Cyrillic -->
+<!ENTITY mcy              "&#x0043C;" ><!--=small em, Cyrillic -->
+<!ENTITY Ncy              "&#x0041D;" ><!--=capital EN, Cyrillic -->
+<!ENTITY ncy              "&#x0043D;" ><!--=small en, Cyrillic -->
+<!ENTITY numero           "&#x02116;" ><!--=numero sign -->
+<!ENTITY Ocy              "&#x0041E;" ><!--=capital O, Cyrillic -->
+<!ENTITY ocy              "&#x0043E;" ><!--=small o, Cyrillic -->
+<!ENTITY Pcy              "&#x0041F;" ><!--=capital PE, Cyrillic -->
+<!ENTITY pcy              "&#x0043F;" ><!--=small pe, Cyrillic -->
+<!ENTITY Rcy              "&#x00420;" ><!--=capital ER, Cyrillic -->
+<!ENTITY rcy              "&#x00440;" ><!--=small er, Cyrillic -->
+<!ENTITY Scy              "&#x00421;" ><!--=capital ES, Cyrillic -->
+<!ENTITY scy              "&#x00441;" ><!--=small es, Cyrillic -->
+<!ENTITY SHCHcy           "&#x00429;" ><!--=capital SHCHA, Cyrillic -->
+<!ENTITY shchcy           "&#x00449;" ><!--=small shcha, Cyrillic -->
+<!ENTITY SHcy             "&#x00428;" ><!--=capital SHA, Cyrillic -->
+<!ENTITY shcy             "&#x00448;" ><!--=small sha, Cyrillic -->
+<!ENTITY SOFTcy           "&#x0042C;" ><!--=capital SOFT sign, Cyrillic -->
+<!ENTITY softcy           "&#x0044C;" ><!--=small soft sign, Cyrillic -->
+<!ENTITY Tcy              "&#x00422;" ><!--=capital TE, Cyrillic -->
+<!ENTITY tcy              "&#x00442;" ><!--=small te, Cyrillic -->
+<!ENTITY TScy             "&#x00426;" ><!--=capital TSE, Cyrillic -->
+<!ENTITY tscy             "&#x00446;" ><!--=small tse, Cyrillic -->
+<!ENTITY Ucy              "&#x00423;" ><!--=capital U, Cyrillic -->
+<!ENTITY ucy              "&#x00443;" ><!--=small u, Cyrillic -->
+<!ENTITY Vcy              "&#x00412;" ><!--=capital VE, Cyrillic -->
+<!ENTITY vcy              "&#x00432;" ><!--=small ve, Cyrillic -->
+<!ENTITY YAcy             "&#x0042F;" ><!--=capital YA, Cyrillic -->
+<!ENTITY yacy             "&#x0044F;" ><!--=small ya, Cyrillic -->
+<!ENTITY Ycy              "&#x0042B;" ><!--=capital YERU, Cyrillic -->
+<!ENTITY ycy              "&#x0044B;" ><!--=small yeru, Cyrillic -->
+<!ENTITY YUcy             "&#x0042E;" ><!--=capital YU, Cyrillic -->
+<!ENTITY yucy             "&#x0044E;" ><!--=small yu, Cyrillic -->
+<!ENTITY Zcy              "&#x00417;" ><!--=capital ZE, Cyrillic -->
+<!ENTITY zcy              "&#x00437;" ><!--=small ze, Cyrillic -->
+<!ENTITY ZHcy             "&#x00416;" ><!--=capital ZHE, Cyrillic -->
+<!ENTITY zhcy             "&#x00436;" ><!--=small zhe, Cyrillic -->

--- a/src/main/resources/dtd/archiving/1.2/iso8879/isocyr2.ent
+++ b/src/main/resources/dtd/archiving/1.2/iso8879/isocyr2.ent
@@ -1,0 +1,47 @@
+
+<!--
+     File isocyr2.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY DJcy             "&#x00402;" ><!--=capital DJE, Serbian -->
+<!ENTITY djcy             "&#x00452;" ><!--=small dje, Serbian -->
+<!ENTITY DScy             "&#x00405;" ><!--=capital DSE, Macedonian -->
+<!ENTITY dscy             "&#x00455;" ><!--=small dse, Macedonian -->
+<!ENTITY DZcy             "&#x0040F;" ><!--=capital dze, Serbian -->
+<!ENTITY dzcy             "&#x0045F;" ><!--=small dze, Serbian -->
+<!ENTITY GJcy             "&#x00403;" ><!--=capital GJE Macedonian -->
+<!ENTITY gjcy             "&#x00453;" ><!--=small gje, Macedonian -->
+<!ENTITY Iukcy            "&#x00406;" ><!--=capital I, Ukrainian -->
+<!ENTITY iukcy            "&#x00456;" ><!--=small i, Ukrainian -->
+<!ENTITY Jsercy           "&#x00408;" ><!--=capital JE, Serbian -->
+<!ENTITY jsercy           "&#x00458;" ><!--=small je, Serbian -->
+<!ENTITY Jukcy            "&#x00404;" ><!--=capital JE, Ukrainian -->
+<!ENTITY jukcy            "&#x00454;" ><!--=small je, Ukrainian -->
+<!ENTITY KJcy             "&#x0040C;" ><!--=capital KJE, Macedonian -->
+<!ENTITY kjcy             "&#x0045C;" ><!--=small kje Macedonian -->
+<!ENTITY LJcy             "&#x00409;" ><!--=capital LJE, Serbian -->
+<!ENTITY ljcy             "&#x00459;" ><!--=small lje, Serbian -->
+<!ENTITY NJcy             "&#x0040A;" ><!--=capital NJE, Serbian -->
+<!ENTITY njcy             "&#x0045A;" ><!--=small nje, Serbian -->
+<!ENTITY TSHcy            "&#x0040B;" ><!--=capital TSHE, Serbian -->
+<!ENTITY tshcy            "&#x0045B;" ><!--=small tshe, Serbian -->
+<!ENTITY Ubrcy            "&#x0040E;" ><!--=capital U, Byelorussian -->
+<!ENTITY ubrcy            "&#x0045E;" ><!--=small u, Byelorussian -->
+<!ENTITY YIcy             "&#x00407;" ><!--=capital YI, Ukrainian -->
+<!ENTITY yicy             "&#x00457;" ><!--=small yi, Ukrainian -->

--- a/src/main/resources/dtd/archiving/1.2/iso8879/isodia.ent
+++ b/src/main/resources/dtd/archiving/1.2/iso8879/isodia.ent
@@ -1,0 +1,35 @@
+
+<!--
+     File isodia.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY acute            "&#x000B4;" ><!--=acute accent -->
+<!ENTITY breve            "&#x002D8;" ><!--=breve -->
+<!ENTITY caron            "&#x002C7;" ><!--=caron -->
+<!ENTITY cedil            "&#x000B8;" ><!--=cedilla -->
+<!ENTITY circ             "&#x002C6;" ><!--circumflex accent -->
+<!ENTITY dblac            "&#x002DD;" ><!--=double acute accent -->
+<!ENTITY die              "&#x000A8;" ><!--=dieresis -->
+<!ENTITY dot              "&#x002D9;" ><!--=dot above -->
+<!ENTITY grave            "&#x00060;" ><!--=grave accent -->
+<!ENTITY macr             "&#x000AF;" ><!--=macron -->
+<!ENTITY ogon             "&#x002DB;" ><!--=ogonek -->
+<!ENTITY ring             "&#x002DA;" ><!--=ring -->
+<!ENTITY tilde            "&#x002DC;" ><!--=tilde -->
+<!ENTITY uml              "&#x000A8;" ><!--=umlaut mark -->

--- a/src/main/resources/dtd/archiving/1.2/iso8879/isolat1.ent
+++ b/src/main/resources/dtd/archiving/1.2/iso8879/isolat1.ent
@@ -1,0 +1,83 @@
+
+<!--
+     File isolat1.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY Aacute           "&#x000C1;" ><!--=capital A, acute accent -->
+<!ENTITY aacute           "&#x000E1;" ><!--=small a, acute accent -->
+<!ENTITY Acirc            "&#x000C2;" ><!--=capital A, circumflex accent -->
+<!ENTITY acirc            "&#x000E2;" ><!--=small a, circumflex accent -->
+<!ENTITY AElig            "&#x000C6;" ><!--=capital AE diphthong (ligature) -->
+<!ENTITY aelig            "&#x000E6;" ><!--=small ae diphthong (ligature) -->
+<!ENTITY Agrave           "&#x000C0;" ><!--=capital A, grave accent -->
+<!ENTITY agrave           "&#x000E0;" ><!--=small a, grave accent -->
+<!ENTITY Aring            "&#x000C5;" ><!--=capital A, ring -->
+<!ENTITY aring            "&#x000E5;" ><!--=small a, ring -->
+<!ENTITY Atilde           "&#x000C3;" ><!--=capital A, tilde -->
+<!ENTITY atilde           "&#x000E3;" ><!--=small a, tilde -->
+<!ENTITY Auml             "&#x000C4;" ><!--=capital A, dieresis or umlaut mark -->
+<!ENTITY auml             "&#x000E4;" ><!--=small a, dieresis or umlaut mark -->
+<!ENTITY Ccedil           "&#x000C7;" ><!--=capital C, cedilla -->
+<!ENTITY ccedil           "&#x000E7;" ><!--=small c, cedilla -->
+<!ENTITY Eacute           "&#x000C9;" ><!--=capital E, acute accent -->
+<!ENTITY eacute           "&#x000E9;" ><!--=small e, acute accent -->
+<!ENTITY Ecirc            "&#x000CA;" ><!--=capital E, circumflex accent -->
+<!ENTITY ecirc            "&#x000EA;" ><!--=small e, circumflex accent -->
+<!ENTITY Egrave           "&#x000C8;" ><!--=capital E, grave accent -->
+<!ENTITY egrave           "&#x000E8;" ><!--=small e, grave accent -->
+<!ENTITY ETH              "&#x000D0;" ><!--=capital Eth, Icelandic -->
+<!ENTITY eth              "&#x000F0;" ><!--=small eth, Icelandic -->
+<!ENTITY Euml             "&#x000CB;" ><!--=capital E, dieresis or umlaut mark -->
+<!ENTITY euml             "&#x000EB;" ><!--=small e, dieresis or umlaut mark -->
+<!ENTITY Iacute           "&#x000CD;" ><!--=capital I, acute accent -->
+<!ENTITY iacute           "&#x000ED;" ><!--=small i, acute accent -->
+<!ENTITY Icirc            "&#x000CE;" ><!--=capital I, circumflex accent -->
+<!ENTITY icirc            "&#x000EE;" ><!--=small i, circumflex accent -->
+<!ENTITY Igrave           "&#x000CC;" ><!--=capital I, grave accent -->
+<!ENTITY igrave           "&#x000EC;" ><!--=small i, grave accent -->
+<!ENTITY Iuml             "&#x000CF;" ><!--=capital I, dieresis or umlaut mark -->
+<!ENTITY iuml             "&#x000EF;" ><!--=small i, dieresis or umlaut mark -->
+<!ENTITY Ntilde           "&#x000D1;" ><!--=capital N, tilde -->
+<!ENTITY ntilde           "&#x000F1;" ><!--=small n, tilde -->
+<!ENTITY Oacute           "&#x000D3;" ><!--=capital O, acute accent -->
+<!ENTITY oacute           "&#x000F3;" ><!--=small o, acute accent -->
+<!ENTITY Ocirc            "&#x000D4;" ><!--=capital O, circumflex accent -->
+<!ENTITY ocirc            "&#x000F4;" ><!--=small o, circumflex accent -->
+<!ENTITY Ograve           "&#x000D2;" ><!--=capital O, grave accent -->
+<!ENTITY ograve           "&#x000F2;" ><!--=small o, grave accent -->
+<!ENTITY Oslash           "&#x000D8;" ><!--=capital O, slash -->
+<!ENTITY oslash           "&#x000F8;" ><!--latin small letter o with stroke -->
+<!ENTITY Otilde           "&#x000D5;" ><!--=capital O, tilde -->
+<!ENTITY otilde           "&#x000F5;" ><!--=small o, tilde -->
+<!ENTITY Ouml             "&#x000D6;" ><!--=capital O, dieresis or umlaut mark -->
+<!ENTITY ouml             "&#x000F6;" ><!--=small o, dieresis or umlaut mark -->
+<!ENTITY szlig            "&#x000DF;" ><!--=small sharp s, German (sz ligature) -->
+<!ENTITY THORN            "&#x000DE;" ><!--=capital THORN, Icelandic -->
+<!ENTITY thorn            "&#x000FE;" ><!--=small thorn, Icelandic -->
+<!ENTITY Uacute           "&#x000DA;" ><!--=capital U, acute accent -->
+<!ENTITY uacute           "&#x000FA;" ><!--=small u, acute accent -->
+<!ENTITY Ucirc            "&#x000DB;" ><!--=capital U, circumflex accent -->
+<!ENTITY ucirc            "&#x000FB;" ><!--=small u, circumflex accent -->
+<!ENTITY Ugrave           "&#x000D9;" ><!--=capital U, grave accent -->
+<!ENTITY ugrave           "&#x000F9;" ><!--=small u, grave accent -->
+<!ENTITY Uuml             "&#x000DC;" ><!--=capital U, dieresis or umlaut mark -->
+<!ENTITY uuml             "&#x000FC;" ><!--=small u, dieresis or umlaut mark -->
+<!ENTITY Yacute           "&#x000DD;" ><!--=capital Y, acute accent -->
+<!ENTITY yacute           "&#x000FD;" ><!--=small y, acute accent -->
+<!ENTITY yuml             "&#x000FF;" ><!--=small y, dieresis or umlaut mark -->

--- a/src/main/resources/dtd/archiving/1.2/iso8879/isolat2.ent
+++ b/src/main/resources/dtd/archiving/1.2/iso8879/isolat2.ent
@@ -1,0 +1,142 @@
+
+<!--
+     File isolat2.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY Abreve           "&#x00102;" ><!--=capital A, breve -->
+<!ENTITY abreve           "&#x00103;" ><!--=small a, breve -->
+<!ENTITY Amacr            "&#x00100;" ><!--=capital A, macron -->
+<!ENTITY amacr            "&#x00101;" ><!--=small a, macron -->
+<!ENTITY Aogon            "&#x00104;" ><!--=capital A, ogonek -->
+<!ENTITY aogon            "&#x00105;" ><!--=small a, ogonek -->
+<!ENTITY Cacute           "&#x00106;" ><!--=capital C, acute accent -->
+<!ENTITY cacute           "&#x00107;" ><!--=small c, acute accent -->
+<!ENTITY Ccaron           "&#x0010C;" ><!--=capital C, caron -->
+<!ENTITY ccaron           "&#x0010D;" ><!--=small c, caron -->
+<!ENTITY Ccirc            "&#x00108;" ><!--=capital C, circumflex accent -->
+<!ENTITY ccirc            "&#x00109;" ><!--=small c, circumflex accent -->
+<!ENTITY Cdot             "&#x0010A;" ><!--=capital C, dot above -->
+<!ENTITY cdot             "&#x0010B;" ><!--=small c, dot above -->
+<!ENTITY Dcaron           "&#x0010E;" ><!--=capital D, caron -->
+<!ENTITY dcaron           "&#x0010F;" ><!--=small d, caron -->
+<!ENTITY Dstrok           "&#x00110;" ><!--=capital D, stroke -->
+<!ENTITY dstrok           "&#x00111;" ><!--=small d, stroke -->
+<!ENTITY Ecaron           "&#x0011A;" ><!--=capital E, caron -->
+<!ENTITY ecaron           "&#x0011B;" ><!--=small e, caron -->
+<!ENTITY Edot             "&#x00116;" ><!--=capital E, dot above -->
+<!ENTITY edot             "&#x00117;" ><!--=small e, dot above -->
+<!ENTITY Emacr            "&#x00112;" ><!--=capital E, macron -->
+<!ENTITY emacr            "&#x00113;" ><!--=small e, macron -->
+<!ENTITY ENG              "&#x0014A;" ><!--=capital ENG, Lapp -->
+<!ENTITY eng              "&#x0014B;" ><!--=small eng, Lapp -->
+<!ENTITY Eogon            "&#x00118;" ><!--=capital E, ogonek -->
+<!ENTITY eogon            "&#x00119;" ><!--=small e, ogonek -->
+<!ENTITY gacute           "&#x001F5;" ><!--=small g, acute accent -->
+<!ENTITY Gbreve           "&#x0011E;" ><!--=capital G, breve -->
+<!ENTITY gbreve           "&#x0011F;" ><!--=small g, breve -->
+<!ENTITY Gcedil           "&#x00122;" ><!--=capital G, cedilla -->
+<!ENTITY Gcirc            "&#x0011C;" ><!--=capital G, circumflex accent -->
+<!ENTITY gcirc            "&#x0011D;" ><!--=small g, circumflex accent -->
+<!ENTITY Gdot             "&#x00120;" ><!--=capital G, dot above -->
+<!ENTITY gdot             "&#x00121;" ><!--=small g, dot above -->
+<!ENTITY Hcirc            "&#x00124;" ><!--=capital H, circumflex accent -->
+<!ENTITY hcirc            "&#x00125;" ><!--=small h, circumflex accent -->
+<!ENTITY Hstrok           "&#x00126;" ><!--=capital H, stroke -->
+<!ENTITY hstrok           "&#x00127;" ><!--=small h, stroke -->
+<!ENTITY Idot             "&#x00130;" ><!--=capital I, dot above -->
+<!ENTITY IJlig            "&#x00132;" ><!--=capital IJ ligature -->
+<!ENTITY ijlig            "&#x00133;" ><!--=small ij ligature -->
+<!ENTITY Imacr            "&#x0012A;" ><!--=capital I, macron -->
+<!ENTITY imacr            "&#x0012B;" ><!--=small i, macron -->
+<!ENTITY inodot           "&#x00131;" ><!--=small i without dot -->
+<!ENTITY Iogon            "&#x0012E;" ><!--=capital I, ogonek -->
+<!ENTITY iogon            "&#x0012F;" ><!--=small i, ogonek -->
+<!ENTITY Itilde           "&#x00128;" ><!--=capital I, tilde -->
+<!ENTITY itilde           "&#x00129;" ><!--=small i, tilde -->
+<!ENTITY Jcirc            "&#x00134;" ><!--=capital J, circumflex accent -->
+<!ENTITY jcirc            "&#x00135;" ><!--=small j, circumflex accent -->
+<!ENTITY Kcedil           "&#x00136;" ><!--=capital K, cedilla -->
+<!ENTITY kcedil           "&#x00137;" ><!--=small k, cedilla -->
+<!ENTITY kgreen           "&#x00138;" ><!--=small k, Greenlandic -->
+<!ENTITY Lacute           "&#x00139;" ><!--=capital L, acute accent -->
+<!ENTITY lacute           "&#x0013A;" ><!--=small l, acute accent -->
+<!ENTITY Lcaron           "&#x0013D;" ><!--=capital L, caron -->
+<!ENTITY lcaron           "&#x0013E;" ><!--=small l, caron -->
+<!ENTITY Lcedil           "&#x0013B;" ><!--=capital L, cedilla -->
+<!ENTITY lcedil           "&#x0013C;" ><!--=small l, cedilla -->
+<!ENTITY Lmidot           "&#x0013F;" ><!--=capital L, middle dot -->
+<!ENTITY lmidot           "&#x00140;" ><!--=small l, middle dot -->
+<!ENTITY Lstrok           "&#x00141;" ><!--=capital L, stroke -->
+<!ENTITY lstrok           "&#x00142;" ><!--=small l, stroke -->
+<!ENTITY Nacute           "&#x00143;" ><!--=capital N, acute accent -->
+<!ENTITY nacute           "&#x00144;" ><!--=small n, acute accent -->
+<!ENTITY napos            "&#x00149;" ><!--=small n, apostrophe -->
+<!ENTITY Ncaron           "&#x00147;" ><!--=capital N, caron -->
+<!ENTITY ncaron           "&#x00148;" ><!--=small n, caron -->
+<!ENTITY Ncedil           "&#x00145;" ><!--=capital N, cedilla -->
+<!ENTITY ncedil           "&#x00146;" ><!--=small n, cedilla -->
+<!ENTITY Odblac           "&#x00150;" ><!--=capital O, double acute accent -->
+<!ENTITY odblac           "&#x00151;" ><!--=small o, double acute accent -->
+<!ENTITY OElig            "&#x00152;" ><!--=capital OE ligature -->
+<!ENTITY oelig            "&#x00153;" ><!--=small oe ligature -->
+<!ENTITY Omacr            "&#x0014C;" ><!--=capital O, macron -->
+<!ENTITY omacr            "&#x0014D;" ><!--=small o, macron -->
+<!ENTITY Racute           "&#x00154;" ><!--=capital R, acute accent -->
+<!ENTITY racute           "&#x00155;" ><!--=small r, acute accent -->
+<!ENTITY Rcaron           "&#x00158;" ><!--=capital R, caron -->
+<!ENTITY rcaron           "&#x00159;" ><!--=small r, caron -->
+<!ENTITY Rcedil           "&#x00156;" ><!--=capital R, cedilla -->
+<!ENTITY rcedil           "&#x00157;" ><!--=small r, cedilla -->
+<!ENTITY Sacute           "&#x0015A;" ><!--=capital S, acute accent -->
+<!ENTITY sacute           "&#x0015B;" ><!--=small s, acute accent -->
+<!ENTITY Scaron           "&#x00160;" ><!--=capital S, caron -->
+<!ENTITY scaron           "&#x00161;" ><!--=small s, caron -->
+<!ENTITY Scedil           "&#x0015E;" ><!--=capital S, cedilla -->
+<!ENTITY scedil           "&#x0015F;" ><!--=small s, cedilla -->
+<!ENTITY Scirc            "&#x0015C;" ><!--=capital S, circumflex accent -->
+<!ENTITY scirc            "&#x0015D;" ><!--=small s, circumflex accent -->
+<!ENTITY Tcaron           "&#x00164;" ><!--=capital T, caron -->
+<!ENTITY tcaron           "&#x00165;" ><!--=small t, caron -->
+<!ENTITY Tcedil           "&#x00162;" ><!--=capital T, cedilla -->
+<!ENTITY tcedil           "&#x00163;" ><!--=small t, cedilla -->
+<!ENTITY Tstrok           "&#x00166;" ><!--=capital T, stroke -->
+<!ENTITY tstrok           "&#x00167;" ><!--=small t, stroke -->
+<!ENTITY Ubreve           "&#x0016C;" ><!--=capital U, breve -->
+<!ENTITY ubreve           "&#x0016D;" ><!--=small u, breve -->
+<!ENTITY Udblac           "&#x00170;" ><!--=capital U, double acute accent -->
+<!ENTITY udblac           "&#x00171;" ><!--=small u, double acute accent -->
+<!ENTITY Umacr            "&#x0016A;" ><!--=capital U, macron -->
+<!ENTITY umacr            "&#x0016B;" ><!--=small u, macron -->
+<!ENTITY Uogon            "&#x00172;" ><!--=capital U, ogonek -->
+<!ENTITY uogon            "&#x00173;" ><!--=small u, ogonek -->
+<!ENTITY Uring            "&#x0016E;" ><!--=capital U, ring -->
+<!ENTITY uring            "&#x0016F;" ><!--=small u, ring -->
+<!ENTITY Utilde           "&#x00168;" ><!--=capital U, tilde -->
+<!ENTITY utilde           "&#x00169;" ><!--=small u, tilde -->
+<!ENTITY Wcirc            "&#x00174;" ><!--=capital W, circumflex accent -->
+<!ENTITY wcirc            "&#x00175;" ><!--=small w, circumflex accent -->
+<!ENTITY Ycirc            "&#x00176;" ><!--=capital Y, circumflex accent -->
+<!ENTITY ycirc            "&#x00177;" ><!--=small y, circumflex accent -->
+<!ENTITY Yuml             "&#x00178;" ><!--=capital Y, dieresis or umlaut mark -->
+<!ENTITY Zacute           "&#x00179;" ><!--=capital Z, acute accent -->
+<!ENTITY zacute           "&#x0017A;" ><!--=small z, acute accent -->
+<!ENTITY Zcaron           "&#x0017D;" ><!--=capital Z, caron -->
+<!ENTITY zcaron           "&#x0017E;" ><!--=small z, caron -->
+<!ENTITY Zdot             "&#x0017B;" ><!--=capital Z, dot above -->
+<!ENTITY zdot             "&#x0017C;" ><!--=small z, dot above -->

--- a/src/main/resources/dtd/archiving/1.2/iso8879/isonum.ent
+++ b/src/main/resources/dtd/archiving/1.2/iso8879/isonum.ent
@@ -1,0 +1,97 @@
+
+<!--
+     File isonum.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY amp              "&#38;#38;" ><!--=ampersand -->
+<!ENTITY apos             "&#x00027;" ><!--=apostrophe -->
+<!ENTITY ast              "&#x0002A;" ><!--/ast B: =asterisk -->
+<!ENTITY brvbar           "&#x000A6;" ><!--=broken (vertical) bar -->
+<!ENTITY bsol             "&#x0005C;" ><!--/backslash =reverse solidus -->
+<!ENTITY cent             "&#x000A2;" ><!--=cent sign -->
+<!ENTITY colon            "&#x0003A;" ><!--/colon P: -->
+<!ENTITY comma            "&#x0002C;" ><!--P: =comma -->
+<!ENTITY commat           "&#x00040;" ><!--=commercial at -->
+<!ENTITY copy             "&#x000A9;" ><!--=copyright sign -->
+<!ENTITY curren           "&#x000A4;" ><!--=general currency sign -->
+<!ENTITY darr             "&#x02193;" ><!--/downarrow A: =downward arrow -->
+<!ENTITY deg              "&#x000B0;" ><!--=degree sign -->
+<!ENTITY divide           "&#x000F7;" ><!--/div B: =divide sign -->
+<!ENTITY dollar           "&#x00024;" ><!--=dollar sign -->
+<!ENTITY equals           "&#x0003D;" ><!--=equals sign R: -->
+<!ENTITY excl             "&#x00021;" ><!--=exclamation mark -->
+<!ENTITY frac12           "&#x000BD;" ><!--=fraction one-half -->
+<!ENTITY frac14           "&#x000BC;" ><!--=fraction one-quarter -->
+<!ENTITY frac18           "&#x0215B;" ><!--=fraction one-eighth -->
+<!ENTITY frac34           "&#x000BE;" ><!--=fraction three-quarters -->
+<!ENTITY frac38           "&#x0215C;" ><!--=fraction three-eighths -->
+<!ENTITY frac58           "&#x0215D;" ><!--=fraction five-eighths -->
+<!ENTITY frac78           "&#x0215E;" ><!--=fraction seven-eighths -->
+<!ENTITY gt               "&#x0003E;" ><!--=greater-than sign R: -->
+<!ENTITY half             "&#x000BD;" ><!--=fraction one-half -->
+<!ENTITY horbar           "&#x02015;" ><!--=horizontal bar -->
+<!ENTITY hyphen           "&#x02010;" ><!--=hyphen -->
+<!ENTITY iexcl            "&#x000A1;" ><!--=inverted exclamation mark -->
+<!ENTITY iquest           "&#x000BF;" ><!--=inverted question mark -->
+<!ENTITY laquo            "&#x000AB;" ><!--=angle quotation mark, left -->
+<!ENTITY larr             "&#x02190;" ><!--/leftarrow /gets A: =leftward arrow -->
+<!ENTITY lcub             "&#x0007B;" ><!--/lbrace O: =left curly bracket -->
+<!ENTITY ldquo            "&#x0201C;" ><!--=double quotation mark, left -->
+<!ENTITY lowbar           "&#x0005F;" ><!--=low line -->
+<!ENTITY lpar             "&#x00028;" ><!--O: =left parenthesis -->
+<!ENTITY lsqb             "&#x0005B;" ><!--/lbrack O: =left square bracket -->
+<!ENTITY lsquo            "&#x02018;" ><!--=single quotation mark, left -->
+<!ENTITY lt               "&#38;#60;" ><!--=less-than sign R: -->
+<!ENTITY micro            "&#x000B5;" ><!--=micro sign -->
+<!ENTITY middot           "&#x000B7;" ><!--/centerdot B: =middle dot -->
+<!ENTITY nbsp             "&#x000A0;" ><!--=no break (required) space -->
+<!ENTITY not              "&#x000AC;" ><!--/neg /lnot =not sign -->
+<!ENTITY num              "&#x00023;" ><!--=number sign -->
+<!ENTITY ohm              "&#x02126;" ><!--=ohm sign -->
+<!ENTITY ordf             "&#x000AA;" ><!--=ordinal indicator, feminine -->
+<!ENTITY ordm             "&#x000BA;" ><!--=ordinal indicator, masculine -->
+<!ENTITY para             "&#x000B6;" ><!--=pilcrow (paragraph sign) -->
+<!ENTITY percnt           "&#x00025;" ><!--=percent sign -->
+<!ENTITY period           "&#x0002E;" ><!--=full stop, period -->
+<!ENTITY plus             "&#x0002B;" ><!--=plus sign B: -->
+<!ENTITY plusmn           "&#x000B1;" ><!--/pm B: =plus-or-minus sign -->
+<!ENTITY pound            "&#x000A3;" ><!--=pound sign -->
+<!ENTITY quest            "&#x0003F;" ><!--=question mark -->
+<!ENTITY quot             "&#x00022;" ><!--=quotation mark -->
+<!ENTITY raquo            "&#x000BB;" ><!--=angle quotation mark, right -->
+<!ENTITY rarr             "&#x02192;" ><!--/rightarrow /to A: =rightward arrow -->
+<!ENTITY rcub             "&#x0007D;" ><!--/rbrace C: =right curly bracket -->
+<!ENTITY rdquo            "&#x0201D;" ><!--=double quotation mark, right -->
+<!ENTITY reg              "&#x000AE;" ><!--/circledR =registered sign -->
+<!ENTITY rpar             "&#x00029;" ><!--C: =right parenthesis -->
+<!ENTITY rsqb             "&#x0005D;" ><!--/rbrack C: =right square bracket -->
+<!ENTITY rsquo            "&#x02019;" ><!--=single quotation mark, right -->
+<!ENTITY sect             "&#x000A7;" ><!--=section sign -->
+<!ENTITY semi             "&#x0003B;" ><!--=semicolon P: -->
+<!ENTITY shy              "&#x000AD;" ><!--=soft hyphen -->
+<!ENTITY sol              "&#x0002F;" ><!--=solidus -->
+<!ENTITY sung             "&#x0266A;" ><!--=music note (sung text sign) -->
+<!ENTITY sup1             "&#x000B9;" ><!--=superscript one -->
+<!ENTITY sup2             "&#x000B2;" ><!--=superscript two -->
+<!ENTITY sup3             "&#x000B3;" ><!--=superscript three -->
+<!ENTITY times            "&#x000D7;" ><!--/times B: =multiply sign -->
+<!ENTITY trade            "&#x02122;" ><!--=trade mark sign -->
+<!ENTITY uarr             "&#x02191;" ><!--/uparrow A: =upward arrow -->
+<!ENTITY verbar           "&#x0007C;" ><!--/vert =vertical bar -->
+<!ENTITY yen              "&#x000A5;" ><!--/yen =yen sign -->

--- a/src/main/resources/dtd/archiving/1.2/iso8879/isopub.ent
+++ b/src/main/resources/dtd/archiving/1.2/iso8879/isopub.ent
@@ -1,0 +1,105 @@
+
+<!--
+     File isopub.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY blank            "&#x02423;" ><!--=significant blank symbol -->
+<!ENTITY blk12            "&#x02592;" ><!--=50% shaded block -->
+<!ENTITY blk14            "&#x02591;" ><!--=25% shaded block -->
+<!ENTITY blk34            "&#x02593;" ><!--=75% shaded block -->
+<!ENTITY block            "&#x02588;" ><!--=full block -->
+<!ENTITY bull             "&#x02022;" ><!--/bullet B: =round bullet, filled -->
+<!ENTITY caret            "&#x02041;" ><!--=caret (insertion mark) -->
+<!ENTITY check            "&#x02713;" ><!--/checkmark =tick, check mark -->
+<!ENTITY cir              "&#x025CB;" ><!--/circ B: =circle, open -->
+<!ENTITY clubs            "&#x02663;" ><!--/clubsuit =club suit symbol  -->
+<!ENTITY copysr           "&#x02117;" ><!--=sound recording copyright sign -->
+<!ENTITY cross            "&#x02717;" ><!--=ballot cross -->
+<!ENTITY Dagger           "&#x02021;" ><!--/ddagger B: =double dagger -->
+<!ENTITY dagger           "&#x02020;" ><!--/dagger B: =dagger -->
+<!ENTITY dash             "&#x02010;" ><!--=hyphen (true graphic) -->
+<!ENTITY diams            "&#x02666;" ><!--/diamondsuit =diamond suit symbol  -->
+<!ENTITY dlcrop           "&#x0230D;" ><!--downward left crop mark  -->
+<!ENTITY drcrop           "&#x0230C;" ><!--downward right crop mark  -->
+<!ENTITY dtri             "&#x025BF;" ><!--/triangledown =down triangle, open -->
+<!ENTITY dtrif            "&#x025BE;" ><!--/blacktriangledown =dn tri, filled -->
+<!ENTITY emsp             "&#x02003;" ><!--=em space -->
+<!ENTITY emsp13           "&#x02004;" ><!--=1/3-em space -->
+<!ENTITY emsp14           "&#x02005;" ><!--=1/4-em space -->
+<!ENTITY ensp             "&#x02002;" ><!--=en space (1/2-em) -->
+<!ENTITY female           "&#x02640;" ><!--=female symbol -->
+<!ENTITY ffilig           "&#x0FB03;" ><!--small ffi ligature -->
+<!ENTITY fflig            "&#x0FB00;" ><!--small ff ligature -->
+<!ENTITY ffllig           "&#x0FB04;" ><!--small ffl ligature -->
+<!ENTITY filig            "&#x0FB01;" ><!--small fi ligature -->
+<!ENTITY flat             "&#x0266D;" ><!--/flat =musical flat -->
+<!ENTITY fllig            "&#x0FB02;" ><!--small fl ligature -->
+<!ENTITY frac13           "&#x02153;" ><!--=fraction one-third -->
+<!ENTITY frac15           "&#x02155;" ><!--=fraction one-fifth -->
+<!ENTITY frac16           "&#x02159;" ><!--=fraction one-sixth -->
+<!ENTITY frac23           "&#x02154;" ><!--=fraction two-thirds -->
+<!ENTITY frac25           "&#x02156;" ><!--=fraction two-fifths -->
+<!ENTITY frac35           "&#x02157;" ><!--=fraction three-fifths -->
+<!ENTITY frac45           "&#x02158;" ><!--=fraction four-fifths -->
+<!ENTITY frac56           "&#x0215A;" ><!--=fraction five-sixths -->
+<!ENTITY hairsp           "&#x0200A;" ><!--=hair space -->
+<!ENTITY hearts           "&#x02665;" ><!--/heartsuit =heart suit symbol -->
+<!ENTITY hellip           "&#x02026;" ><!--=ellipsis (horizontal) -->
+<!ENTITY hybull           "&#x02043;" ><!--rectangle, filled (hyphen bullet) -->
+<!ENTITY incare           "&#x02105;" ><!--=in-care-of symbol -->
+<!ENTITY ldquor           "&#x0201E;" ><!--=rising dbl quote, left (low) -->
+<!ENTITY lhblk            "&#x02584;" ><!--=lower half block -->
+<!ENTITY loz              "&#x025CA;" ><!--/lozenge - lozenge or total mark -->
+<!ENTITY lozf             "&#x029EB;" ><!--/blacklozenge - lozenge, filled -->
+<!ENTITY lsquor           "&#x0201A;" ><!--=rising single quote, left (low) -->
+<!ENTITY ltri             "&#x025C3;" ><!--/triangleleft B: l triangle, open -->
+<!ENTITY ltrif            "&#x025C2;" ><!--/blacktriangleleft R: =l tri, filled -->
+<!ENTITY male             "&#x02642;" ><!--=male symbol -->
+<!ENTITY malt             "&#x02720;" ><!--/maltese =maltese cross -->
+<!ENTITY marker           "&#x025AE;" ><!--=histogram marker -->
+<!ENTITY mdash            "&#x02014;" ><!--=em dash  -->
+<!ENTITY mldr             "&#x02026;" ><!--em leader -->
+<!ENTITY natur            "&#x0266E;" ><!--/natural - music natural -->
+<!ENTITY ndash            "&#x02013;" ><!--=en dash -->
+<!ENTITY nldr             "&#x02025;" ><!--=double baseline dot (en leader) -->
+<!ENTITY numsp            "&#x02007;" ><!--=digit space (width of a number) -->
+<!ENTITY phone            "&#x0260E;" ><!--=telephone symbol  -->
+<!ENTITY puncsp           "&#x02008;" ><!--=punctuation space (width of comma) -->
+<!ENTITY rdquor           "&#x0201D;" ><!--rising dbl quote, right (high) -->
+<!ENTITY rect             "&#x025AD;" ><!--=rectangle, open -->
+<!ENTITY rsquor           "&#x02019;" ><!--rising single quote, right (high) -->
+<!ENTITY rtri             "&#x025B9;" ><!--/triangleright B: r triangle, open -->
+<!ENTITY rtrif            "&#x025B8;" ><!--/blacktriangleright R: =r tri, filled -->
+<!ENTITY rx               "&#x0211E;" ><!--pharmaceutical prescription (Rx) -->
+<!ENTITY sext             "&#x02736;" ><!--sextile (6-pointed star) -->
+<!ENTITY sharp            "&#x0266F;" ><!--/sharp =musical sharp -->
+<!ENTITY spades           "&#x02660;" ><!--/spadesuit =spades suit symbol  -->
+<!ENTITY squ              "&#x025A1;" ><!--=square, open -->
+<!ENTITY squf             "&#x025AA;" ><!--/blacksquare =sq bullet, filled -->
+<!ENTITY star             "&#x02606;" ><!--=star, open -->
+<!ENTITY starf            "&#x02605;" ><!--/bigstar - star, filled  -->
+<!ENTITY target           "&#x02316;" ><!--register mark or target -->
+<!ENTITY telrec           "&#x02315;" ><!--=telephone recorder symbol -->
+<!ENTITY thinsp           "&#x02009;" ><!--=thin space (1/6-em) -->
+<!ENTITY uhblk            "&#x02580;" ><!--=upper half block -->
+<!ENTITY ulcrop           "&#x0230F;" ><!--upward left crop mark  -->
+<!ENTITY urcrop           "&#x0230E;" ><!--upward right crop mark  -->
+<!ENTITY utri             "&#x025B5;" ><!--/triangle =up triangle, open -->
+<!ENTITY utrif            "&#x025B4;" ><!--/blacktriangle =up tri, filled -->
+<!ENTITY vellip           "&#x022EE;" ><!--vertical ellipsis -->

--- a/src/main/resources/dtd/archiving/1.2/iso9573-13/isoamsa.ent
+++ b/src/main/resources/dtd/archiving/1.2/iso9573-13/isoamsa.ent
@@ -1,0 +1,167 @@
+
+<!--
+     File isoamsa.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY angzarr          "&#x0237C;" ><!--angle with down zig-zag arrow -->
+<!ENTITY cirmid           "&#x02AEF;" ><!--circle, mid below -->
+<!ENTITY cudarrl          "&#x02938;" ><!--left, curved, down arrow -->
+<!ENTITY cudarrr          "&#x02935;" ><!--right, curved, down arrow -->
+<!ENTITY cularr           "&#x021B6;" ><!--/curvearrowleft A: left curved arrow -->
+<!ENTITY cularrp          "&#x0293D;" ><!--curved left arrow with plus -->
+<!ENTITY curarr           "&#x021B7;" ><!--/curvearrowright A: rt curved arrow -->
+<!ENTITY curarrm          "&#x0293C;" ><!--curved right arrow with minus -->
+<!ENTITY Darr             "&#x021A1;" ><!--down two-headed arrow -->
+<!ENTITY dArr             "&#x021D3;" ><!--/Downarrow A: down dbl arrow -->
+<!ENTITY ddarr            "&#x021CA;" ><!--/downdownarrows A: two down arrows -->
+<!ENTITY DDotrahd         "&#x02911;" ><!--right arrow with dotted stem -->
+<!ENTITY dfisht           "&#x0297F;" ><!--down fish tail -->
+<!ENTITY dHar             "&#x02965;" ><!--down harpoon-left, down harpoon-right -->
+<!ENTITY dharl            "&#x021C3;" ><!--/downharpoonleft A: dn harpoon-left -->
+<!ENTITY dharr            "&#x021C2;" ><!--/downharpoonright A: down harpoon-rt -->
+<!ENTITY duarr            "&#x021F5;" ><!--down arrow, up arrow -->
+<!ENTITY duhar            "&#x0296F;" ><!--down harp, up harp -->
+<!ENTITY dzigrarr         "&#x027FF;" ><!--right long zig-zag arrow -->
+<!ENTITY erarr            "&#x02971;" ><!--equal, right arrow below -->
+<!ENTITY hArr             "&#x021D4;" ><!--/Leftrightarrow A: l&r dbl arrow -->
+<!ENTITY harr             "&#x02194;" ><!--/leftrightarrow A: l&r arrow -->
+<!ENTITY harrcir          "&#x02948;" ><!--left and right arrow with a circle -->
+<!ENTITY harrw            "&#x021AD;" ><!--/leftrightsquigarrow A: l&r arr-wavy -->
+<!ENTITY hoarr            "&#x021FF;" ><!--horizontal open arrow -->
+<!ENTITY imof             "&#x022B7;" ><!--image of -->
+<!ENTITY lAarr            "&#x021DA;" ><!--/Lleftarrow A: left triple arrow -->
+<!ENTITY Larr             "&#x0219E;" ><!--/twoheadleftarrow A: -->
+<!ENTITY larrbfs          "&#x0291F;" ><!--left arrow-bar, filled square -->
+<!ENTITY larrfs           "&#x0291D;" ><!--left arrow, filled square -->
+<!ENTITY larrhk           "&#x021A9;" ><!--/hookleftarrow A: left arrow-hooked -->
+<!ENTITY larrlp           "&#x021AB;" ><!--/looparrowleft A: left arrow-looped -->
+<!ENTITY larrpl           "&#x02939;" ><!--left arrow, plus -->
+<!ENTITY larrsim          "&#x02973;" ><!--left arrow, similar -->
+<!ENTITY larrtl           "&#x021A2;" ><!--/leftarrowtail A: left arrow-tailed -->
+<!ENTITY lAtail           "&#x0291B;" ><!--left double arrow-tail -->
+<!ENTITY latail           "&#x02919;" ><!--left arrow-tail -->
+<!ENTITY lBarr            "&#x0290E;" ><!--left doubly broken arrow -->
+<!ENTITY lbarr            "&#x0290C;" ><!--left broken arrow -->
+<!ENTITY ldca             "&#x02936;" ><!--left down curved arrow -->
+<!ENTITY ldrdhar          "&#x02967;" ><!--left harpoon-down over right harpoon-down -->
+<!ENTITY ldrushar         "&#x0294B;" ><!--left-down-right-up harpoon -->
+<!ENTITY ldsh             "&#x021B2;" ><!--left down angled arrow -->
+<!ENTITY lfisht           "&#x0297C;" ><!--left fish tail -->
+<!ENTITY lHar             "&#x02962;" ><!--left harpoon-up over left harpoon-down -->
+<!ENTITY lhard            "&#x021BD;" ><!--/leftharpoondown A: l harpoon-down -->
+<!ENTITY lharu            "&#x021BC;" ><!--/leftharpoonup A: left harpoon-up -->
+<!ENTITY lharul           "&#x0296A;" ><!--left harpoon-up over long dash -->
+<!ENTITY llarr            "&#x021C7;" ><!--/leftleftarrows A: two left arrows -->
+<!ENTITY llhard           "&#x0296B;" ><!--left harpoon-down below long dash -->
+<!ENTITY loarr            "&#x021FD;" ><!--left open arrow -->
+<!ENTITY lrarr            "&#x021C6;" ><!--/leftrightarrows A: l arr over r arr -->
+<!ENTITY lrhar            "&#x021CB;" ><!--/leftrightharpoons A: l harp over r -->
+<!ENTITY lrhard           "&#x0296D;" ><!--right harpoon-down below long dash -->
+<!ENTITY lsh              "&#x021B0;" ><!--/Lsh A: -->
+<!ENTITY lurdshar         "&#x0294A;" ><!--left-up-right-down harpoon -->
+<!ENTITY luruhar          "&#x02966;" ><!--left harpoon-up over right harpoon-up -->
+<!ENTITY Map              "&#x02905;" ><!--twoheaded mapsto -->
+<!ENTITY map              "&#x021A6;" ><!--/mapsto A: -->
+<!ENTITY midcir           "&#x02AF0;" ><!--mid, circle below  -->
+<!ENTITY mumap            "&#x022B8;" ><!--/multimap A: -->
+<!ENTITY nearhk           "&#x02924;" ><!--NE arrow-hooked -->
+<!ENTITY neArr            "&#x021D7;" ><!--NE pointing dbl arrow -->
+<!ENTITY nearr            "&#x02197;" ><!--/nearrow A: NE pointing arrow -->
+<!ENTITY nesear           "&#x02928;" ><!--/toea A: NE & SE arrows -->
+<!ENTITY nhArr            "&#x021CE;" ><!--/nLeftrightarrow A: not l&r dbl arr -->
+<!ENTITY nharr            "&#x021AE;" ><!--/nleftrightarrow A: not l&r arrow -->
+<!ENTITY nlArr            "&#x021CD;" ><!--/nLeftarrow A: not implied by -->
+<!ENTITY nlarr            "&#x0219A;" ><!--/nleftarrow A: not left arrow -->
+<!ENTITY nrArr            "&#x021CF;" ><!--/nRightarrow A: not implies -->
+<!ENTITY nrarr            "&#x0219B;" ><!--/nrightarrow A: not right arrow -->
+<!ENTITY nrarrc           "&#x02933;&#x00338;" ><!--not right arrow-curved -->
+<!ENTITY nrarrw           "&#x0219D;&#x00338;" ><!--not right arrow-wavy -->
+<!ENTITY nvHarr           "&#x02904;" ><!--not, vert, left and right double arrow  -->
+<!ENTITY nvlArr           "&#x02902;" ><!--not, vert, left double arrow -->
+<!ENTITY nvrArr           "&#x02903;" ><!--not, vert, right double arrow -->
+<!ENTITY nwarhk           "&#x02923;" ><!--NW arrow-hooked -->
+<!ENTITY nwArr            "&#x021D6;" ><!--NW pointing dbl arrow -->
+<!ENTITY nwarr            "&#x02196;" ><!--/nwarrow A: NW pointing arrow -->
+<!ENTITY nwnear           "&#x02927;" ><!--NW & NE arrows -->
+<!ENTITY olarr            "&#x021BA;" ><!--/circlearrowleft A: l arr in circle -->
+<!ENTITY orarr            "&#x021BB;" ><!--/circlearrowright A: r arr in circle -->
+<!ENTITY origof           "&#x022B6;" ><!--original of -->
+<!ENTITY rAarr            "&#x021DB;" ><!--/Rrightarrow A: right triple arrow -->
+<!ENTITY Rarr             "&#x021A0;" ><!--/twoheadrightarrow A: -->
+<!ENTITY rarrap           "&#x02975;" ><!--approximate, right arrow above -->
+<!ENTITY rarrbfs          "&#x02920;" ><!--right arrow-bar, filled square -->
+<!ENTITY rarrc            "&#x02933;" ><!--right arrow-curved -->
+<!ENTITY rarrfs           "&#x0291E;" ><!--right arrow, filled square -->
+<!ENTITY rarrhk           "&#x021AA;" ><!--/hookrightarrow A: rt arrow-hooked -->
+<!ENTITY rarrlp           "&#x021AC;" ><!--/looparrowright A: rt arrow-looped -->
+<!ENTITY rarrpl           "&#x02945;" ><!--right arrow, plus -->
+<!ENTITY rarrsim          "&#x02974;" ><!--right arrow, similar -->
+<!ENTITY Rarrtl           "&#x02916;" ><!--right two-headed arrow with tail -->
+<!ENTITY rarrtl           "&#x021A3;" ><!--/rightarrowtail A: rt arrow-tailed -->
+<!ENTITY rarrw            "&#x0219D;" ><!--/rightsquigarrow A: rt arrow-wavy -->
+<!ENTITY rAtail           "&#x0291C;" ><!--right double arrow-tail -->
+<!ENTITY ratail           "&#x0291A;" ><!--right arrow-tail -->
+<!ENTITY RBarr            "&#x02910;" ><!--/drbkarow A: twoheaded right broken arrow -->
+<!ENTITY rBarr            "&#x0290F;" ><!--/dbkarow A: right doubly broken arrow -->
+<!ENTITY rbarr            "&#x0290D;" ><!--/bkarow A: right broken arrow -->
+<!ENTITY rdca             "&#x02937;" ><!--right down curved arrow -->
+<!ENTITY rdldhar          "&#x02969;" ><!--right harpoon-down over left harpoon-down -->
+<!ENTITY rdsh             "&#x021B3;" ><!--right down angled arrow -->
+<!ENTITY rfisht           "&#x0297D;" ><!--right fish tail -->
+<!ENTITY rHar             "&#x02964;" ><!--right harpoon-up over right harpoon-down -->
+<!ENTITY rhard            "&#x021C1;" ><!--/rightharpoondown A: rt harpoon-down -->
+<!ENTITY rharu            "&#x021C0;" ><!--/rightharpoonup A: rt harpoon-up -->
+<!ENTITY rharul           "&#x0296C;" ><!--right harpoon-up over long dash -->
+<!ENTITY rlarr            "&#x021C4;" ><!--/rightleftarrows A: r arr over l arr -->
+<!ENTITY rlhar            "&#x021CC;" ><!--/rightleftharpoons A: r harp over l -->
+<!ENTITY roarr            "&#x021FE;" ><!--right open arrow -->
+<!ENTITY rrarr            "&#x021C9;" ><!--/rightrightarrows A: two rt arrows -->
+<!ENTITY rsh              "&#x021B1;" ><!--/Rsh A: -->
+<!ENTITY ruluhar          "&#x02968;" ><!--right harpoon-up over left harpoon-up -->
+<!ENTITY searhk           "&#x02925;" ><!--/hksearow A: SE arrow-hooken -->
+<!ENTITY seArr            "&#x021D8;" ><!--SE pointing dbl arrow -->
+<!ENTITY searr            "&#x02198;" ><!--/searrow A: SE pointing arrow -->
+<!ENTITY seswar           "&#x02929;" ><!--/tosa A: SE & SW arrows -->
+<!ENTITY simrarr          "&#x02972;" ><!--similar, right arrow below -->
+<!ENTITY slarr            "&#x02190;" ><!--short left arrow -->
+<!ENTITY srarr            "&#x02192;" ><!--short right arrow -->
+<!ENTITY swarhk           "&#x02926;" ><!--/hkswarow A: SW arrow-hooked -->
+<!ENTITY swArr            "&#x021D9;" ><!--SW pointing dbl arrow -->
+<!ENTITY swarr            "&#x02199;" ><!--/swarrow A: SW pointing arrow -->
+<!ENTITY swnwar           "&#x0292A;" ><!--SW & NW arrows -->
+<!ENTITY Uarr             "&#x0219F;" ><!--up two-headed arrow -->
+<!ENTITY uArr             "&#x021D1;" ><!--/Uparrow A: up dbl arrow -->
+<!ENTITY Uarrocir         "&#x02949;" ><!--up two-headed arrow above circle -->
+<!ENTITY udarr            "&#x021C5;" ><!--up arrow, down arrow -->
+<!ENTITY udhar            "&#x0296E;" ><!--up harp, down harp -->
+<!ENTITY ufisht           "&#x0297E;" ><!--up fish tail -->
+<!ENTITY uHar             "&#x02963;" ><!--up harpoon-left, up harpoon-right -->
+<!ENTITY uharl            "&#x021BF;" ><!--/upharpoonleft A: up harpoon-left -->
+<!ENTITY uharr            "&#x021BE;" ><!--/upharpoonright /restriction A: up harp-r -->
+<!ENTITY uuarr            "&#x021C8;" ><!--/upuparrows A: two up arrows -->
+<!ENTITY vArr             "&#x021D5;" ><!--/Updownarrow A: up&down dbl arrow -->
+<!ENTITY varr             "&#x02195;" ><!--/updownarrow A: up&down arrow -->
+<!ENTITY xhArr            "&#x027FA;" ><!--/Longleftrightarrow A: long l&r dbl arr -->
+<!ENTITY xharr            "&#x027F7;" ><!--/longleftrightarrow A: long l&r arr -->
+<!ENTITY xlArr            "&#x027F8;" ><!--/Longleftarrow A: long l dbl arrow -->
+<!ENTITY xlarr            "&#x027F5;" ><!--/longleftarrow A: long left arrow -->
+<!ENTITY xmap             "&#x027FC;" ><!--/longmapsto A: -->
+<!ENTITY xrArr            "&#x027F9;" ><!--/Longrightarrow A: long rt dbl arr -->
+<!ENTITY xrarr            "&#x027F6;" ><!--/longrightarrow A: long right arrow -->
+<!ENTITY zigrarr          "&#x021DD;" ><!--right zig-zag arrow -->

--- a/src/main/resources/dtd/archiving/1.2/iso9573-13/isoamsb.ent
+++ b/src/main/resources/dtd/archiving/1.2/iso9573-13/isoamsb.ent
@@ -1,0 +1,143 @@
+
+<!--
+     File isoamsb.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     References to the VARIANT SELECTOR 1 character (&#x0FE00;)
+     should match the uses listed in Unicode Technical Report 25.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY ac               "&#x0223E;" ><!--most positive -->
+<!ENTITY acE              "&#x0223E;&#x00333;" ><!--most positive, two lines below -->
+<!ENTITY amalg            "&#x02A3F;" ><!--/amalg B: amalgamation or coproduct -->
+<!ENTITY barvee           "&#x022BD;" ><!--bar, vee -->
+<!ENTITY Barwed           "&#x02306;" ><!--/doublebarwedge B: log and, dbl bar above -->
+<!ENTITY barwed           "&#x02305;" ><!--/barwedge B: logical and, bar above -->
+<!ENTITY bsolb            "&#x029C5;" ><!--reverse solidus in square -->
+<!ENTITY Cap              "&#x022D2;" ><!--/Cap /doublecap B: dbl intersection -->
+<!ENTITY capand           "&#x02A44;" ><!--intersection, and -->
+<!ENTITY capbrcup         "&#x02A49;" ><!--intersection, bar, union -->
+<!ENTITY capcap           "&#x02A4B;" ><!--intersection, intersection, joined -->
+<!ENTITY capcup           "&#x02A47;" ><!--intersection above union -->
+<!ENTITY capdot           "&#x02A40;" ><!--intersection, with dot -->
+<!ENTITY caps             "&#x02229;&#x0FE00;" ><!--intersection, serifs -->
+<!ENTITY ccaps            "&#x02A4D;" ><!--closed intersection, serifs -->
+<!ENTITY ccups            "&#x02A4C;" ><!--closed union, serifs -->
+<!ENTITY ccupssm          "&#x02A50;" ><!--closed union, serifs, smash product -->
+<!ENTITY coprod           "&#x02210;" ><!--/coprod L: coproduct operator -->
+<!ENTITY Cup              "&#x022D3;" ><!--/Cup /doublecup B: dbl union -->
+<!ENTITY cupbrcap         "&#x02A48;" ><!--union, bar, intersection -->
+<!ENTITY cupcap           "&#x02A46;" ><!--union above intersection -->
+<!ENTITY cupcup           "&#x02A4A;" ><!--union, union, joined -->
+<!ENTITY cupdot           "&#x0228D;" ><!--union, with dot -->
+<!ENTITY cupor            "&#x02A45;" ><!--union, or -->
+<!ENTITY cups             "&#x0222A;&#x0FE00;" ><!--union, serifs -->
+<!ENTITY cuvee            "&#x022CE;" ><!--/curlyvee B: curly logical or -->
+<!ENTITY cuwed            "&#x022CF;" ><!--/curlywedge B: curly logical and -->
+<!ENTITY Dagger           "&#x02021;" ><!--/ddagger B: double dagger relation -->
+<!ENTITY dagger           "&#x02020;" ><!--/dagger B: dagger relation -->
+<!ENTITY diam             "&#x022C4;" ><!--/diamond B: open diamond -->
+<!ENTITY divonx           "&#x022C7;" ><!--/divideontimes B: division on times -->
+<!ENTITY eplus            "&#x02A71;" ><!--equal, plus -->
+<!ENTITY hercon           "&#x022B9;" ><!--hermitian conjugate matrix -->
+<!ENTITY intcal           "&#x022BA;" ><!--/intercal B: intercal -->
+<!ENTITY iprod            "&#x02A3C;" ><!--/intprod -->
+<!ENTITY loplus           "&#x02A2D;" ><!--plus sign in left half circle -->
+<!ENTITY lotimes          "&#x02A34;" ><!--multiply sign in left half circle  -->
+<!ENTITY lthree           "&#x022CB;" ><!--/leftthreetimes B: -->
+<!ENTITY ltimes           "&#x022C9;" ><!--/ltimes B: times sign, left closed -->
+<!ENTITY midast           "&#x0002A;" ><!--/ast B: asterisk -->
+<!ENTITY minusb           "&#x0229F;" ><!--/boxminus B: minus sign in box -->
+<!ENTITY minusd           "&#x02238;" ><!--/dotminus B: minus sign, dot above -->
+<!ENTITY minusdu          "&#x02A2A;" ><!--minus sign, dot below -->
+<!ENTITY ncap             "&#x02A43;" ><!--bar, intersection -->
+<!ENTITY ncup             "&#x02A42;" ><!--bar, union -->
+<!ENTITY oast             "&#x0229B;" ><!--/circledast B: asterisk in circle -->
+<!ENTITY ocir             "&#x0229A;" ><!--/circledcirc B: small circle in circle -->
+<!ENTITY odash            "&#x0229D;" ><!--/circleddash B: hyphen in circle -->
+<!ENTITY odiv             "&#x02A38;" ><!--divide in circle -->
+<!ENTITY odot             "&#x02299;" ><!--/odot B: middle dot in circle -->
+<!ENTITY odsold           "&#x029BC;" ><!--dot, solidus, dot in circle -->
+<!ENTITY ofcir            "&#x029BF;" ><!--filled circle in circle -->
+<!ENTITY ogt              "&#x029C1;" ><!--greater-than in circle -->
+<!ENTITY ohbar            "&#x029B5;" ><!--circle with horizontal bar -->
+<!ENTITY olcir            "&#x029BE;" ><!--large circle in circle -->
+<!ENTITY olt              "&#x029C0;" ><!--less-than in circle -->
+<!ENTITY omid             "&#x029B6;" ><!--vertical bar in circle -->
+<!ENTITY ominus           "&#x02296;" ><!--/ominus B: minus sign in circle -->
+<!ENTITY opar             "&#x029B7;" ><!--parallel in circle -->
+<!ENTITY operp            "&#x029B9;" ><!--perpendicular in circle -->
+<!ENTITY oplus            "&#x02295;" ><!--/oplus B: plus sign in circle -->
+<!ENTITY osol             "&#x02298;" ><!--/oslash B: solidus in circle -->
+<!ENTITY Otimes           "&#x02A37;" ><!--multiply sign in double circle -->
+<!ENTITY otimes           "&#x02297;" ><!--/otimes B: multiply sign in circle -->
+<!ENTITY otimesas         "&#x02A36;" ><!--multiply sign in circle, circumflex accent -->
+<!ENTITY ovbar            "&#x0233D;" ><!--circle with vertical bar -->
+<!ENTITY plusacir         "&#x02A23;" ><!--plus, circumflex accent above -->
+<!ENTITY plusb            "&#x0229E;" ><!--/boxplus B: plus sign in box -->
+<!ENTITY pluscir          "&#x02A22;" ><!--plus, small circle above -->
+<!ENTITY plusdo           "&#x02214;" ><!--/dotplus B: plus sign, dot above -->
+<!ENTITY plusdu           "&#x02A25;" ><!--plus sign, dot below -->
+<!ENTITY pluse            "&#x02A72;" ><!--plus, equals -->
+<!ENTITY plussim          "&#x02A26;" ><!--plus, similar below -->
+<!ENTITY plustwo          "&#x02A27;" ><!--plus, two; Nim-addition -->
+<!ENTITY prod             "&#x0220F;" ><!--/prod L: product operator -->
+<!ENTITY race             "&#x029DA;" ><!--reverse most positive, line below -->
+<!ENTITY roplus           "&#x02A2E;" ><!--plus sign in right half circle -->
+<!ENTITY rotimes          "&#x02A35;" ><!--multiply sign in right half circle -->
+<!ENTITY rthree           "&#x022CC;" ><!--/rightthreetimes B: -->
+<!ENTITY rtimes           "&#x022CA;" ><!--/rtimes B: times sign, right closed -->
+<!ENTITY sdot             "&#x022C5;" ><!--/cdot B: small middle dot -->
+<!ENTITY sdotb            "&#x022A1;" ><!--/dotsquare /boxdot B: small dot in box -->
+<!ENTITY setmn            "&#x02216;" ><!--/setminus B: reverse solidus -->
+<!ENTITY simplus          "&#x02A24;" ><!--plus, similar above -->
+<!ENTITY smashp           "&#x02A33;" ><!--smash product -->
+<!ENTITY solb             "&#x029C4;" ><!--solidus in square -->
+<!ENTITY sqcap            "&#x02293;" ><!--/sqcap B: square intersection -->
+<!ENTITY sqcaps           "&#x02293;&#x0FE00;" ><!--square intersection, serifs -->
+<!ENTITY sqcup            "&#x02294;" ><!--/sqcup B: square union -->
+<!ENTITY sqcups           "&#x02294;&#x0FE00;" ><!--square union, serifs -->
+<!ENTITY ssetmn           "&#x02216;" ><!--/smallsetminus B: sm reverse solidus -->
+<!ENTITY sstarf           "&#x022C6;" ><!--/star B: small star, filled -->
+<!ENTITY subdot           "&#x02ABD;" ><!--subset, with dot -->
+<!ENTITY sum              "&#x02211;" ><!--/sum L: summation operator -->
+<!ENTITY supdot           "&#x02ABE;" ><!--superset, with dot -->
+<!ENTITY timesb           "&#x022A0;" ><!--/boxtimes B: multiply sign in box -->
+<!ENTITY timesbar         "&#x02A31;" ><!--multiply sign, bar below -->
+<!ENTITY timesd           "&#x02A30;" ><!--times, dot -->
+<!ENTITY tridot           "&#x025EC;" ><!--dot in triangle -->
+<!ENTITY triminus         "&#x02A3A;" ><!--minus in triangle -->
+<!ENTITY triplus          "&#x02A39;" ><!--plus in triangle -->
+<!ENTITY trisb            "&#x029CD;" ><!--triangle, serifs at bottom -->
+<!ENTITY tritime          "&#x02A3B;" ><!--multiply in triangle -->
+<!ENTITY uplus            "&#x0228E;" ><!--/uplus B: plus sign in union -->
+<!ENTITY veebar           "&#x022BB;" ><!--/veebar B: logical or, bar below -->
+<!ENTITY wedbar           "&#x02A5F;" ><!--wedge, bar below -->
+<!ENTITY wreath           "&#x02240;" ><!--/wr B: wreath product -->
+<!ENTITY xcap             "&#x022C2;" ><!--/bigcap L: intersection operator -->
+<!ENTITY xcirc            "&#x025EF;" ><!--/bigcirc B: large circle -->
+<!ENTITY xcup             "&#x022C3;" ><!--/bigcup L: union operator -->
+<!ENTITY xdtri            "&#x025BD;" ><!--/bigtriangledown B: big dn tri, open -->
+<!ENTITY xodot            "&#x02A00;" ><!--/bigodot L: circle dot operator -->
+<!ENTITY xoplus           "&#x02A01;" ><!--/bigoplus L: circle plus operator -->
+<!ENTITY xotime           "&#x02A02;" ><!--/bigotimes L: circle times operator -->
+<!ENTITY xsqcup           "&#x02A06;" ><!--/bigsqcup L: square union operator -->
+<!ENTITY xuplus           "&#x02A04;" ><!--/biguplus L: -->
+<!ENTITY xutri            "&#x025B3;" ><!--/bigtriangleup B: big up tri, open -->
+<!ENTITY xvee             "&#x022C1;" ><!--/bigvee L: logical and operator -->
+<!ENTITY xwedge           "&#x022C0;" ><!--/bigwedge L: logical or operator -->

--- a/src/main/resources/dtd/archiving/1.2/iso9573-13/isoamsc.ent
+++ b/src/main/resources/dtd/archiving/1.2/iso9573-13/isoamsc.ent
@@ -1,0 +1,43 @@
+
+<!--
+     File isoamsc.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY dlcorn           "&#x0231E;" ><!--/llcorner O: lower left corner -->
+<!ENTITY drcorn           "&#x0231F;" ><!--/lrcorner C: lower right corner -->
+<!ENTITY gtlPar           "&#x02995;" ><!--dbl left parenthesis, greater -->
+<!ENTITY langd            "&#x02991;" ><!--left angle, dot -->
+<!ENTITY lbrke            "&#x0298B;" ><!--left bracket, equal -->
+<!ENTITY lbrksld          "&#x0298F;" ><!--left bracket, solidus bottom corner -->
+<!ENTITY lbrkslu          "&#x0298D;" ><!--left bracket, solidus top corner -->
+<!ENTITY lceil            "&#x02308;" ><!--/lceil O: left ceiling -->
+<!ENTITY lfloor           "&#x0230A;" ><!--/lfloor O: left floor -->
+<!ENTITY lmoust           "&#x023B0;" ><!--/lmoustache -->
+<!ENTITY lparlt           "&#x02993;" ><!--O: left parenthesis, lt -->
+<!ENTITY ltrPar           "&#x02996;" ><!--dbl right parenthesis, less -->
+<!ENTITY rangd            "&#x02992;" ><!--right angle, dot -->
+<!ENTITY rbrke            "&#x0298C;" ><!--right bracket, equal -->
+<!ENTITY rbrksld          "&#x0298E;" ><!--right bracket, solidus bottom corner -->
+<!ENTITY rbrkslu          "&#x02990;" ><!--right bracket, solidus top corner -->
+<!ENTITY rceil            "&#x02309;" ><!--/rceil C: right ceiling -->
+<!ENTITY rfloor           "&#x0230B;" ><!--/rfloor C: right floor -->
+<!ENTITY rmoust           "&#x023B1;" ><!--/rmoustache -->
+<!ENTITY rpargt           "&#x02994;" ><!--C: right paren, gt -->
+<!ENTITY ulcorn           "&#x0231C;" ><!--/ulcorner O: upper left corner -->
+<!ENTITY urcorn           "&#x0231D;" ><!--/urcorner C: upper right corner -->

--- a/src/main/resources/dtd/archiving/1.2/iso9573-13/isoamsn.ent
+++ b/src/main/resources/dtd/archiving/1.2/iso9573-13/isoamsn.ent
@@ -1,0 +1,114 @@
+
+<!--
+     File isoamsn.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     References to the VARIANT SELECTOR 1 character (&#x0FE00;)
+     should match the uses listed in Unicode Technical Report 25.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY gnap             "&#x02A8A;" ><!--/gnapprox N: greater, not approximate -->
+<!ENTITY gnE              "&#x02269;" ><!--/gneqq N: greater, not dbl equals -->
+<!ENTITY gne              "&#x02A88;" ><!--/gneq N: greater, not equals -->
+<!ENTITY gnsim            "&#x022E7;" ><!--/gnsim N: greater, not similar -->
+<!ENTITY gvnE             "&#x02269;&#x0FE00;" ><!--/gvertneqq N: gt, vert, not dbl eq -->
+<!ENTITY lnap             "&#x02A89;" ><!--/lnapprox N: less, not approximate -->
+<!ENTITY lnE              "&#x02268;" ><!--/lneqq N: less, not double equals -->
+<!ENTITY lne              "&#x02A87;" ><!--/lneq N: less, not equals -->
+<!ENTITY lnsim            "&#x022E6;" ><!--/lnsim N: less, not similar -->
+<!ENTITY lvnE             "&#x02268;&#x0FE00;" ><!--/lvertneqq N: less, vert, not dbl eq -->
+<!ENTITY nap              "&#x02249;" ><!--/napprox N: not approximate -->
+<!ENTITY napE             "&#x02A70;&#x00338;" ><!--not approximately equal or equal to -->
+<!ENTITY napid            "&#x0224B;&#x00338;" ><!--not approximately identical to -->
+<!ENTITY ncong            "&#x02247;" ><!--/ncong N: not congruent with -->
+<!ENTITY ncongdot         "&#x02A6D;&#x00338;" ><!--not congruent, dot -->
+<!ENTITY nequiv           "&#x02262;" ><!--/nequiv N: not identical with -->
+<!ENTITY ngE              "&#x02267;&#x00338;" ><!--/ngeqq N: not greater, dbl equals -->
+<!ENTITY nge              "&#x02271;" ><!--/ngeq N: not greater-than-or-equal -->
+<!ENTITY nges             "&#x02A7E;&#x00338;" ><!--/ngeqslant N: not gt-or-eq, slanted -->
+<!ENTITY nGg              "&#x022D9;&#x00338;" ><!--not triple greater than -->
+<!ENTITY ngsim            "&#x02275;" ><!--not greater, similar -->
+<!ENTITY nGt              "&#x0226B;&#x020D2;" ><!--not, vert, much greater than -->
+<!ENTITY ngt              "&#x0226F;" ><!--/ngtr N: not greater-than -->
+<!ENTITY nGtv             "&#x0226B;&#x00338;" ><!--not much greater than, variant -->
+<!ENTITY nlE              "&#x02266;&#x00338;" ><!--/nleqq N: not less, dbl equals -->
+<!ENTITY nle              "&#x02270;" ><!--/nleq N: not less-than-or-equal -->
+<!ENTITY nles             "&#x02A7D;&#x00338;" ><!--/nleqslant N: not less-or-eq, slant -->
+<!ENTITY nLl              "&#x022D8;&#x00338;" ><!--not triple less than -->
+<!ENTITY nlsim            "&#x02274;" ><!--not less, similar -->
+<!ENTITY nLt              "&#x0226A;&#x020D2;" ><!--not, vert, much less than -->
+<!ENTITY nlt              "&#x0226E;" ><!--/nless N: not less-than -->
+<!ENTITY nltri            "&#x022EA;" ><!--/ntriangleleft N: not left triangle -->
+<!ENTITY nltrie           "&#x022EC;" ><!--/ntrianglelefteq N: not l tri, eq -->
+<!ENTITY nLtv             "&#x0226A;&#x00338;" ><!--not much less than, variant -->
+<!ENTITY nmid             "&#x02224;" ><!--/nmid -->
+<!ENTITY npar             "&#x02226;" ><!--/nparallel N: not parallel -->
+<!ENTITY npr              "&#x02280;" ><!--/nprec N: not precedes -->
+<!ENTITY nprcue           "&#x022E0;" ><!--not curly precedes, eq -->
+<!ENTITY npre             "&#x02AAF;&#x00338;" ><!--/npreceq N: not precedes, equals -->
+<!ENTITY nrtri            "&#x022EB;" ><!--/ntriangleright N: not rt triangle -->
+<!ENTITY nrtrie           "&#x022ED;" ><!--/ntrianglerighteq N: not r tri, eq -->
+<!ENTITY nsc              "&#x02281;" ><!--/nsucc N: not succeeds -->
+<!ENTITY nsccue           "&#x022E1;" ><!--not succeeds, curly eq -->
+<!ENTITY nsce             "&#x02AB0;&#x00338;" ><!--/nsucceq N: not succeeds, equals -->
+<!ENTITY nsim             "&#x02241;" ><!--/nsim N: not similar -->
+<!ENTITY nsime            "&#x02244;" ><!--/nsimeq N: not similar, equals -->
+<!ENTITY nsmid            "&#x02224;" ><!--/nshortmid -->
+<!ENTITY nspar            "&#x02226;" ><!--/nshortparallel N: not short par -->
+<!ENTITY nsqsube          "&#x022E2;" ><!--not, square subset, equals -->
+<!ENTITY nsqsupe          "&#x022E3;" ><!--not, square superset, equals -->
+<!ENTITY nsub             "&#x02284;" ><!--not subset -->
+<!ENTITY nsubE            "&#x02AC5;&#x00338;" ><!--/nsubseteqq N: not subset, dbl eq -->
+<!ENTITY nsube            "&#x02288;" ><!--/nsubseteq N: not subset, equals -->
+<!ENTITY nsup             "&#x02285;" ><!--not superset -->
+<!ENTITY nsupE            "&#x02AC6;&#x00338;" ><!--/nsupseteqq N: not superset, dbl eq -->
+<!ENTITY nsupe            "&#x02289;" ><!--/nsupseteq N: not superset, equals -->
+<!ENTITY ntgl             "&#x02279;" ><!--not greater, less -->
+<!ENTITY ntlg             "&#x02278;" ><!--not less, greater -->
+<!ENTITY nvap             "&#x0224D;&#x020D2;" ><!--not, vert, approximate -->
+<!ENTITY nVDash           "&#x022AF;" ><!--/nVDash N: not dbl vert, dbl dash -->
+<!ENTITY nVdash           "&#x022AE;" ><!--/nVdash N: not dbl vertical, dash -->
+<!ENTITY nvDash           "&#x022AD;" ><!--/nvDash N: not vertical, dbl dash -->
+<!ENTITY nvdash           "&#x022AC;" ><!--/nvdash N: not vertical, dash -->
+<!ENTITY nvge             "&#x02265;&#x020D2;" ><!--not, vert, greater-than-or-equal -->
+<!ENTITY nvgt             "&#x0003E;&#x020D2;" ><!--not, vert, greater-than -->
+<!ENTITY nvle             "&#x02264;&#x020D2;" ><!--not, vert, less-than-or-equal -->
+<!ENTITY nvlt             "&#38;#x0003C;&#x020D2;" ><!--not, vert, less-than -->
+<!ENTITY nvltrie          "&#x022B4;&#x020D2;" ><!--not, vert, left triangle, equals -->
+<!ENTITY nvrtrie          "&#x022B5;&#x020D2;" ><!--not, vert, right triangle, equals -->
+<!ENTITY nvsim            "&#x0223C;&#x020D2;" ><!--not, vert, similar -->
+<!ENTITY parsim           "&#x02AF3;" ><!--parallel, similar -->
+<!ENTITY prnap            "&#x02AB9;" ><!--/precnapprox N: precedes, not approx -->
+<!ENTITY prnE             "&#x02AB5;" ><!--/precneqq N: precedes, not dbl eq -->
+<!ENTITY prnsim           "&#x022E8;" ><!--/precnsim N: precedes, not similar -->
+<!ENTITY rnmid            "&#x02AEE;" ><!--reverse /nmid -->
+<!ENTITY scnap            "&#x02ABA;" ><!--/succnapprox N: succeeds, not approx -->
+<!ENTITY scnE             "&#x02AB6;" ><!--/succneqq N: succeeds, not dbl eq -->
+<!ENTITY scnsim           "&#x022E9;" ><!--/succnsim N: succeeds, not similar -->
+<!ENTITY simne            "&#x02246;" ><!--similar, not equals -->
+<!ENTITY solbar           "&#x0233F;" ><!--solidus, bar through -->
+<!ENTITY subnE            "&#x02ACB;" ><!--/subsetneqq N: subset, not dbl eq -->
+<!ENTITY subne            "&#x0228A;" ><!--/subsetneq N: subset, not equals -->
+<!ENTITY supnE            "&#x02ACC;" ><!--/supsetneqq N: superset, not dbl eq -->
+<!ENTITY supne            "&#x0228B;" ><!--/supsetneq N: superset, not equals -->
+<!ENTITY vnsub            "&#x02282;&#x020D2;" ><!--/nsubset N: not subset, var -->
+<!ENTITY vnsup            "&#x02283;&#x020D2;" ><!--/nsupset N: not superset, var -->
+<!ENTITY vsubnE           "&#x02ACB;&#x0FE00;" ><!--/varsubsetneqq N: subset not dbl eq, var -->
+<!ENTITY vsubne           "&#x0228A;&#x0FE00;" ><!--/varsubsetneq N: subset, not eq, var -->
+<!ENTITY vsupnE           "&#x02ACC;&#x0FE00;" ><!--/varsupsetneqq N: super not dbl eq, var -->
+<!ENTITY vsupne           "&#x0228B;&#x0FE00;" ><!--/varsupsetneq N: superset, not eq, var -->

--- a/src/main/resources/dtd/archiving/1.2/iso9573-13/isoamso.ent
+++ b/src/main/resources/dtd/archiving/1.2/iso9573-13/isoamso.ent
@@ -1,0 +1,73 @@
+
+<!--
+     File isoamso.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY ang              "&#x02220;" ><!--/angle - angle -->
+<!ENTITY ange             "&#x029A4;" ><!--angle, equal -->
+<!ENTITY angmsd           "&#x02221;" ><!--/measuredangle - angle-measured -->
+<!ENTITY angmsdaa         "&#x029A8;" ><!--angle-measured, arrow, up, right -->
+<!ENTITY angmsdab         "&#x029A9;" ><!--angle-measured, arrow, up, left -->
+<!ENTITY angmsdac         "&#x029AA;" ><!--angle-measured, arrow, down, right -->
+<!ENTITY angmsdad         "&#x029AB;" ><!--angle-measured, arrow, down, left -->
+<!ENTITY angmsdae         "&#x029AC;" ><!--angle-measured, arrow, right, up -->
+<!ENTITY angmsdaf         "&#x029AD;" ><!--angle-measured, arrow, left, up -->
+<!ENTITY angmsdag         "&#x029AE;" ><!--angle-measured, arrow, right, down -->
+<!ENTITY angmsdah         "&#x029AF;" ><!--angle-measured, arrow, left, down -->
+<!ENTITY angrtvb          "&#x022BE;" ><!--right angle-measured -->
+<!ENTITY angrtvbd         "&#x0299D;" ><!--right angle-measured, dot -->
+<!ENTITY bbrk             "&#x023B5;" ><!--bottom square bracket -->
+<!ENTITY bbrktbrk         "&#x023B6;" ><!--bottom above top square bracket -->
+<!ENTITY bemptyv          "&#x029B0;" ><!--reversed circle, slash -->
+<!ENTITY beth             "&#x02136;" ><!--/beth - beth, Hebrew -->
+<!ENTITY boxbox           "&#x029C9;" ><!--two joined squares -->
+<!ENTITY bprime           "&#x02035;" ><!--/backprime - reverse prime -->
+<!ENTITY bsemi            "&#x0204F;" ><!--reverse semi-colon -->
+<!ENTITY cemptyv          "&#x029B2;" ><!--circle, slash, small circle above -->
+<!ENTITY cirE             "&#x029C3;" ><!--circle, two horizontal stroked to the right -->
+<!ENTITY cirscir          "&#x029C2;" ><!--circle, small circle to the right -->
+<!ENTITY comp             "&#x02201;" ><!--/complement - complement sign -->
+<!ENTITY daleth           "&#x02138;" ><!--/daleth - daleth, Hebrew -->
+<!ENTITY demptyv          "&#x029B1;" ><!--circle, slash, bar above -->
+<!ENTITY ell              "&#x02113;" ><!--/ell - cursive small l -->
+<!ENTITY empty            "&#x02205;" ><!--/emptyset - zero, slash -->
+<!ENTITY emptyv           "&#x02205;" ><!--/varnothing - circle, slash -->
+<!ENTITY gimel            "&#x02137;" ><!--/gimel - gimel, Hebrew -->
+<!ENTITY iiota            "&#x02129;" ><!--inverted iota -->
+<!ENTITY image            "&#x02111;" ><!--/Im - imaginary   -->
+<!ENTITY imath            "&#x00131;" ><!--/imath - small i, no dot -->
+<!ENTITY jmath            "&#x0006A;" ><!--/jmath - small j, no dot -->
+<!ENTITY laemptyv         "&#x029B4;" ><!--circle, slash, left arrow above -->
+<!ENTITY lltri            "&#x025FA;" ><!--lower left triangle -->
+<!ENTITY lrtri            "&#x022BF;" ><!--lower right triangle -->
+<!ENTITY mho              "&#x02127;" ><!--/mho - conductance -->
+<!ENTITY nang             "&#x02220;&#x020D2;" ><!--not, vert, angle -->
+<!ENTITY nexist           "&#x02204;" ><!--/nexists - negated exists -->
+<!ENTITY oS               "&#x024C8;" ><!--/circledS - capital S in circle -->
+<!ENTITY planck           "&#x0210F;" ><!--/hbar - Planck's over 2pi -->
+<!ENTITY plankv           "&#x0210F;" ><!--/hslash - variant Planck's over 2pi -->
+<!ENTITY raemptyv         "&#x029B3;" ><!--circle, slash, right arrow above -->
+<!ENTITY range            "&#x029A5;" ><!--reverse angle, equal -->
+<!ENTITY real             "&#x0211C;" ><!--/Re - real -->
+<!ENTITY tbrk             "&#x023B4;" ><!--top square bracket -->
+<!ENTITY trpezium         "&#x0FFFD;" ><!--trapezium -->
+<!ENTITY ultri            "&#x025F8;" ><!--upper left triangle -->
+<!ENTITY urtri            "&#x025F9;" ><!--upper right triangle -->
+<!ENTITY vzigzag          "&#x0299A;" ><!--vertical zig-zag line -->
+<!ENTITY weierp           "&#x02118;" ><!--/wp - Weierstrass p -->

--- a/src/main/resources/dtd/archiving/1.2/iso9573-13/isoamsr.ent
+++ b/src/main/resources/dtd/archiving/1.2/iso9573-13/isoamsr.ent
@@ -1,0 +1,204 @@
+
+<!--
+     File isoamsr.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     References to the VARIANT SELECTOR 1 character (&#x0FE00;)
+     should match the uses listed in Unicode Technical Report 25.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY apE              "&#x02A70;" ><!--approximately equal or equal to -->
+<!ENTITY ape              "&#x0224A;" ><!--/approxeq R: approximate, equals -->
+<!ENTITY apid             "&#x0224B;" ><!--approximately identical to -->
+<!ENTITY asymp            "&#x02248;" ><!--/asymp R: asymptotically equal to -->
+<!ENTITY Barv             "&#x02AE7;" ><!--vert, dbl bar (over) -->
+<!ENTITY bcong            "&#x0224C;" ><!--/backcong R: reverse congruent -->
+<!ENTITY bepsi            "&#x003F6;" ><!--/backepsilon R: such that -->
+<!ENTITY bowtie           "&#x022C8;" ><!--/bowtie R: -->
+<!ENTITY bsim             "&#x0223D;" ><!--/backsim R: reverse similar -->
+<!ENTITY bsime            "&#x022CD;" ><!--/backsimeq R: reverse similar, eq -->
+<!ENTITY bsolhsub         "&#x0005C;&#x02282;" ><!--reverse solidus, subset -->
+<!ENTITY bump             "&#x0224E;" ><!--/Bumpeq R: bumpy equals -->
+<!ENTITY bumpE            "&#x02AAE;" ><!--bump, equals -->
+<!ENTITY bumpe            "&#x0224F;" ><!--/bumpeq R: bumpy equals, equals -->
+<!ENTITY cire             "&#x02257;" ><!--/circeq R: circle, equals -->
+<!ENTITY Colon            "&#x02237;" ><!--/Colon, two colons -->
+<!ENTITY Colone           "&#x02A74;" ><!--double colon, equals -->
+<!ENTITY colone           "&#x02254;" ><!--/coloneq R: colon, equals -->
+<!ENTITY congdot          "&#x02A6D;" ><!--congruent, dot -->
+<!ENTITY csub             "&#x02ACF;" ><!--subset, closed -->
+<!ENTITY csube            "&#x02AD1;" ><!--subset, closed, equals -->
+<!ENTITY csup             "&#x02AD0;" ><!--superset, closed -->
+<!ENTITY csupe            "&#x02AD2;" ><!--superset, closed, equals -->
+<!ENTITY cuepr            "&#x022DE;" ><!--/curlyeqprec R: curly eq, precedes -->
+<!ENTITY cuesc            "&#x022DF;" ><!--/curlyeqsucc R: curly eq, succeeds -->
+<!ENTITY Dashv            "&#x02AE4;" ><!--dbl dash, vertical -->
+<!ENTITY dashv            "&#x022A3;" ><!--/dashv R: dash, vertical -->
+<!ENTITY easter           "&#x02A6E;" ><!--equal, asterisk above -->
+<!ENTITY ecir             "&#x02256;" ><!--/eqcirc R: circle on equals sign -->
+<!ENTITY ecolon           "&#x02255;" ><!--/eqcolon R: equals, colon -->
+<!ENTITY eDDot            "&#x02A77;" ><!--/ddotseq R: equal with four dots -->
+<!ENTITY eDot             "&#x02251;" ><!--/doteqdot /Doteq R: eq, even dots -->
+<!ENTITY efDot            "&#x02252;" ><!--/fallingdotseq R: eq, falling dots -->
+<!ENTITY eg               "&#x02A9A;" ><!--equal-or-greater -->
+<!ENTITY egs              "&#x02A96;" ><!--/eqslantgtr R: equal-or-gtr, slanted -->
+<!ENTITY egsdot           "&#x02A98;" ><!--equal-or-greater, slanted, dot inside -->
+<!ENTITY el               "&#x02A99;" ><!--equal-or-less -->
+<!ENTITY els              "&#x02A95;" ><!--/eqslantless R: eq-or-less, slanted -->
+<!ENTITY elsdot           "&#x02A97;" ><!--equal-or-less, slanted, dot inside -->
+<!ENTITY equest           "&#x0225F;" ><!--/questeq R: equal with questionmark -->
+<!ENTITY equivDD          "&#x02A78;" ><!--equivalent, four dots above -->
+<!ENTITY erDot            "&#x02253;" ><!--/risingdotseq R: eq, rising dots -->
+<!ENTITY esdot            "&#x02250;" ><!--/doteq R: equals, single dot above -->
+<!ENTITY Esim             "&#x02A73;" ><!--equal, similar -->
+<!ENTITY esim             "&#x02242;" ><!--/esim R: equals, similar -->
+<!ENTITY fork             "&#x022D4;" ><!--/pitchfork R: pitchfork -->
+<!ENTITY forkv            "&#x02AD9;" ><!--fork, variant -->
+<!ENTITY frown            "&#x02322;" ><!--/frown R: down curve -->
+<!ENTITY gap              "&#x02A86;" ><!--/gtrapprox R: greater, approximate -->
+<!ENTITY gE               "&#x02267;" ><!--/geqq R: greater, double equals -->
+<!ENTITY gEl              "&#x02A8C;" ><!--/gtreqqless R: gt, dbl equals, less -->
+<!ENTITY gel              "&#x022DB;" ><!--/gtreqless R: greater, equals, less -->
+<!ENTITY ges              "&#x02A7E;" ><!--/geqslant R: gt-or-equal, slanted -->
+<!ENTITY gescc            "&#x02AA9;" ><!--greater than, closed by curve, equal, slanted -->
+<!ENTITY gesdot           "&#x02A80;" ><!--greater-than-or-equal, slanted, dot inside -->
+<!ENTITY gesdoto          "&#x02A82;" ><!--greater-than-or-equal, slanted, dot above -->
+<!ENTITY gesdotol         "&#x02A84;" ><!--greater-than-or-equal, slanted, dot above left -->
+<!ENTITY gesl             "&#x022DB;&#x0FE00;" ><!--greater, equal, slanted, less -->
+<!ENTITY gesles           "&#x02A94;" ><!--greater, equal, slanted, less, equal, slanted -->
+<!ENTITY Gg               "&#x022D9;" ><!--/ggg /Gg /gggtr R: triple gtr-than -->
+<!ENTITY gl               "&#x02277;" ><!--/gtrless R: greater, less -->
+<!ENTITY gla              "&#x02AA5;" ><!--greater, less, apart -->
+<!ENTITY glE              "&#x02A92;" ><!--greater, less, equal -->
+<!ENTITY glj              "&#x02AA4;" ><!--greater, less, overlapping -->
+<!ENTITY gsim             "&#x02273;" ><!--/gtrsim R: greater, similar -->
+<!ENTITY gsime            "&#x02A8E;" ><!--greater, similar, equal -->
+<!ENTITY gsiml            "&#x02A90;" ><!--greater, similar, less -->
+<!ENTITY Gt               "&#x0226B;" ><!--/gg R: dbl greater-than sign -->
+<!ENTITY gtcc             "&#x02AA7;" ><!--greater than, closed by curve -->
+<!ENTITY gtcir            "&#x02A7A;" ><!--greater than, circle inside -->
+<!ENTITY gtdot            "&#x022D7;" ><!--/gtrdot R: greater than, with dot -->
+<!ENTITY gtquest          "&#x02A7C;" ><!--greater than, questionmark above -->
+<!ENTITY gtrarr           "&#x02978;" ><!--greater than, right arrow -->
+<!ENTITY homtht           "&#x0223B;" ><!--homothetic -->
+<!ENTITY lap              "&#x02A85;" ><!--/lessapprox R: less, approximate -->
+<!ENTITY lat              "&#x02AAB;" ><!--larger than -->
+<!ENTITY late             "&#x02AAD;" ><!--larger than or equal -->
+<!ENTITY lates            "&#x02AAD;&#x0FE00;" ><!--larger than or equal, slanted -->
+<!ENTITY lE               "&#x02266;" ><!--/leqq R: less, double equals -->
+<!ENTITY lEg              "&#x02A8B;" ><!--/lesseqqgtr R: less, dbl eq, greater -->
+<!ENTITY leg              "&#x022DA;" ><!--/lesseqgtr R: less, eq, greater -->
+<!ENTITY les              "&#x02A7D;" ><!--/leqslant R: less-than-or-eq, slant -->
+<!ENTITY lescc            "&#x02AA8;" ><!--less than, closed by curve, equal, slanted -->
+<!ENTITY lesdot           "&#x02A7F;" ><!--less-than-or-equal, slanted, dot inside -->
+<!ENTITY lesdoto          "&#x02A81;" ><!--less-than-or-equal, slanted, dot above -->
+<!ENTITY lesdotor         "&#x02A83;" ><!--less-than-or-equal, slanted, dot above right -->
+<!ENTITY lesg             "&#x022DA;&#x0FE00;" ><!--less, equal, slanted, greater -->
+<!ENTITY lesges           "&#x02A93;" ><!--less, equal, slanted, greater, equal, slanted -->
+<!ENTITY lg               "&#x02276;" ><!--/lessgtr R: less, greater -->
+<!ENTITY lgE              "&#x02A91;" ><!--less, greater, equal -->
+<!ENTITY Ll               "&#x022D8;" ><!--/Ll /lll /llless R: triple less-than -->
+<!ENTITY lsim             "&#x02272;" ><!--/lesssim R: less, similar -->
+<!ENTITY lsime            "&#x02A8D;" ><!--less, similar, equal -->
+<!ENTITY lsimg            "&#x02A8F;" ><!--less, similar, greater -->
+<!ENTITY Lt               "&#x0226A;" ><!--/ll R: double less-than sign -->
+<!ENTITY ltcc             "&#x02AA6;" ><!--less than, closed by curve -->
+<!ENTITY ltcir            "&#x02A79;" ><!--less than, circle inside -->
+<!ENTITY ltdot            "&#x022D6;" ><!--/lessdot R: less than, with dot -->
+<!ENTITY ltlarr           "&#x02976;" ><!--less than, left arrow -->
+<!ENTITY ltquest          "&#x02A7B;" ><!--less than, questionmark above -->
+<!ENTITY ltrie            "&#x022B4;" ><!--/trianglelefteq R: left triangle, eq -->
+<!ENTITY mcomma           "&#x02A29;" ><!--minus, comma above -->
+<!ENTITY mDDot            "&#x0223A;" ><!--minus with four dots, geometric properties -->
+<!ENTITY mid              "&#x02223;" ><!--/mid R: -->
+<!ENTITY mlcp             "&#x02ADB;" ><!--/mlcp -->
+<!ENTITY models           "&#x022A7;" ><!--/models R: -->
+<!ENTITY mstpos           "&#x0223E;" ><!--most positive -->
+<!ENTITY Pr               "&#x02ABB;" ><!--dbl precedes -->
+<!ENTITY pr               "&#x0227A;" ><!--/prec R: precedes -->
+<!ENTITY prap             "&#x02AB7;" ><!--/precapprox R: precedes, approximate -->
+<!ENTITY prcue            "&#x0227C;" ><!--/preccurlyeq R: precedes, curly eq -->
+<!ENTITY prE              "&#x02AB3;" ><!--precedes, dbl equals -->
+<!ENTITY pre              "&#x02AAF;" ><!--/preceq R: precedes, equals -->
+<!ENTITY prsim            "&#x0227E;" ><!--/precsim R: precedes, similar -->
+<!ENTITY prurel           "&#x022B0;" ><!--element precedes under relation -->
+<!ENTITY ratio            "&#x02236;" ><!--/ratio -->
+<!ENTITY rtrie            "&#x022B5;" ><!--/trianglerighteq R: right tri, eq -->
+<!ENTITY rtriltri         "&#x029CE;" ><!--right triangle above left triangle -->
+<!ENTITY Sc               "&#x02ABC;" ><!--dbl succeeds -->
+<!ENTITY sc               "&#x0227B;" ><!--/succ R: succeeds -->
+<!ENTITY scap             "&#x02AB8;" ><!--/succapprox R: succeeds, approximate -->
+<!ENTITY sccue            "&#x0227D;" ><!--/succcurlyeq R: succeeds, curly eq -->
+<!ENTITY scE              "&#x02AB4;" ><!--succeeds, dbl equals -->
+<!ENTITY sce              "&#x02AB0;" ><!--/succeq R: succeeds, equals -->
+<!ENTITY scsim            "&#x0227F;" ><!--/succsim R: succeeds, similar -->
+<!ENTITY sdote            "&#x02A66;" ><!--equal, dot below -->
+<!ENTITY sfrown           "&#x02322;" ><!--/smallfrown R: small down curve -->
+<!ENTITY simg             "&#x02A9E;" ><!--similar, greater -->
+<!ENTITY simgE            "&#x02AA0;" ><!--similar, greater, equal -->
+<!ENTITY siml             "&#x02A9D;" ><!--similar, less -->
+<!ENTITY simlE            "&#x02A9F;" ><!--similar, less, equal -->
+<!ENTITY smid             "&#x02223;" ><!--/shortmid R: -->
+<!ENTITY smile            "&#x02323;" ><!--/smile R: up curve -->
+<!ENTITY smt              "&#x02AAA;" ><!--smaller than -->
+<!ENTITY smte             "&#x02AAC;" ><!--smaller than or equal -->
+<!ENTITY smtes            "&#x02AAC;&#x0FE00;" ><!--smaller than or equal, slanted -->
+<!ENTITY spar             "&#x02225;" ><!--/shortparallel R: short parallel -->
+<!ENTITY sqsub            "&#x0228F;" ><!--/sqsubset R: square subset -->
+<!ENTITY sqsube           "&#x02291;" ><!--/sqsubseteq R: square subset, equals -->
+<!ENTITY sqsup            "&#x02290;" ><!--/sqsupset R: square superset -->
+<!ENTITY sqsupe           "&#x02292;" ><!--/sqsupseteq R: square superset, eq -->
+<!ENTITY ssmile           "&#x02323;" ><!--/smallsmile R: small up curve -->
+<!ENTITY Sub              "&#x022D0;" ><!--/Subset R: double subset -->
+<!ENTITY subE             "&#x02AC5;" ><!--/subseteqq R: subset, dbl equals -->
+<!ENTITY subedot          "&#x02AC3;" ><!--subset, equals, dot -->
+<!ENTITY submult          "&#x02AC1;" ><!--subset, multiply -->
+<!ENTITY subplus          "&#x02ABF;" ><!--subset, plus -->
+<!ENTITY subrarr          "&#x02979;" ><!--subset, right arrow -->
+<!ENTITY subsim           "&#x02AC7;" ><!--subset, similar -->
+<!ENTITY subsub           "&#x02AD5;" ><!--subset above subset -->
+<!ENTITY subsup           "&#x02AD3;" ><!--subset above superset -->
+<!ENTITY Sup              "&#x022D1;" ><!--/Supset R: dbl superset -->
+<!ENTITY supdsub          "&#x02AD8;" ><!--superset, subset, dash joining them -->
+<!ENTITY supE             "&#x02AC6;" ><!--/supseteqq R: superset, dbl equals -->
+<!ENTITY supedot          "&#x02AC4;" ><!--superset, equals, dot -->
+<!ENTITY suphsol          "&#x02283;&#x0002F;" ><!--superset, solidus -->
+<!ENTITY suphsub          "&#x02AD7;" ><!--superset, subset -->
+<!ENTITY suplarr          "&#x0297B;" ><!--superset, left arrow -->
+<!ENTITY supmult          "&#x02AC2;" ><!--superset, multiply -->
+<!ENTITY supplus          "&#x02AC0;" ><!--superset, plus -->
+<!ENTITY supsim           "&#x02AC8;" ><!--superset, similar -->
+<!ENTITY supsub           "&#x02AD4;" ><!--superset above subset -->
+<!ENTITY supsup           "&#x02AD6;" ><!--superset above superset -->
+<!ENTITY thkap            "&#x02248;" ><!--/thickapprox R: thick approximate -->
+<!ENTITY thksim           "&#x0223C;" ><!--/thicksim R: thick similar -->
+<!ENTITY topfork          "&#x02ADA;" ><!--fork with top -->
+<!ENTITY trie             "&#x0225C;" ><!--/triangleq R: triangle, equals -->
+<!ENTITY twixt            "&#x0226C;" ><!--/between R: between -->
+<!ENTITY Vbar             "&#x02AEB;" ><!--dbl vert, bar (under) -->
+<!ENTITY vBar             "&#x02AE8;" ><!--vert, dbl bar (under) -->
+<!ENTITY vBarv            "&#x02AE9;" ><!--dbl bar, vert over and under -->
+<!ENTITY VDash            "&#x022AB;" ><!--dbl vert, dbl dash -->
+<!ENTITY Vdash            "&#x022A9;" ><!--/Vdash R: dbl vertical, dash -->
+<!ENTITY vDash            "&#x022A8;" ><!--/vDash R: vertical, dbl dash -->
+<!ENTITY vdash            "&#x022A2;" ><!--/vdash R: vertical, dash -->
+<!ENTITY Vdashl           "&#x02AE6;" ><!--vertical, dash (long) -->
+<!ENTITY vltri            "&#x022B2;" ><!--/vartriangleleft R: l tri, open, var -->
+<!ENTITY vprop            "&#x0221D;" ><!--/varpropto R: proportional, variant -->
+<!ENTITY vrtri            "&#x022B3;" ><!--/vartriangleright R: r tri, open, var -->
+<!ENTITY Vvdash           "&#x022AA;" ><!--/Vvdash R: triple vertical, dash -->

--- a/src/main/resources/dtd/archiving/1.2/iso9573-13/isogrk3.ent
+++ b/src/main/resources/dtd/archiving/1.2/iso9573-13/isogrk3.ent
@@ -1,0 +1,64 @@
+
+<!--
+     File isogrk3.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY alpha            "&#x003B1;" ><!--/alpha small alpha, Greek -->
+<!ENTITY beta             "&#x003B2;" ><!--/beta small beta, Greek -->
+<!ENTITY chi              "&#x003C7;" ><!--/chi small chi, Greek -->
+<!ENTITY Delta            "&#x00394;" ><!--/Delta capital Delta, Greek -->
+<!ENTITY delta            "&#x003B4;" ><!--/delta small delta, Greek -->
+<!ENTITY epsi             "&#x003F5;" ><!--/straightepsilon, small epsilon, Greek -->
+<!ENTITY epsiv            "&#x003B5;" ><!--/varepsilon -->
+<!ENTITY eta              "&#x003B7;" ><!--/eta small eta, Greek -->
+<!ENTITY Gamma            "&#x00393;" ><!--/Gamma capital Gamma, Greek -->
+<!ENTITY gamma            "&#x003B3;" ><!--/gamma small gamma, Greek -->
+<!ENTITY Gammad           "&#x003DC;" ><!--capital digamma -->
+<!ENTITY gammad           "&#x003DD;" ><!--/digamma -->
+<!ENTITY iota             "&#x003B9;" ><!--/iota small iota, Greek -->
+<!ENTITY kappa            "&#x003BA;" ><!--/kappa small kappa, Greek -->
+<!ENTITY kappav           "&#x003F0;" ><!--/varkappa -->
+<!ENTITY Lambda           "&#x0039B;" ><!--/Lambda capital Lambda, Greek -->
+<!ENTITY lambda           "&#x003BB;" ><!--/lambda small lambda, Greek -->
+<!ENTITY mu               "&#x003BC;" ><!--/mu small mu, Greek -->
+<!ENTITY nu               "&#x003BD;" ><!--/nu small nu, Greek -->
+<!ENTITY Omega            "&#x003A9;" ><!--/Omega capital Omega, Greek -->
+<!ENTITY omega            "&#x003C9;" ><!--/omega small omega, Greek -->
+<!ENTITY Phi              "&#x003A6;" ><!--/Phi capital Phi, Greek -->
+<!ENTITY phi              "&#x003D5;" ><!--/straightphi - small phi, Greek -->
+<!ENTITY phiv             "&#x003C6;" ><!--/varphi - curly or open phi -->
+<!ENTITY Pi               "&#x003A0;" ><!--/Pi capital Pi, Greek -->
+<!ENTITY pi               "&#x003C0;" ><!--/pi small pi, Greek -->
+<!ENTITY piv              "&#x003D6;" ><!--/varpi -->
+<!ENTITY Psi              "&#x003A8;" ><!--/Psi capital Psi, Greek -->
+<!ENTITY psi              "&#x003C8;" ><!--/psi small psi, Greek -->
+<!ENTITY rho              "&#x003C1;" ><!--/rho small rho, Greek -->
+<!ENTITY rhov             "&#x003F1;" ><!--/varrho -->
+<!ENTITY Sigma            "&#x003A3;" ><!--/Sigma capital Sigma, Greek -->
+<!ENTITY sigma            "&#x003C3;" ><!--/sigma small sigma, Greek -->
+<!ENTITY sigmav           "&#x003C2;" ><!--/varsigma -->
+<!ENTITY tau              "&#x003C4;" ><!--/tau small tau, Greek -->
+<!ENTITY Theta            "&#x00398;" ><!--/Theta capital Theta, Greek -->
+<!ENTITY theta            "&#x003B8;" ><!--/theta straight theta, small theta, Greek -->
+<!ENTITY thetav           "&#x003D1;" ><!--/vartheta - curly or open theta -->
+<!ENTITY Upsi             "&#x003D2;" ><!--/Upsilon capital Upsilon, Greek -->
+<!ENTITY upsi             "&#x003C5;" ><!--/upsilon small upsilon, Greek -->
+<!ENTITY Xi               "&#x0039E;" ><!--/Xi capital Xi, Greek -->
+<!ENTITY xi               "&#x003BE;" ><!--/xi small xi, Greek -->
+<!ENTITY zeta             "&#x003B6;" ><!--/zeta small zeta, Greek -->

--- a/src/main/resources/dtd/archiving/1.2/iso9573-13/isomfrk.ent
+++ b/src/main/resources/dtd/archiving/1.2/iso9573-13/isomfrk.ent
@@ -1,0 +1,75 @@
+
+<!--
+     File isomfrk.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY % plane1D  "&#38;#38;#x1D">
+
+<!ENTITY Afr              "%plane1D;504;" ><!--/frak A, upper case a -->
+<!ENTITY afr              "%plane1D;51E;" ><!--/frak a, lower case a -->
+<!ENTITY Bfr              "%plane1D;505;" ><!--/frak B, upper case b -->
+<!ENTITY bfr              "%plane1D;51F;" ><!--/frak b, lower case b -->
+<!ENTITY Cfr              "&#x0212D;" ><!--/frak C, upper case c -->
+<!ENTITY cfr              "%plane1D;520;" ><!--/frak c, lower case c -->
+<!ENTITY Dfr              "%plane1D;507;" ><!--/frak D, upper case d -->
+<!ENTITY dfr              "%plane1D;521;" ><!--/frak d, lower case d -->
+<!ENTITY Efr              "%plane1D;508;" ><!--/frak E, upper case e -->
+<!ENTITY efr              "%plane1D;522;" ><!--/frak e, lower case e -->
+<!ENTITY Ffr              "%plane1D;509;" ><!--/frak F, upper case f -->
+<!ENTITY ffr              "%plane1D;523;" ><!--/frak f, lower case f -->
+<!ENTITY Gfr              "%plane1D;50A;" ><!--/frak G, upper case g -->
+<!ENTITY gfr              "%plane1D;524;" ><!--/frak g, lower case g -->
+<!ENTITY Hfr              "&#x0210C;" ><!--/frak H, upper case h -->
+<!ENTITY hfr              "%plane1D;525;" ><!--/frak h, lower case h -->
+<!ENTITY Ifr              "&#x02111;" ><!--/frak I, upper case i -->
+<!ENTITY ifr              "%plane1D;526;" ><!--/frak i, lower case i -->
+<!ENTITY Jfr              "%plane1D;50D;" ><!--/frak J, upper case j -->
+<!ENTITY jfr              "%plane1D;527;" ><!--/frak j, lower case j -->
+<!ENTITY Kfr              "%plane1D;50E;" ><!--/frak K, upper case k -->
+<!ENTITY kfr              "%plane1D;528;" ><!--/frak k, lower case k -->
+<!ENTITY Lfr              "%plane1D;50F;" ><!--/frak L, upper case l -->
+<!ENTITY lfr              "%plane1D;529;" ><!--/frak l, lower case l -->
+<!ENTITY Mfr              "%plane1D;510;" ><!--/frak M, upper case m -->
+<!ENTITY mfr              "%plane1D;52A;" ><!--/frak m, lower case m -->
+<!ENTITY Nfr              "%plane1D;511;" ><!--/frak N, upper case n -->
+<!ENTITY nfr              "%plane1D;52B;" ><!--/frak n, lower case n -->
+<!ENTITY Ofr              "%plane1D;512;" ><!--/frak O, upper case o -->
+<!ENTITY ofr              "%plane1D;52C;" ><!--/frak o, lower case o -->
+<!ENTITY Pfr              "%plane1D;513;" ><!--/frak P, upper case p -->
+<!ENTITY pfr              "%plane1D;52D;" ><!--/frak p, lower case p -->
+<!ENTITY Qfr              "%plane1D;514;" ><!--/frak Q, upper case q -->
+<!ENTITY qfr              "%plane1D;52E;" ><!--/frak q, lower case q -->
+<!ENTITY Rfr              "&#x0211C;" ><!--/frak R, upper case r -->
+<!ENTITY rfr              "%plane1D;52F;" ><!--/frak r, lower case r -->
+<!ENTITY Sfr              "%plane1D;516;" ><!--/frak S, upper case s -->
+<!ENTITY sfr              "%plane1D;530;" ><!--/frak s, lower case s -->
+<!ENTITY Tfr              "%plane1D;517;" ><!--/frak T, upper case t -->
+<!ENTITY tfr              "%plane1D;531;" ><!--/frak t, lower case t -->
+<!ENTITY Ufr              "%plane1D;518;" ><!--/frak U, upper case u -->
+<!ENTITY ufr              "%plane1D;532;" ><!--/frak u, lower case u -->
+<!ENTITY Vfr              "%plane1D;519;" ><!--/frak V, upper case v -->
+<!ENTITY vfr              "%plane1D;533;" ><!--/frak v, lower case v -->
+<!ENTITY Wfr              "%plane1D;51A;" ><!--/frak W, upper case w -->
+<!ENTITY wfr              "%plane1D;534;" ><!--/frak w, lower case w -->
+<!ENTITY Xfr              "%plane1D;51B;" ><!--/frak X, upper case x -->
+<!ENTITY xfr              "%plane1D;535;" ><!--/frak x, lower case x -->
+<!ENTITY Yfr              "%plane1D;51C;" ><!--/frak Y, upper case y -->
+<!ENTITY yfr              "%plane1D;536;" ><!--/frak y, lower case y -->
+<!ENTITY Zfr              "&#x02128;" ><!--/frak Z, upper case z  -->
+<!ENTITY zfr              "%plane1D;537;" ><!--/frak z, lower case z -->

--- a/src/main/resources/dtd/archiving/1.2/iso9573-13/isomopf.ent
+++ b/src/main/resources/dtd/archiving/1.2/iso9573-13/isomopf.ent
@@ -1,0 +1,49 @@
+
+<!--
+     File isomopf.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY % plane1D  "&#38;#38;#x1D">
+
+<!ENTITY Aopf             "%plane1D;538;" ><!--/Bbb A, open face A -->
+<!ENTITY Bopf             "%plane1D;539;" ><!--/Bbb B, open face B -->
+<!ENTITY Copf             "&#x02102;" ><!--/Bbb C, open face C -->
+<!ENTITY Dopf             "%plane1D;53B;" ><!--/Bbb D, open face D -->
+<!ENTITY Eopf             "%plane1D;53C;" ><!--/Bbb E, open face E -->
+<!ENTITY Fopf             "%plane1D;53D;" ><!--/Bbb F, open face F -->
+<!ENTITY Gopf             "%plane1D;53E;" ><!--/Bbb G, open face G -->
+<!ENTITY Hopf             "&#x0210D;" ><!--/Bbb H, open face H -->
+<!ENTITY Iopf             "%plane1D;540;" ><!--/Bbb I, open face I -->
+<!ENTITY Jopf             "%plane1D;541;" ><!--/Bbb J, open face J -->
+<!ENTITY Kopf             "%plane1D;542;" ><!--/Bbb K, open face K  -->
+<!ENTITY Lopf             "%plane1D;543;" ><!--/Bbb L, open face L  -->
+<!ENTITY Mopf             "%plane1D;544;" ><!--/Bbb M, open face M  -->
+<!ENTITY Nopf             "&#x02115;" ><!--/Bbb N, open face N -->
+<!ENTITY Oopf             "%plane1D;546;" ><!--/Bbb O, open face O -->
+<!ENTITY Popf             "&#x02119;" ><!--/Bbb P, open face P -->
+<!ENTITY Qopf             "&#x0211A;" ><!--/Bbb Q, open face Q -->
+<!ENTITY Ropf             "&#x0211D;" ><!--/Bbb R, open face R -->
+<!ENTITY Sopf             "%plane1D;54A;" ><!--/Bbb S, open face S -->
+<!ENTITY Topf             "%plane1D;54B;" ><!--/Bbb T, open face T -->
+<!ENTITY Uopf             "%plane1D;54C;" ><!--/Bbb U, open face U -->
+<!ENTITY Vopf             "%plane1D;54D;" ><!--/Bbb V, open face V -->
+<!ENTITY Wopf             "%plane1D;54E;" ><!--/Bbb W, open face W -->
+<!ENTITY Xopf             "%plane1D;54F;" ><!--/Bbb X, open face X -->
+<!ENTITY Yopf             "%plane1D;550;" ><!--/Bbb Y, open face Y -->
+<!ENTITY Zopf             "&#x02124;" ><!--/Bbb Z, open face Z -->

--- a/src/main/resources/dtd/archiving/1.2/iso9573-13/isomscr.ent
+++ b/src/main/resources/dtd/archiving/1.2/iso9573-13/isomscr.ent
@@ -1,0 +1,75 @@
+
+<!--
+     File isomscr.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY % plane1D  "&#38;#38;#x1D">
+
+<!ENTITY Ascr             "%plane1D;49C;" ><!--/scr A, script letter A -->
+<!ENTITY ascr             "%plane1D;4B6;" ><!--/scr a, script letter a -->
+<!ENTITY Bscr             "&#x0212C;" ><!--/scr B, script letter B -->
+<!ENTITY bscr             "%plane1D;4B7;" ><!--/scr b, script letter b -->
+<!ENTITY Cscr             "%plane1D;49E;" ><!--/scr C, script letter C -->
+<!ENTITY cscr             "%plane1D;4B8;" ><!--/scr c, script letter c -->
+<!ENTITY Dscr             "%plane1D;49F;" ><!--/scr D, script letter D -->
+<!ENTITY dscr             "%plane1D;4B9;" ><!--/scr d, script letter d -->
+<!ENTITY Escr             "&#x02130;" ><!--/scr E, script letter E -->
+<!ENTITY escr             "&#x0212F;" ><!--/scr e, script letter e -->
+<!ENTITY Fscr             "&#x02131;" ><!--/scr F, script letter F -->
+<!ENTITY fscr             "%plane1D;4BB;" ><!--/scr f, script letter f -->
+<!ENTITY Gscr             "%plane1D;4A2;" ><!--/scr G, script letter G -->
+<!ENTITY gscr             "&#x0210A;" ><!--/scr g, script letter g -->
+<!ENTITY Hscr             "&#x0210B;" ><!--/scr H, script letter H -->
+<!ENTITY hscr             "%plane1D;4BD;" ><!--/scr h, script letter h -->
+<!ENTITY Iscr             "&#x02110;" ><!--/scr I, script letter I -->
+<!ENTITY iscr             "%plane1D;4BE;" ><!--/scr i, script letter i -->
+<!ENTITY Jscr             "%plane1D;4A5;" ><!--/scr J, script letter J -->
+<!ENTITY jscr             "%plane1D;4BF;" ><!--/scr j, script letter j -->
+<!ENTITY Kscr             "%plane1D;4A6;" ><!--/scr K, script letter K -->
+<!ENTITY kscr             "%plane1D;4C0;" ><!--/scr k, script letter k -->
+<!ENTITY Lscr             "&#x02112;" ><!--/scr L, script letter L -->
+<!ENTITY lscr             "%plane1D;4C1;" ><!--/scr l, script letter l -->
+<!ENTITY Mscr             "&#x02133;" ><!--/scr M, script letter M -->
+<!ENTITY mscr             "%plane1D;4C2;" ><!--/scr m, script letter m -->
+<!ENTITY Nscr             "%plane1D;4A9;" ><!--/scr N, script letter N -->
+<!ENTITY nscr             "%plane1D;4C3;" ><!--/scr n, script letter n -->
+<!ENTITY Oscr             "%plane1D;4AA;" ><!--/scr O, script letter O -->
+<!ENTITY oscr             "&#x02134;" ><!--/scr o, script letter o -->
+<!ENTITY Pscr             "%plane1D;4AB;" ><!--/scr P, script letter P -->
+<!ENTITY pscr             "%plane1D;4C5;" ><!--/scr p, script letter p -->
+<!ENTITY Qscr             "%plane1D;4AC;" ><!--/scr Q, script letter Q -->
+<!ENTITY qscr             "%plane1D;4C6;" ><!--/scr q, script letter q -->
+<!ENTITY Rscr             "&#x0211B;" ><!--/scr R, script letter R -->
+<!ENTITY rscr             "%plane1D;4C7;" ><!--/scr r, script letter r -->
+<!ENTITY Sscr             "%plane1D;4AE;" ><!--/scr S, script letter S -->
+<!ENTITY sscr             "%plane1D;4C8;" ><!--/scr s, script letter s -->
+<!ENTITY Tscr             "%plane1D;4AF;" ><!--/scr T, script letter T -->
+<!ENTITY tscr             "%plane1D;4C9;" ><!--/scr t, script letter t -->
+<!ENTITY Uscr             "%plane1D;4B0;" ><!--/scr U, script letter U -->
+<!ENTITY uscr             "%plane1D;4CA;" ><!--/scr u, script letter u -->
+<!ENTITY Vscr             "%plane1D;4B1;" ><!--/scr V, script letter V -->
+<!ENTITY vscr             "%plane1D;4CB;" ><!--/scr v, script letter v -->
+<!ENTITY Wscr             "%plane1D;4B2;" ><!--/scr W, script letter W -->
+<!ENTITY wscr             "%plane1D;4CC;" ><!--/scr w, script letter w -->
+<!ENTITY Xscr             "%plane1D;4B3;" ><!--/scr X, script letter X -->
+<!ENTITY xscr             "%plane1D;4CD;" ><!--/scr x, script letter x -->
+<!ENTITY Yscr             "%plane1D;4B4;" ><!--/scr Y, script letter Y -->
+<!ENTITY yscr             "%plane1D;4CE;" ><!--/scr y, script letter y -->
+<!ENTITY Zscr             "%plane1D;4B5;" ><!--/scr Z, script letter Z -->
+<!ENTITY zscr             "%plane1D;4CF;" ><!--/scr z, script letter z -->

--- a/src/main/resources/dtd/archiving/1.2/iso9573-13/isotech.ent
+++ b/src/main/resources/dtd/archiving/1.2/iso9573-13/isotech.ent
@@ -1,0 +1,182 @@
+
+<!--
+     File isotech.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY acd              "&#x0223F;" ><!--ac current -->
+<!ENTITY aleph            "&#x02135;" ><!--/aleph aleph, Hebrew -->
+<!ENTITY And              "&#x02A53;" ><!--dbl logical and -->
+<!ENTITY and              "&#x02227;" ><!--/wedge /land B: logical and -->
+<!ENTITY andand           "&#x02A55;" ><!--two logical and -->
+<!ENTITY andd             "&#x02A5C;" ><!--and, horizontal dash -->
+<!ENTITY andslope         "&#x02A58;" ><!--sloping large and -->
+<!ENTITY andv             "&#x02A5A;" ><!--and with middle stem -->
+<!ENTITY angrt            "&#x0221F;" ><!--right (90 degree) angle -->
+<!ENTITY angsph           "&#x02222;" ><!--/sphericalangle angle-spherical -->
+<!ENTITY angst            "&#x0212B;" ><!--Angstrom capital A, ring -->
+<!ENTITY ap               "&#x02248;" ><!--/approx R: approximate -->
+<!ENTITY apacir           "&#x02A6F;" ><!--approximate, circumflex accent -->
+<!ENTITY awconint         "&#x02233;" ><!--contour integral, anti-clockwise -->
+<!ENTITY awint            "&#x02A11;" ><!--anti clock-wise integration -->
+<!ENTITY becaus           "&#x02235;" ><!--/because R: because -->
+<!ENTITY bernou           "&#x0212C;" ><!--Bernoulli function (script capital B)  -->
+<!ENTITY bne              "&#x0003D;&#x020E5;" ><!--reverse not equal -->
+<!ENTITY bnequiv          "&#x02261;&#x020E5;" ><!--reverse not equivalent -->
+<!ENTITY bNot             "&#x02AED;" ><!--reverse not with two horizontal strokes -->
+<!ENTITY bnot             "&#x02310;" ><!--reverse not -->
+<!ENTITY bottom           "&#x022A5;" ><!--/bot bottom -->
+<!ENTITY cap              "&#x02229;" ><!--/cap B: intersection -->
+<!ENTITY Cconint          "&#x02230;" ><!--triple contour integral operator -->
+<!ENTITY cirfnint         "&#x02A10;" ><!--circulation function -->
+<!ENTITY compfn           "&#x02218;" ><!--/circ B: composite function (small circle) -->
+<!ENTITY cong             "&#x02245;" ><!--/cong R: congruent with -->
+<!ENTITY Conint           "&#x0222F;" ><!--double contour integral operator -->
+<!ENTITY conint           "&#x0222E;" ><!--/oint L: contour integral operator -->
+<!ENTITY ctdot            "&#x022EF;" ><!--/cdots, three dots, centered -->
+<!ENTITY cup              "&#x0222A;" ><!--/cup B: union or logical sum -->
+<!ENTITY cwconint         "&#x02232;" ><!--contour integral, clockwise -->
+<!ENTITY cwint            "&#x02231;" ><!--clockwise integral -->
+<!ENTITY cylcty           "&#x0232D;" ><!--cylindricity -->
+<!ENTITY disin            "&#x022F2;" ><!--set membership, long horizontal stroke -->
+<!ENTITY Dot              "&#x000A8;" ><!--dieresis or umlaut mark -->
+<!ENTITY DotDot           "&#x020DC;" ><!--four dots above -->
+<!ENTITY dsol             "&#x029F6;" ><!--solidus, bar above -->
+<!ENTITY dtdot            "&#x022F1;" ><!--/ddots, three dots, descending -->
+<!ENTITY dwangle          "&#x029A6;" ><!--large downward pointing angle -->
+<!ENTITY elinters         "&#x0FFFD;" ><!--electrical intersection -->
+<!ENTITY epar             "&#x022D5;" ><!--parallel, equal; equal or parallel -->
+<!ENTITY eparsl           "&#x029E3;" ><!--parallel, slanted, equal; homothetically congruent to -->
+<!ENTITY equiv            "&#x02261;" ><!--/equiv R: identical with -->
+<!ENTITY eqvparsl         "&#x029E5;" ><!--equivalent, equal; congruent and parallel -->
+<!ENTITY exist            "&#x02203;" ><!--/exists at least one exists -->
+<!ENTITY fltns            "&#x025B1;" ><!--flatness -->
+<!ENTITY fnof             "&#x00192;" ><!--function of (italic small f) -->
+<!ENTITY forall           "&#x02200;" ><!--/forall for all -->
+<!ENTITY fpartint         "&#x02A0D;" ><!--finite part integral -->
+<!ENTITY ge               "&#x02265;" ><!--/geq /ge R: greater-than-or-equal -->
+<!ENTITY hamilt           "&#x0210B;" ><!--Hamiltonian (script capital H)  -->
+<!ENTITY iff              "&#x021D4;" ><!--/iff if and only if  -->
+<!ENTITY iinfin           "&#x029DC;" ><!--infinity sign, incomplete -->
+<!ENTITY imped            "&#x001B5;" ><!--impedance -->
+<!ENTITY infin            "&#x0221E;" ><!--/infty infinity -->
+<!ENTITY infintie         "&#x029DD;" ><!--tie, infinity -->
+<!ENTITY Int              "&#x0222C;" ><!--double integral operator -->
+<!ENTITY int              "&#x0222B;" ><!--/int L: integral operator -->
+<!ENTITY intlarhk         "&#x02A17;" ><!--integral, left arrow with hook -->
+<!ENTITY isin             "&#x02208;" ><!--/in R: set membership  -->
+<!ENTITY isindot          "&#x022F5;" ><!--set membership, dot above -->
+<!ENTITY isinE            "&#x022F9;" ><!--set membership, two horizontal strokes -->
+<!ENTITY isins            "&#x022F4;" ><!--set membership, vertical bar on horizontal stroke -->
+<!ENTITY isinsv           "&#x022F3;" ><!--large set membership, vertical bar on horizontal stroke -->
+<!ENTITY isinv            "&#x02208;" ><!--set membership, variant -->
+<!ENTITY lagran           "&#x02112;" ><!--Lagrangian (script capital L)  -->
+<!ENTITY Lang             "&#x0300A;" ><!--left angle bracket, double -->
+<!ENTITY lang             "&#x02329;" ><!--/langle O: left angle bracket -->
+<!ENTITY lArr             "&#x021D0;" ><!--/Leftarrow A: is implied by -->
+<!ENTITY lbbrk            "&#x03014;" ><!--left broken bracket -->
+<!ENTITY le               "&#x02264;" ><!--/leq /le R: less-than-or-equal -->
+<!ENTITY loang            "&#x03018;" ><!--left open angular bracket -->
+<!ENTITY lobrk            "&#x0301A;" ><!--left open bracket -->
+<!ENTITY lopar            "&#x02985;" ><!--left open parenthesis -->
+<!ENTITY lowast           "&#x02217;" ><!--low asterisk -->
+<!ENTITY minus            "&#x02212;" ><!--B: minus sign -->
+<!ENTITY mnplus           "&#x02213;" ><!--/mp B: minus-or-plus sign -->
+<!ENTITY nabla            "&#x02207;" ><!--/nabla del, Hamilton operator -->
+<!ENTITY ne               "&#x02260;" ><!--/ne /neq R: not equal -->
+<!ENTITY nedot            "&#x02250;&#x00338;" ><!--not equal, dot -->
+<!ENTITY nhpar            "&#x02AF2;" ><!--not, horizontal, parallel -->
+<!ENTITY ni               "&#x0220B;" ><!--/ni /owns R: contains -->
+<!ENTITY nis              "&#x022FC;" ><!--contains, vertical bar on horizontal stroke -->
+<!ENTITY nisd             "&#x022FA;" ><!--contains, long horizontal stroke -->
+<!ENTITY niv              "&#x0220B;" ><!--contains, variant -->
+<!ENTITY Not              "&#x02AEC;" ><!--not with two horizontal strokes -->
+<!ENTITY notin            "&#x02209;" ><!--/notin N: negated set membership -->
+<!ENTITY notindot         "&#x022F5;&#x00338;" ><!--negated set membership, dot above -->
+<!ENTITY notinE           "&#x022F9;&#x00338;" ><!--negated set membership, two horizontal strokes -->
+<!ENTITY notinva          "&#x02209;" ><!--negated set membership, variant -->
+<!ENTITY notinvb          "&#x022F7;" ><!--negated set membership, variant -->
+<!ENTITY notinvc          "&#x022F6;" ><!--negated set membership, variant -->
+<!ENTITY notni            "&#x0220C;" ><!--negated contains -->
+<!ENTITY notniva          "&#x0220C;" ><!--negated contains, variant -->
+<!ENTITY notnivb          "&#x022FE;" ><!--contains, variant -->
+<!ENTITY notnivc          "&#x022FD;" ><!--contains, variant -->
+<!ENTITY nparsl           "&#x02AFD;&#x020E5;" ><!--not parallel, slanted -->
+<!ENTITY npart            "&#x02202;&#x00338;" ><!--not partial differential -->
+<!ENTITY npolint          "&#x02A14;" ><!--line integration, not including the pole -->
+<!ENTITY nvinfin          "&#x029DE;" ><!--not, vert, infinity -->
+<!ENTITY olcross          "&#x029BB;" ><!--circle, cross -->
+<!ENTITY Or               "&#x02A54;" ><!--dbl logical or -->
+<!ENTITY or               "&#x02228;" ><!--/vee /lor B: logical or -->
+<!ENTITY ord              "&#x02A5D;" ><!--or, horizontal dash -->
+<!ENTITY order            "&#x02134;" ><!--order of (script small o)  -->
+<!ENTITY oror             "&#x02A56;" ><!--two logical or -->
+<!ENTITY orslope          "&#x02A57;" ><!--sloping large or -->
+<!ENTITY orv              "&#x02A5B;" ><!--or with middle stem -->
+<!ENTITY par              "&#x02225;" ><!--/parallel R: parallel -->
+<!ENTITY parsl            "&#x02AFD;" ><!--parallel, slanted -->
+<!ENTITY part             "&#x02202;" ><!--/partial partial differential -->
+<!ENTITY permil           "&#x02030;" ><!--per thousand -->
+<!ENTITY perp             "&#x022A5;" ><!--/perp R: perpendicular -->
+<!ENTITY pertenk          "&#x02031;" ><!--per 10 thousand -->
+<!ENTITY phmmat           "&#x02133;" ><!--physics M-matrix (script capital M)  -->
+<!ENTITY pointint         "&#x02A15;" ><!--integral around a point operator -->
+<!ENTITY Prime            "&#x02033;" ><!--double prime or second -->
+<!ENTITY prime            "&#x02032;" ><!--/prime prime or minute -->
+<!ENTITY profalar         "&#x0232E;" ><!--all-around profile -->
+<!ENTITY profline         "&#x02312;" ><!--profile of a line -->
+<!ENTITY profsurf         "&#x02313;" ><!--profile of a surface -->
+<!ENTITY prop             "&#x0221D;" ><!--/propto R: is proportional to -->
+<!ENTITY qint             "&#x02A0C;" ><!--/iiiint quadruple integral operator -->
+<!ENTITY qprime           "&#x02057;" ><!--quadruple prime -->
+<!ENTITY quatint          "&#x02A16;" ><!--quaternion integral operator -->
+<!ENTITY radic            "&#x0221A;" ><!--/surd radical -->
+<!ENTITY Rang             "&#x0300B;" ><!--right angle bracket, double -->
+<!ENTITY rang             "&#x0232A;" ><!--/rangle C: right angle bracket -->
+<!ENTITY rArr             "&#x021D2;" ><!--/Rightarrow A: implies -->
+<!ENTITY rbbrk            "&#x03015;" ><!--right broken bracket -->
+<!ENTITY roang            "&#x03019;" ><!--right open angular bracket -->
+<!ENTITY robrk            "&#x0301B;" ><!--right open bracket -->
+<!ENTITY ropar            "&#x02986;" ><!--right open parenthesis -->
+<!ENTITY rppolint         "&#x02A12;" ><!--line integration, rectangular path around pole -->
+<!ENTITY scpolint         "&#x02A13;" ><!--line integration, semi-circular path around pole -->
+<!ENTITY sim              "&#x0223C;" ><!--/sim R: similar -->
+<!ENTITY simdot           "&#x02A6A;" ><!--similar, dot -->
+<!ENTITY sime             "&#x02243;" ><!--/simeq R: similar, equals -->
+<!ENTITY smeparsl         "&#x029E4;" ><!--similar, parallel, slanted, equal -->
+<!ENTITY square           "&#x025A1;" ><!--/square, square -->
+<!ENTITY squarf           "&#x025AA;" ><!--/blacksquare, square, filled  -->
+<!ENTITY strns            "&#x000AF;" ><!--straightness -->
+<!ENTITY sub              "&#x02282;" ><!--/subset R: subset or is implied by -->
+<!ENTITY sube             "&#x02286;" ><!--/subseteq R: subset, equals -->
+<!ENTITY sup              "&#x02283;" ><!--/supset R: superset or implies -->
+<!ENTITY supe             "&#x02287;" ><!--/supseteq R: superset, equals -->
+<!ENTITY tdot             "&#x020DB;" ><!--three dots above -->
+<!ENTITY there4           "&#x02234;" ><!--/therefore R: therefore -->
+<!ENTITY tint             "&#x0222D;" ><!--/iiint triple integral operator -->
+<!ENTITY top              "&#x022A4;" ><!--/top top -->
+<!ENTITY topbot           "&#x02336;" ><!--top and bottom -->
+<!ENTITY topcir           "&#x02AF1;" ><!--top, circle below -->
+<!ENTITY tprime           "&#x02034;" ><!--triple prime -->
+<!ENTITY utdot            "&#x022F0;" ><!--three dots, ascending -->
+<!ENTITY uwangle          "&#x029A7;" ><!--large upward pointing angle -->
+<!ENTITY vangrt           "&#x0299C;" ><!--right angle, variant -->
+<!ENTITY veeeq            "&#x0225A;" ><!--logical or, equals -->
+<!ENTITY Verbar           "&#x02016;" ><!--/Vert dbl vertical bar -->
+<!ENTITY wedgeq           "&#x02259;" ><!--/wedgeq R: corresponds to (wedge, equals) -->
+<!ENTITY xnis             "&#x022FB;" ><!--large contains, vertical bar on horizontal stroke -->

--- a/src/main/resources/dtd/archiving/1.2/mathml/mmlalias.ent
+++ b/src/main/resources/dtd/archiving/1.2/mathml/mmlalias.ent
@@ -1,0 +1,564 @@
+
+<!--
+     File mmlalias.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     References to the VARIANT SELECTOR 1 character (&#x0FE00;)
+     should match the uses listed in Unicode Technical Report 25.
+
+-->
+
+<!ENTITY angle            "&#x02220;" ><!--alias ISOAMSO ang -->
+<!ENTITY ApplyFunction    "&#x02061;" ><!--character showing function application in presentation tagging -->
+<!ENTITY approx           "&#x02248;" ><!--alias ISOTECH ap -->
+<!ENTITY approxeq         "&#x0224A;" ><!--alias ISOAMSR ape -->
+<!ENTITY Assign           "&#x02254;" ><!--assignment operator, alias ISOAMSR colone -->
+<!ENTITY backcong         "&#x0224C;" ><!--alias ISOAMSR bcong -->
+<!ENTITY backepsilon      "&#x003F6;" ><!--alias ISOAMSR bepsi -->
+<!ENTITY backprime        "&#x02035;" ><!--alias ISOAMSO bprime -->
+<!ENTITY backsim          "&#x0223D;" ><!--alias ISOAMSR bsim -->
+<!ENTITY backsimeq        "&#x022CD;" ><!--alias ISOAMSR bsime -->
+<!ENTITY Backslash        "&#x02216;" ><!--alias ISOAMSB setmn -->
+<!ENTITY barwedge         "&#x02305;" ><!--alias ISOAMSB barwed -->
+<!ENTITY Because          "&#x02235;" ><!--alias ISOTECH becaus -->
+<!ENTITY because          "&#x02235;" ><!--alias ISOTECH becaus -->
+<!ENTITY Bernoullis       "&#x0212C;" ><!--alias ISOTECH bernou -->
+<!ENTITY between          "&#x0226C;" ><!--alias ISOAMSR twixt -->
+<!ENTITY bigcap           "&#x022C2;" ><!--alias ISOAMSB xcap -->
+<!ENTITY bigcirc          "&#x025EF;" ><!--alias ISOAMSB xcirc -->
+<!ENTITY bigcup           "&#x022C3;" ><!--alias ISOAMSB xcup -->
+<!ENTITY bigodot          "&#x02A00;" ><!--alias ISOAMSB xodot -->
+<!ENTITY bigoplus         "&#x02A01;" ><!--alias ISOAMSB xoplus -->
+<!ENTITY bigotimes        "&#x02A02;" ><!--alias ISOAMSB xotime -->
+<!ENTITY bigsqcup         "&#x02A06;" ><!--alias ISOAMSB xsqcup -->
+<!ENTITY bigstar          "&#x02605;" ><!--ISOPUB    starf  -->
+<!ENTITY bigtriangledown  "&#x025BD;" ><!--alias ISOAMSB xdtri -->
+<!ENTITY bigtriangleup    "&#x025B3;" ><!--alias ISOAMSB xutri -->
+<!ENTITY biguplus         "&#x02A04;" ><!--alias ISOAMSB xuplus -->
+<!ENTITY bigvee           "&#x022C1;" ><!--alias ISOAMSB xvee -->
+<!ENTITY bigwedge         "&#x022C0;" ><!--alias ISOAMSB xwedge -->
+<!ENTITY bkarow           "&#x0290D;" ><!--alias ISOAMSA rbarr -->
+<!ENTITY blacklozenge     "&#x029EB;" ><!--alias ISOPUB lozf -->
+<!ENTITY blacksquare      "&#x025AA;" ><!--ISOTECH  squarf  -->
+<!ENTITY blacktriangle    "&#x025B4;" ><!--alias ISOPUB utrif -->
+<!ENTITY blacktriangledown "&#x025BE;" ><!--alias ISOPUB dtrif -->
+<!ENTITY blacktriangleleft "&#x025C2;" ><!--alias ISOPUB ltrif -->
+<!ENTITY blacktriangleright "&#x025B8;" ><!--alias ISOPUB rtrif -->
+<!ENTITY bot              "&#x022A5;" ><!--alias ISOTECH bottom -->
+<!ENTITY boxminus         "&#x0229F;" ><!--alias ISOAMSB minusb -->
+<!ENTITY boxplus          "&#x0229E;" ><!--alias ISOAMSB plusb -->
+<!ENTITY boxtimes         "&#x022A0;" ><!--alias ISOAMSB timesb -->
+<!ENTITY Breve            "&#x002D8;" ><!--alias ISODIA breve -->
+<!ENTITY bullet           "&#x02022;" ><!--alias ISOPUB bull -->
+<!ENTITY Bumpeq           "&#x0224E;" ><!--alias ISOAMSR bump -->
+<!ENTITY bumpeq           "&#x0224F;" ><!--alias ISOAMSR bumpe -->
+<!ENTITY CapitalDifferentialD "&#x02145;" ><!--D for use in differentials, e.g., within integrals -->
+<!ENTITY Cayleys          "&#x0212D;" ><!--the non-associative ring of octonions or Cayley numbers -->
+<!ENTITY Cedilla          "&#x000B8;" ><!--alias ISODIA cedil -->
+<!ENTITY CenterDot        "&#x000B7;" ><!--alias ISONUM middot -->
+<!ENTITY centerdot        "&#x000B7;" ><!--alias ISONUM middot -->
+<!ENTITY checkmark        "&#x02713;" ><!--alias ISOPUB check -->
+<!ENTITY circeq           "&#x02257;" ><!--alias ISOAMSR cire -->
+<!ENTITY circlearrowleft  "&#x021BA;" ><!--alias ISOAMSA olarr -->
+<!ENTITY circlearrowright "&#x021BB;" ><!--alias ISOAMSA orarr -->
+<!ENTITY circledast       "&#x0229B;" ><!--alias ISOAMSB oast -->
+<!ENTITY circledcirc      "&#x0229A;" ><!--alias ISOAMSB ocir -->
+<!ENTITY circleddash      "&#x0229D;" ><!--alias ISOAMSB odash -->
+<!ENTITY CircleDot        "&#x02299;" ><!--alias ISOAMSB odot -->
+<!ENTITY circledR         "&#x000AE;" ><!--alias ISONUM reg -->
+<!ENTITY circledS         "&#x024C8;" ><!--alias ISOAMSO oS -->
+<!ENTITY CircleMinus      "&#x02296;" ><!--alias ISOAMSB ominus -->
+<!ENTITY CirclePlus       "&#x02295;" ><!--alias ISOAMSB oplus -->
+<!ENTITY CircleTimes      "&#x02297;" ><!--alias ISOAMSB otimes -->
+<!ENTITY ClockwiseContourIntegral "&#x02232;" ><!--alias ISOTECH cwconint -->
+<!ENTITY CloseCurlyDoubleQuote "&#x0201D;" ><!--alias ISONUM rdquo -->
+<!ENTITY CloseCurlyQuote  "&#x02019;" ><!--alias ISONUM rsquo -->
+<!ENTITY clubsuit         "&#x02663;" ><!--ISOPUB    clubs  -->
+<!ENTITY coloneq          "&#x02254;" ><!--alias ISOAMSR colone -->
+<!ENTITY complement       "&#x02201;" ><!--alias ISOAMSO comp -->
+<!ENTITY complexes        "&#x02102;" ><!--the field of complex numbers -->
+<!ENTITY Congruent        "&#x02261;" ><!--alias ISOTECH equiv -->
+<!ENTITY ContourIntegral  "&#x0222E;" ><!--alias ISOTECH conint -->
+<!ENTITY Coproduct        "&#x02210;" ><!--alias ISOAMSB coprod -->
+<!ENTITY CounterClockwiseContourIntegral "&#x02233;" ><!--alias ISOTECH awconint -->
+<!ENTITY CupCap           "&#x0224D;" ><!--alias asympeq -->
+<!ENTITY curlyeqprec      "&#x022DE;" ><!--alias ISOAMSR cuepr -->
+<!ENTITY curlyeqsucc      "&#x022DF;" ><!--alias ISOAMSR cuesc -->
+<!ENTITY curlyvee         "&#x022CE;" ><!--alias ISOAMSB cuvee -->
+<!ENTITY curlywedge       "&#x022CF;" ><!--alias ISOAMSB cuwed -->
+<!ENTITY curvearrowleft   "&#x021B6;" ><!--alias ISOAMSA cularr -->
+<!ENTITY curvearrowright  "&#x021B7;" ><!--alias ISOAMSA curarr -->
+<!ENTITY dbkarow          "&#x0290F;" ><!--alias ISOAMSA rBarr -->
+<!ENTITY ddagger          "&#x02021;" ><!--alias ISOPUB Dagger -->
+<!ENTITY ddotseq          "&#x02A77;" ><!--alias ISOAMSR eDDot -->
+<!ENTITY Del              "&#x02207;" ><!--alias ISOTECH nabla -->
+<!ENTITY DiacriticalAcute "&#x000B4;" ><!--alias ISODIA acute -->
+<!ENTITY DiacriticalDot   "&#x002D9;" ><!--alias ISODIA dot -->
+<!ENTITY DiacriticalDoubleAcute "&#x002DD;" ><!--alias ISODIA dblac -->
+<!ENTITY DiacriticalGrave "&#x00060;" ><!--alias ISODIA grave -->
+<!ENTITY DiacriticalTilde "&#x002DC;" ><!--alias ISODIA tilde -->
+<!ENTITY Diamond          "&#x022C4;" ><!--alias ISOAMSB diam -->
+<!ENTITY diamond          "&#x022C4;" ><!--alias ISOAMSB diam -->
+<!ENTITY diamondsuit      "&#x02666;" ><!--ISOPUB    diams  -->
+<!ENTITY DifferentialD    "&#x02146;" ><!--d for use in differentials, e.g., within integrals -->
+<!ENTITY digamma          "&#x003DD;" ><!--alias ISOGRK3 gammad -->
+<!ENTITY div              "&#x000F7;" ><!--alias ISONUM divide -->
+<!ENTITY divideontimes    "&#x022C7;" ><!--alias ISOAMSB divonx -->
+<!ENTITY doteq            "&#x02250;" ><!--alias ISOAMSR esdot -->
+<!ENTITY doteqdot         "&#x02251;" ><!--alias ISOAMSR eDot -->
+<!ENTITY DotEqual         "&#x02250;" ><!--alias ISOAMSR esdot -->
+<!ENTITY dotminus         "&#x02238;" ><!--alias ISOAMSB minusd -->
+<!ENTITY dotplus          "&#x02214;" ><!--alias ISOAMSB plusdo -->
+<!ENTITY dotsquare        "&#x022A1;" ><!--alias ISOAMSB sdotb -->
+<!ENTITY doublebarwedge   "&#x02306;" ><!--alias ISOAMSB Barwed -->
+<!ENTITY DoubleContourIntegral "&#x0222F;" ><!--alias ISOTECH Conint -->
+<!ENTITY DoubleDot        "&#x000A8;" ><!--alias ISODIA die -->
+<!ENTITY DoubleDownArrow  "&#x021D3;" ><!--alias ISOAMSA dArr -->
+<!ENTITY DoubleLeftArrow  "&#x021D0;" ><!--alias ISOTECH lArr -->
+<!ENTITY DoubleLeftRightArrow "&#x021D4;" ><!--alias ISOAMSA hArr -->
+<!ENTITY DoubleLeftTee    "&#x02AE4;" ><!--alias for  &Dashv;  -->
+<!ENTITY DoubleLongLeftArrow "&#x027F8;" ><!--alias ISOAMSA xlArr -->
+<!ENTITY DoubleLongLeftRightArrow "&#x027FA;" ><!--alias ISOAMSA xhArr -->
+<!ENTITY DoubleLongRightArrow "&#x027F9;" ><!--alias ISOAMSA xrArr -->
+<!ENTITY DoubleRightArrow "&#x021D2;" ><!--alias ISOTECH rArr -->
+<!ENTITY DoubleRightTee   "&#x022A8;" ><!--alias ISOAMSR vDash -->
+<!ENTITY DoubleUpArrow    "&#x021D1;" ><!--alias ISOAMSA uArr -->
+<!ENTITY DoubleUpDownArrow "&#x021D5;" ><!--alias ISOAMSA vArr -->
+<!ENTITY DoubleVerticalBar "&#x02225;" ><!--alias ISOTECH par -->
+<!ENTITY DownArrow        "&#x02193;" ><!--alias ISONUM darr -->
+<!ENTITY Downarrow        "&#x021D3;" ><!--alias ISOAMSA dArr -->
+<!ENTITY downarrow        "&#x02193;" ><!--alias ISONUM darr -->
+<!ENTITY DownArrowUpArrow "&#x021F5;" ><!--alias ISOAMSA duarr -->
+<!ENTITY downdownarrows   "&#x021CA;" ><!--alias ISOAMSA ddarr -->
+<!ENTITY downharpoonleft  "&#x021C3;" ><!--alias ISOAMSA dharl -->
+<!ENTITY downharpoonright "&#x021C2;" ><!--alias ISOAMSA dharr -->
+<!ENTITY DownLeftVector   "&#x021BD;" ><!--alias ISOAMSA lhard -->
+<!ENTITY DownRightVector  "&#x021C1;" ><!--alias ISOAMSA rhard -->
+<!ENTITY DownTee          "&#x022A4;" ><!--alias ISOTECH top -->
+<!ENTITY DownTeeArrow     "&#x021A7;" ><!--alias for mapstodown -->
+<!ENTITY drbkarow         "&#x02910;" ><!--alias ISOAMSA RBarr -->
+<!ENTITY Element          "&#x02208;" ><!--alias ISOTECH isinv -->
+<!ENTITY emptyset         "&#x02205;" ><!--alias ISOAMSO empty -->
+<!ENTITY eqcirc           "&#x02256;" ><!--alias ISOAMSR ecir -->
+<!ENTITY eqcolon          "&#x02255;" ><!--alias ISOAMSR ecolon -->
+<!ENTITY eqsim            "&#x02242;" ><!--alias ISOAMSR esim -->
+<!ENTITY eqslantgtr       "&#x02A96;" ><!--alias ISOAMSR egs -->
+<!ENTITY eqslantless      "&#x02A95;" ><!--alias ISOAMSR els -->
+<!ENTITY EqualTilde       "&#x02242;" ><!--alias ISOAMSR esim -->
+<!ENTITY Equilibrium      "&#x021CC;" ><!--alias ISOAMSA rlhar -->
+<!ENTITY Exists           "&#x02203;" ><!--alias ISOTECH exist -->
+<!ENTITY expectation      "&#x02130;" ><!--expectation (operator) -->
+<!ENTITY ExponentialE     "&#x02147;" ><!--e use for the exponential base of the natural logarithms -->
+<!ENTITY exponentiale     "&#x02147;" ><!--base of the Napierian logarithms -->
+<!ENTITY fallingdotseq    "&#x02252;" ><!--alias ISOAMSR efDot -->
+<!ENTITY ForAll           "&#x02200;" ><!--alias ISOTECH forall -->
+<!ENTITY Fouriertrf       "&#x02131;" ><!--Fourier transform -->
+<!ENTITY geq              "&#x02265;" ><!--alias ISOTECH ge -->
+<!ENTITY geqq             "&#x02267;" ><!--alias ISOAMSR gE -->
+<!ENTITY geqslant         "&#x02A7E;" ><!--alias ISOAMSR ges -->
+<!ENTITY gg               "&#x0226B;" ><!--alias ISOAMSR Gt -->
+<!ENTITY ggg              "&#x022D9;" ><!--alias ISOAMSR Gg -->
+<!ENTITY gnapprox         "&#x02A8A;" ><!--alias ISOAMSN gnap -->
+<!ENTITY gneq             "&#x02A88;" ><!--alias ISOAMSN gne -->
+<!ENTITY gneqq            "&#x02269;" ><!--alias ISOAMSN gnE -->
+<!ENTITY GreaterEqual     "&#x02265;" ><!--alias ISOTECH ge -->
+<!ENTITY GreaterEqualLess "&#x022DB;" ><!--alias ISOAMSR gel -->
+<!ENTITY GreaterFullEqual "&#x02267;" ><!--alias ISOAMSR gE -->
+<!ENTITY GreaterLess      "&#x02277;" ><!--alias ISOAMSR gl -->
+<!ENTITY GreaterSlantEqual "&#x02A7E;" ><!--alias ISOAMSR ges -->
+<!ENTITY GreaterTilde     "&#x02273;" ><!--alias ISOAMSR gsim -->
+<!ENTITY gtrapprox        "&#x02A86;" ><!--alias ISOAMSR gap -->
+<!ENTITY gtrdot           "&#x022D7;" ><!--alias ISOAMSR gtdot -->
+<!ENTITY gtreqless        "&#x022DB;" ><!--alias ISOAMSR gel -->
+<!ENTITY gtreqqless       "&#x02A8C;" ><!--alias ISOAMSR gEl -->
+<!ENTITY gtrless          "&#x02277;" ><!--alias ISOAMSR gl -->
+<!ENTITY gtrsim           "&#x02273;" ><!--alias ISOAMSR gsim -->
+<!ENTITY gvertneqq        "&#x02269;&#x0FE00;" ><!--alias ISOAMSN gvnE -->
+<!ENTITY Hacek            "&#x002C7;" ><!--alias ISODIA caron -->
+<!ENTITY hbar             "&#x0210F;" ><!--alias ISOAMSO plank -->
+<!ENTITY heartsuit        "&#x02665;" ><!--ISOPUB hearts -->
+<!ENTITY HilbertSpace     "&#x0210B;" ><!--Hilbert space -->
+<!ENTITY hksearow         "&#x02925;" ><!--alias ISOAMSA searhk -->
+<!ENTITY hkswarow         "&#x02926;" ><!--alias ISOAMSA swarhk -->
+<!ENTITY hookleftarrow    "&#x021A9;" ><!--alias ISOAMSA larrhk -->
+<!ENTITY hookrightarrow   "&#x021AA;" ><!--alias ISOAMSA rarrhk -->
+<!ENTITY hslash           "&#x0210F;" ><!--alias ISOAMSO plankv -->
+<!ENTITY HumpDownHump     "&#x0224E;" ><!--alias ISOAMSR bump -->
+<!ENTITY HumpEqual        "&#x0224F;" ><!--alias ISOAMSR bumpe -->
+<!ENTITY iiiint           "&#x02A0C;" ><!--alias ISOTECH qint -->
+<!ENTITY iiint            "&#x0222D;" ><!--alias ISOTECH tint -->
+<!ENTITY Im               "&#x02111;" ><!--alias ISOAMSO image -->
+<!ENTITY ImaginaryI       "&#x02148;" ><!--i for use as a square root of -1 -->
+<!ENTITY imagline         "&#x02110;" ><!--the geometric imaginary line -->
+<!ENTITY imagpart         "&#x02111;" ><!--alias ISOAMSO image -->
+<!ENTITY Implies          "&#x021D2;" ><!--alias ISOTECH rArr -->
+<!ENTITY in               "&#x02208;" ><!--ISOTECH   isin  -->
+<!ENTITY integers         "&#x02124;" ><!--the ring of integers -->
+<!ENTITY Integral         "&#x0222B;" ><!--alias ISOTECH int -->
+<!ENTITY intercal         "&#x022BA;" ><!--alias ISOAMSB intcal -->
+<!ENTITY Intersection     "&#x022C2;" ><!--alias ISOAMSB xcap -->
+<!ENTITY intprod          "&#x02A3C;" ><!--alias ISOAMSB iprod -->
+<!ENTITY InvisibleComma   "&#x02063;" ><!--used as a separator, e.g., in indices -->
+<!ENTITY InvisibleTimes   "&#x02062;" ><!--marks multiplication when it is understood without a mark -->
+<!ENTITY langle           "&#x02329;" ><!--alias ISOTECH lang -->
+<!ENTITY Laplacetrf       "&#x02112;" ><!--Laplace transform -->
+<!ENTITY lbrace           "&#x0007B;" ><!--alias ISONUM lcub -->
+<!ENTITY lbrack           "&#x0005B;" ><!--alias ISONUM lsqb -->
+<!ENTITY LeftAngleBracket "&#x02329;" ><!--alias ISOTECH lang -->
+<!ENTITY LeftArrow        "&#x02190;" ><!--alias ISONUM larr -->
+<!ENTITY Leftarrow        "&#x021D0;" ><!--alias ISOTECH lArr -->
+<!ENTITY leftarrow        "&#x02190;" ><!--alias ISONUM larr -->
+<!ENTITY LeftArrowBar     "&#x021E4;" ><!--alias for larrb -->
+<!ENTITY LeftArrowRightArrow "&#x021C6;" ><!--alias ISOAMSA lrarr -->
+<!ENTITY leftarrowtail    "&#x021A2;" ><!--alias ISOAMSA larrtl -->
+<!ENTITY LeftCeiling      "&#x02308;" ><!--alias ISOAMSC lceil -->
+<!ENTITY LeftDoubleBracket "&#x0301A;" ><!--left double bracket delimiter -->
+<!ENTITY LeftDownVector   "&#x021C3;" ><!--alias ISOAMSA dharl -->
+<!ENTITY LeftFloor        "&#x0230A;" ><!--alias ISOAMSC lfloor -->
+<!ENTITY leftharpoondown  "&#x021BD;" ><!--alias ISOAMSA lhard -->
+<!ENTITY leftharpoonup    "&#x021BC;" ><!--alias ISOAMSA lharu -->
+<!ENTITY leftleftarrows   "&#x021C7;" ><!--alias ISOAMSA llarr -->
+<!ENTITY LeftRightArrow   "&#x02194;" ><!--alias ISOAMSA harr -->
+<!ENTITY Leftrightarrow   "&#x021D4;" ><!--alias ISOAMSA hArr -->
+<!ENTITY leftrightarrow   "&#x02194;" ><!--alias ISOAMSA harr -->
+<!ENTITY leftrightarrows  "&#x021C6;" ><!--alias ISOAMSA lrarr -->
+<!ENTITY leftrightharpoons "&#x021CB;" ><!--alias ISOAMSA lrhar -->
+<!ENTITY leftrightsquigarrow "&#x021AD;" ><!--alias ISOAMSA harrw -->
+<!ENTITY LeftTee          "&#x022A3;" ><!--alias ISOAMSR dashv -->
+<!ENTITY LeftTeeArrow     "&#x021A4;" ><!--alias for mapstoleft -->
+<!ENTITY leftthreetimes   "&#x022CB;" ><!--alias ISOAMSB lthree -->
+<!ENTITY LeftTriangle     "&#x022B2;" ><!--alias ISOAMSR vltri -->
+<!ENTITY LeftTriangleEqual "&#x022B4;" ><!--alias ISOAMSR ltrie -->
+<!ENTITY LeftUpVector     "&#x021BF;" ><!--alias ISOAMSA uharl -->
+<!ENTITY LeftVector       "&#x021BC;" ><!--alias ISOAMSA lharu -->
+<!ENTITY leq              "&#x02264;" ><!--alias ISOTECH le -->
+<!ENTITY leqq             "&#x02266;" ><!--alias ISOAMSR lE -->
+<!ENTITY leqslant         "&#x02A7D;" ><!--alias ISOAMSR les -->
+<!ENTITY lessapprox       "&#x02A85;" ><!--alias ISOAMSR lap -->
+<!ENTITY lessdot          "&#x022D6;" ><!--alias ISOAMSR ltdot -->
+<!ENTITY lesseqgtr        "&#x022DA;" ><!--alias ISOAMSR leg -->
+<!ENTITY lesseqqgtr       "&#x02A8B;" ><!--alias ISOAMSR lEg -->
+<!ENTITY LessEqualGreater "&#x022DA;" ><!--alias ISOAMSR leg -->
+<!ENTITY LessFullEqual    "&#x02266;" ><!--alias ISOAMSR lE -->
+<!ENTITY LessGreater      "&#x02276;" ><!--alias ISOAMSR lg -->
+<!ENTITY lessgtr          "&#x02276;" ><!--alias ISOAMSR lg -->
+<!ENTITY lesssim          "&#x02272;" ><!--alias ISOAMSR lsim -->
+<!ENTITY LessSlantEqual   "&#x02A7D;" ><!--alias ISOAMSR les -->
+<!ENTITY LessTilde        "&#x02272;" ><!--alias ISOAMSR lsim -->
+<!ENTITY ll               "&#x0226A;" ><!--alias ISOAMSR Lt -->
+<!ENTITY llcorner         "&#x0231E;" ><!--alias ISOAMSC dlcorn -->
+<!ENTITY Lleftarrow       "&#x021DA;" ><!--alias ISOAMSA lAarr -->
+<!ENTITY lmoustache       "&#x023B0;" ><!--alias ISOAMSC lmoust -->
+<!ENTITY lnapprox         "&#x02A89;" ><!--alias ISOAMSN lnap -->
+<!ENTITY lneq             "&#x02A87;" ><!--alias ISOAMSN lne -->
+<!ENTITY lneqq            "&#x02268;" ><!--alias ISOAMSN lnE -->
+<!ENTITY LongLeftArrow    "&#x027F5;" ><!--alias ISOAMSA xlarr -->
+<!ENTITY Longleftarrow    "&#x027F8;" ><!--alias ISOAMSA xlArr -->
+<!ENTITY longleftarrow    "&#x027F5;" ><!--alias ISOAMSA xlarr -->
+<!ENTITY LongLeftRightArrow "&#x027F7;" ><!--alias ISOAMSA xharr -->
+<!ENTITY Longleftrightarrow "&#x027FA;" ><!--alias ISOAMSA xhArr -->
+<!ENTITY longleftrightarrow "&#x027F7;" ><!--alias ISOAMSA xharr -->
+<!ENTITY longmapsto       "&#x027FC;" ><!--alias ISOAMSA xmap -->
+<!ENTITY LongRightArrow   "&#x027F6;" ><!--alias ISOAMSA xrarr -->
+<!ENTITY Longrightarrow   "&#x027F9;" ><!--alias ISOAMSA xrArr -->
+<!ENTITY longrightarrow   "&#x027F6;" ><!--alias ISOAMSA xrarr -->
+<!ENTITY looparrowleft    "&#x021AB;" ><!--alias ISOAMSA larrlp -->
+<!ENTITY looparrowright   "&#x021AC;" ><!--alias ISOAMSA rarrlp -->
+<!ENTITY LowerLeftArrow   "&#x02199;" ><!--alias ISOAMSA swarr -->
+<!ENTITY LowerRightArrow  "&#x02198;" ><!--alias ISOAMSA searr -->
+<!ENTITY lozenge          "&#x025CA;" ><!--alias ISOPUB loz -->
+<!ENTITY lrcorner         "&#x0231F;" ><!--alias ISOAMSC drcorn -->
+<!ENTITY Lsh              "&#x021B0;" ><!--alias ISOAMSA lsh -->
+<!ENTITY lvertneqq        "&#x02268;&#x0FE00;" ><!--alias ISOAMSN lvnE -->
+<!ENTITY maltese          "&#x02720;" ><!--alias ISOPUB malt -->
+<!ENTITY mapsto           "&#x021A6;" ><!--alias ISOAMSA map -->
+<!ENTITY measuredangle    "&#x02221;" ><!--alias ISOAMSO angmsd -->
+<!ENTITY Mellintrf        "&#x02133;" ><!--Mellin transform -->
+<!ENTITY MinusPlus        "&#x02213;" ><!--alias ISOTECH mnplus -->
+<!ENTITY mp               "&#x02213;" ><!--alias ISOTECH mnplus -->
+<!ENTITY multimap         "&#x022B8;" ><!--alias ISOAMSA mumap -->
+<!ENTITY napprox          "&#x02249;" ><!--alias ISOAMSN nap -->
+<!ENTITY natural          "&#x0266E;" ><!--alias ISOPUB natur -->
+<!ENTITY naturals         "&#x02115;" ><!--the semi-ring of natural numbers -->
+<!ENTITY nearrow          "&#x02197;" ><!--alias ISOAMSA nearr -->
+<!ENTITY NegativeMediumSpace "&#x0200B;" ><!--space of width -4/18 em -->
+<!ENTITY NegativeThickSpace "&#x0200B;" ><!--space of width -5/18 em -->
+<!ENTITY NegativeThinSpace "&#x0200B;" ><!--space of width -3/18 em -->
+<!ENTITY NegativeVeryThinSpace "&#x0200B;" ><!--space of width -1/18 em -->
+<!ENTITY NestedGreaterGreater "&#x0226B;" ><!--alias ISOAMSR Gt -->
+<!ENTITY NestedLessLess   "&#x0226A;" ><!--alias ISOAMSR Lt -->
+<!ENTITY nexists          "&#x02204;" ><!--alias ISOAMSO nexist -->
+<!ENTITY ngeq             "&#x02271;" ><!--alias ISOAMSN nge -->
+<!ENTITY ngeqq            "&#x02267;&#x00338;" ><!--alias ISOAMSN ngE -->
+<!ENTITY ngeqslant        "&#x02A7E;&#x00338;" ><!--alias ISOAMSN nges -->
+<!ENTITY ngtr             "&#x0226F;" ><!--alias ISOAMSN ngt -->
+<!ENTITY nLeftarrow       "&#x021CD;" ><!--alias ISOAMSA nlArr -->
+<!ENTITY nleftarrow       "&#x0219A;" ><!--alias ISOAMSA nlarr -->
+<!ENTITY nLeftrightarrow  "&#x021CE;" ><!--alias ISOAMSA nhArr -->
+<!ENTITY nleftrightarrow  "&#x021AE;" ><!--alias ISOAMSA nharr -->
+<!ENTITY nleq             "&#x02270;" ><!--alias ISOAMSN nle -->
+<!ENTITY nleqq            "&#x02266;&#x00338;" ><!--alias ISOAMSN nlE -->
+<!ENTITY nleqslant        "&#x02A7D;&#x00338;" ><!--alias ISOAMSN nles -->
+<!ENTITY nless            "&#x0226E;" ><!--alias ISOAMSN nlt -->
+<!ENTITY NonBreakingSpace "&#x000A0;" ><!--alias ISONUM nbsp -->
+<!ENTITY NotCongruent     "&#x02262;" ><!--alias ISOAMSN nequiv -->
+<!ENTITY NotDoubleVerticalBar "&#x02226;" ><!--alias ISOAMSN npar -->
+<!ENTITY NotElement       "&#x02209;" ><!--alias ISOTECH notin -->
+<!ENTITY NotEqual         "&#x02260;" ><!--alias ISOTECH ne -->
+<!ENTITY NotEqualTilde    "&#x02242;&#x00338;" ><!--alias for  &nesim; -->
+<!ENTITY NotExists        "&#x02204;" ><!--alias ISOAMSO nexist -->
+<!ENTITY NotGreater       "&#x0226F;" ><!--alias ISOAMSN ngt -->
+<!ENTITY NotGreaterEqual  "&#x02271;" ><!--alias ISOAMSN nge -->
+<!ENTITY NotGreaterFullEqual "&#x02266;&#x00338;" ><!--alias ISOAMSN nlE -->
+<!ENTITY NotGreaterGreater "&#x0226B;&#x00338;" ><!--alias ISOAMSN nGtv -->
+<!ENTITY NotGreaterLess   "&#x02279;" ><!--alias ISOAMSN ntvgl -->
+<!ENTITY NotGreaterSlantEqual "&#x02A7E;&#x00338;" ><!--alias ISOAMSN nges -->
+<!ENTITY NotGreaterTilde  "&#x02275;" ><!--alias ISOAMSN ngsim -->
+<!ENTITY NotHumpDownHump  "&#x0224E;&#x00338;" ><!--alias for &nbump; -->
+<!ENTITY NotLeftTriangle  "&#x022EA;" ><!--alias ISOAMSN nltri -->
+<!ENTITY NotLeftTriangleEqual "&#x022EC;" ><!--alias ISOAMSN nltrie -->
+<!ENTITY NotLess          "&#x0226E;" ><!--alias ISOAMSN nlt -->
+<!ENTITY NotLessEqual     "&#x02270;" ><!--alias ISOAMSN nle -->
+<!ENTITY NotLessGreater   "&#x02278;" ><!--alias ISOAMSN ntvlg -->
+<!ENTITY NotLessLess      "&#x0226A;&#x00338;" ><!--alias ISOAMSN nLtv -->
+<!ENTITY NotLessSlantEqual "&#x02A7D;&#x00338;" ><!--alias ISOAMSN nles -->
+<!ENTITY NotLessTilde     "&#x02274;" ><!--alias ISOAMSN nlsim -->
+<!ENTITY NotPrecedes      "&#x02280;" ><!--alias ISOAMSN npr -->
+<!ENTITY NotPrecedesEqual "&#x02AAF;&#x00338;" ><!--alias ISOAMSN npre -->
+<!ENTITY NotPrecedesSlantEqual "&#x022E0;" ><!--alias ISOAMSN nprcue -->
+<!ENTITY NotReverseElement "&#x0220C;" ><!--alias ISOTECH notniva -->
+<!ENTITY NotRightTriangle "&#x022EB;" ><!--alias ISOAMSN nrtri -->
+<!ENTITY NotRightTriangleEqual "&#x022ED;" ><!--alias ISOAMSN nrtrie -->
+<!ENTITY NotSquareSubsetEqual "&#x022E2;" ><!--alias ISOAMSN nsqsube -->
+<!ENTITY NotSquareSupersetEqual "&#x022E3;" ><!--alias ISOAMSN nsqsupe -->
+<!ENTITY NotSubset        "&#x02282;&#x020D2;" ><!--alias ISOAMSN vnsub -->
+<!ENTITY NotSubsetEqual   "&#x02288;" ><!--alias ISOAMSN nsube -->
+<!ENTITY NotSucceeds      "&#x02281;" ><!--alias ISOAMSN nsc -->
+<!ENTITY NotSucceedsEqual "&#x02AB0;&#x00338;" ><!--alias ISOAMSN nsce -->
+<!ENTITY NotSucceedsSlantEqual "&#x022E1;" ><!--alias ISOAMSN nsccue -->
+<!ENTITY NotSuperset      "&#x02283;&#x020D2;" ><!--alias ISOAMSN vnsup -->
+<!ENTITY NotSupersetEqual "&#x02289;" ><!--alias ISOAMSN nsupe -->
+<!ENTITY NotTilde         "&#x02241;" ><!--alias ISOAMSN nsim -->
+<!ENTITY NotTildeEqual    "&#x02244;" ><!--alias ISOAMSN nsime -->
+<!ENTITY NotTildeFullEqual "&#x02247;" ><!--alias ISOAMSN ncong -->
+<!ENTITY NotTildeTilde    "&#x02249;" ><!--alias ISOAMSN nap -->
+<!ENTITY NotVerticalBar   "&#x02224;" ><!--alias ISOAMSN nmid -->
+<!ENTITY nparallel        "&#x02226;" ><!--alias ISOAMSN npar -->
+<!ENTITY nprec            "&#x02280;" ><!--alias ISOAMSN npr -->
+<!ENTITY npreceq          "&#x02AAF;&#x00338;" ><!--alias ISOAMSN npre -->
+<!ENTITY nRightarrow      "&#x021CF;" ><!--alias ISOAMSA nrArr -->
+<!ENTITY nrightarrow      "&#x0219B;" ><!--alias ISOAMSA nrarr -->
+<!ENTITY nshortmid        "&#x02224;" ><!--alias ISOAMSN nsmid -->
+<!ENTITY nshortparallel   "&#x02226;" ><!--alias ISOAMSN nspar -->
+<!ENTITY nsimeq           "&#x02244;" ><!--alias ISOAMSN nsime -->
+<!ENTITY nsubset          "&#x02282;&#x020D2;" ><!--alias ISOAMSN vnsub -->
+<!ENTITY nsubseteq        "&#x02288;" ><!--alias ISOAMSN nsube -->
+<!ENTITY nsubseteqq       "&#x02AC5;&#x00338;" ><!--alias ISOAMSN nsubE -->
+<!ENTITY nsucc            "&#x02281;" ><!--alias ISOAMSN nsc -->
+<!ENTITY nsucceq          "&#x02AB0;&#x00338;" ><!--alias ISOAMSN nsce -->
+<!ENTITY nsupset          "&#x02283;&#x020D2;" ><!--alias ISOAMSN vnsup -->
+<!ENTITY nsupseteq        "&#x02289;" ><!--alias ISOAMSN nsupe -->
+<!ENTITY nsupseteqq       "&#x02AC6;&#x00338;" ><!--alias ISOAMSN nsupE -->
+<!ENTITY ntriangleleft    "&#x022EA;" ><!--alias ISOAMSN nltri -->
+<!ENTITY ntrianglelefteq  "&#x022EC;" ><!--alias ISOAMSN nltrie -->
+<!ENTITY ntriangleright   "&#x022EB;" ><!--alias ISOAMSN nrtri -->
+<!ENTITY ntrianglerighteq "&#x022ED;" ><!--alias ISOAMSN nrtrie -->
+<!ENTITY nwarrow          "&#x02196;" ><!--alias ISOAMSA nwarr -->
+<!ENTITY oint             "&#x0222E;" ><!--alias ISOTECH conint -->
+<!ENTITY OpenCurlyDoubleQuote "&#x0201C;" ><!--alias ISONUM ldquo -->
+<!ENTITY OpenCurlyQuote   "&#x02018;" ><!--alias ISONUM lsquo -->
+<!ENTITY orderof          "&#x02134;" ><!--alias ISOTECH order -->
+<!ENTITY parallel         "&#x02225;" ><!--alias ISOTECH par -->
+<!ENTITY PartialD         "&#x02202;" ><!--alias ISOTECH part -->
+<!ENTITY pitchfork        "&#x022D4;" ><!--alias ISOAMSR fork -->
+<!ENTITY PlusMinus        "&#x000B1;" ><!--alias ISONUM plusmn -->
+<!ENTITY pm               "&#x000B1;" ><!--alias ISONUM plusmn -->
+<!ENTITY Poincareplane    "&#x0210C;" ><!--the Poincare upper half-plane -->
+<!ENTITY prec             "&#x0227A;" ><!--alias ISOAMSR pr -->
+<!ENTITY precapprox       "&#x02AB7;" ><!--alias ISOAMSR prap -->
+<!ENTITY preccurlyeq      "&#x0227C;" ><!--alias ISOAMSR prcue -->
+<!ENTITY Precedes         "&#x0227A;" ><!--alias ISOAMSR pr -->
+<!ENTITY PrecedesEqual    "&#x02AAF;" ><!--alias ISOAMSR pre -->
+<!ENTITY PrecedesSlantEqual "&#x0227C;" ><!--alias ISOAMSR prcue -->
+<!ENTITY PrecedesTilde    "&#x0227E;" ><!--alias ISOAMSR prsim -->
+<!ENTITY preceq           "&#x02AAF;" ><!--alias ISOAMSR pre -->
+<!ENTITY precnapprox      "&#x02AB9;" ><!--alias ISOAMSN prnap -->
+<!ENTITY precneqq         "&#x02AB5;" ><!--alias ISOAMSN prnE -->
+<!ENTITY precnsim         "&#x022E8;" ><!--alias ISOAMSN prnsim -->
+<!ENTITY precsim          "&#x0227E;" ><!--alias ISOAMSR prsim -->
+<!ENTITY primes           "&#x02119;" ><!--the prime natural numbers -->
+<!ENTITY Proportion       "&#x02237;" ><!--alias ISOAMSR Colon -->
+<!ENTITY Proportional     "&#x0221D;" ><!--alias ISOTECH prop -->
+<!ENTITY propto           "&#x0221D;" ><!--alias ISOTECH prop -->
+<!ENTITY quaternions      "&#x0210D;" ><!--the ring (skew field) of quaternions -->
+<!ENTITY questeq          "&#x0225F;" ><!--alias ISOAMSR equest -->
+<!ENTITY rangle           "&#x0232A;" ><!--alias ISOTECH rang -->
+<!ENTITY rationals        "&#x0211A;" ><!--the field of rational numbers -->
+<!ENTITY rbrace           "&#x0007D;" ><!--alias ISONUM rcub -->
+<!ENTITY rbrack           "&#x0005D;" ><!--alias ISONUM rsqb -->
+<!ENTITY Re               "&#x0211C;" ><!--alias ISOAMSO real -->
+<!ENTITY realine          "&#x0211B;" ><!--the geometric real line -->
+<!ENTITY realpart         "&#x0211C;" ><!--alias ISOAMSO real -->
+<!ENTITY reals            "&#x0211D;" ><!--the field of real numbers -->
+<!ENTITY ReverseElement   "&#x0220B;" ><!--alias ISOTECH niv -->
+<!ENTITY ReverseEquilibrium "&#x021CB;" ><!--alias ISOAMSA lrhar -->
+<!ENTITY ReverseUpEquilibrium "&#x0296F;" ><!--alias ISOAMSA duhar -->
+<!ENTITY RightAngleBracket "&#x0232A;" ><!--alias ISOTECH rang -->
+<!ENTITY RightArrow       "&#x02192;" ><!--alias ISONUM rarr -->
+<!ENTITY Rightarrow       "&#x021D2;" ><!--alias ISOTECH rArr -->
+<!ENTITY rightarrow       "&#x02192;" ><!--alias ISONUM rarr -->
+<!ENTITY RightArrowBar    "&#x021E5;" ><!--alias for rarrb -->
+<!ENTITY RightArrowLeftArrow "&#x021C4;" ><!--alias ISOAMSA rlarr -->
+<!ENTITY rightarrowtail   "&#x021A3;" ><!--alias ISOAMSA rarrtl -->
+<!ENTITY RightCeiling     "&#x02309;" ><!--alias ISOAMSC rceil -->
+<!ENTITY RightDoubleBracket "&#x0301B;" ><!--right double bracket delimiter -->
+<!ENTITY RightDownVector  "&#x021C2;" ><!--alias ISOAMSA dharr -->
+<!ENTITY RightFloor       "&#x0230B;" ><!--alias ISOAMSC rfloor -->
+<!ENTITY rightharpoondown "&#x021C1;" ><!--alias ISOAMSA rhard -->
+<!ENTITY rightharpoonup   "&#x021C0;" ><!--alias ISOAMSA rharu -->
+<!ENTITY rightleftarrows  "&#x021C4;" ><!--alias ISOAMSA rlarr -->
+<!ENTITY rightleftharpoons "&#x021CC;" ><!--alias ISOAMSA rlhar -->
+<!ENTITY rightrightarrows "&#x021C9;" ><!--alias ISOAMSA rrarr -->
+<!ENTITY rightsquigarrow  "&#x0219D;" ><!--alias ISOAMSA rarrw -->
+<!ENTITY RightTee         "&#x022A2;" ><!--alias ISOAMSR vdash -->
+<!ENTITY RightTeeArrow    "&#x021A6;" ><!--alias ISOAMSA map -->
+<!ENTITY rightthreetimes  "&#x022CC;" ><!--alias ISOAMSB rthree -->
+<!ENTITY RightTriangle    "&#x022B3;" ><!--alias ISOAMSR vrtri -->
+<!ENTITY RightTriangleEqual "&#x022B5;" ><!--alias ISOAMSR rtrie -->
+<!ENTITY RightUpVector    "&#x021BE;" ><!--alias ISOAMSA uharr -->
+<!ENTITY RightVector      "&#x021C0;" ><!--alias ISOAMSA rharu -->
+<!ENTITY risingdotseq     "&#x02253;" ><!--alias ISOAMSR erDot -->
+<!ENTITY rmoustache       "&#x023B1;" ><!--alias ISOAMSC rmoust -->
+<!ENTITY Rrightarrow      "&#x021DB;" ><!--alias ISOAMSA rAarr -->
+<!ENTITY Rsh              "&#x021B1;" ><!--alias ISOAMSA rsh -->
+<!ENTITY searrow          "&#x02198;" ><!--alias ISOAMSA searr -->
+<!ENTITY setminus         "&#x02216;" ><!--alias ISOAMSB setmn -->
+<!ENTITY ShortDownArrow   "&#x02193;" ><!--short down arrow -->
+<!ENTITY ShortLeftArrow   "&#x02190;" ><!--alias ISOAMSA slarr -->
+<!ENTITY shortmid         "&#x02223;" ><!--alias ISOAMSR smid -->
+<!ENTITY shortparallel    "&#x02225;" ><!--alias ISOAMSR spar -->
+<!ENTITY ShortRightArrow  "&#x02192;" ><!--alias ISOAMSA srarr -->
+<!ENTITY ShortUpArrow     "&#x02191;" ><!--short up arrow  -->
+<!ENTITY simeq            "&#x02243;" ><!--alias ISOTECH sime -->
+<!ENTITY SmallCircle      "&#x02218;" ><!--alias ISOTECH compfn -->
+<!ENTITY smallsetminus    "&#x02216;" ><!--alias ISOAMSB ssetmn -->
+<!ENTITY spadesuit        "&#x02660;" ><!--ISOPUB    spades  -->
+<!ENTITY Sqrt             "&#x0221A;" ><!--alias ISOTECH radic -->
+<!ENTITY sqsubset         "&#x0228F;" ><!--alias ISOAMSR sqsub -->
+<!ENTITY sqsubseteq       "&#x02291;" ><!--alias ISOAMSR sqsube -->
+<!ENTITY sqsupset         "&#x02290;" ><!--alias ISOAMSR sqsup -->
+<!ENTITY sqsupseteq       "&#x02292;" ><!--alias ISOAMSR sqsupe -->
+<!ENTITY Square           "&#x025A1;" ><!--alias for square -->
+<!ENTITY SquareIntersection "&#x02293;" ><!--alias ISOAMSB sqcap -->
+<!ENTITY SquareSubset     "&#x0228F;" ><!--alias ISOAMSR sqsub -->
+<!ENTITY SquareSubsetEqual "&#x02291;" ><!--alias ISOAMSR sqsube -->
+<!ENTITY SquareSuperset   "&#x02290;" ><!--alias ISOAMSR sqsup -->
+<!ENTITY SquareSupersetEqual "&#x02292;" ><!--alias ISOAMSR sqsupe -->
+<!ENTITY SquareUnion      "&#x02294;" ><!--alias ISOAMSB sqcup -->
+<!ENTITY Star             "&#x022C6;" ><!--alias ISOAMSB sstarf -->
+<!ENTITY straightepsilon  "&#x003F5;" ><!--alias ISOGRK3 epsi -->
+<!ENTITY straightphi      "&#x003D5;" ><!--alias ISOGRK3 phi -->
+<!ENTITY Subset           "&#x022D0;" ><!--alias ISOAMSR Sub -->
+<!ENTITY subset           "&#x02282;" ><!--alias ISOTECH sub -->
+<!ENTITY subseteq         "&#x02286;" ><!--alias ISOTECH sube -->
+<!ENTITY subseteqq        "&#x02AC5;" ><!--alias ISOAMSR subE -->
+<!ENTITY SubsetEqual      "&#x02286;" ><!--alias ISOTECH sube -->
+<!ENTITY subsetneq        "&#x0228A;" ><!--alias ISOAMSN subne -->
+<!ENTITY subsetneqq       "&#x02ACB;" ><!--alias ISOAMSN subnE -->
+<!ENTITY succ             "&#x0227B;" ><!--alias ISOAMSR sc -->
+<!ENTITY succapprox       "&#x02AB8;" ><!--alias ISOAMSR scap -->
+<!ENTITY succcurlyeq      "&#x0227D;" ><!--alias ISOAMSR sccue -->
+<!ENTITY Succeeds         "&#x0227B;" ><!--alias ISOAMSR sc -->
+<!ENTITY SucceedsEqual    "&#x02AB0;" ><!--alias ISOAMSR sce -->
+<!ENTITY SucceedsSlantEqual "&#x0227D;" ><!--alias ISOAMSR sccue -->
+<!ENTITY SucceedsTilde    "&#x0227F;" ><!--alias ISOAMSR scsim -->
+<!ENTITY succeq           "&#x02AB0;" ><!--alias ISOAMSR sce -->
+<!ENTITY succnapprox      "&#x02ABA;" ><!--alias ISOAMSN scnap -->
+<!ENTITY succneqq         "&#x02AB6;" ><!--alias ISOAMSN scnE -->
+<!ENTITY succnsim         "&#x022E9;" ><!--alias ISOAMSN scnsim -->
+<!ENTITY succsim          "&#x0227F;" ><!--alias ISOAMSR scsim -->
+<!ENTITY SuchThat         "&#x0220B;" ><!--ISOTECH  ni -->
+<!ENTITY Sum              "&#x02211;" ><!--alias ISOAMSB sum -->
+<!ENTITY Superset         "&#x02283;" ><!--alias ISOTECH sup -->
+<!ENTITY SupersetEqual    "&#x02287;" ><!--alias ISOTECH supe -->
+<!ENTITY Supset           "&#x022D1;" ><!--alias ISOAMSR Sup -->
+<!ENTITY supset           "&#x02283;" ><!--alias ISOTECH sup -->
+<!ENTITY supseteq         "&#x02287;" ><!--alias ISOTECH supe -->
+<!ENTITY supseteqq        "&#x02AC6;" ><!--alias ISOAMSR supE -->
+<!ENTITY supsetneq        "&#x0228B;" ><!--alias ISOAMSN supne -->
+<!ENTITY supsetneqq       "&#x02ACC;" ><!--alias ISOAMSN supnE -->
+<!ENTITY swarrow          "&#x02199;" ><!--alias ISOAMSA swarr -->
+<!ENTITY Therefore        "&#x02234;" ><!--alias ISOTECH there4 -->
+<!ENTITY therefore        "&#x02234;" ><!--alias ISOTECH there4 -->
+<!ENTITY thickapprox      "&#x02248;" ><!--ISOAMSR   thkap  -->
+<!ENTITY thicksim         "&#x0223C;" ><!--ISOAMSR   thksim -->
+<!ENTITY ThinSpace        "&#x02009;" ><!--space of width 3/18 em alias ISOPUB thinsp -->
+<!ENTITY Tilde            "&#x0223C;" ><!--alias ISOTECH sim -->
+<!ENTITY TildeEqual       "&#x02243;" ><!--alias ISOTECH sime -->
+<!ENTITY TildeFullEqual   "&#x02245;" ><!--alias ISOTECH cong -->
+<!ENTITY TildeTilde       "&#x02248;" ><!--alias ISOTECH ap -->
+<!ENTITY toea             "&#x02928;" ><!--alias ISOAMSA nesear -->
+<!ENTITY tosa             "&#x02929;" ><!--alias ISOAMSA seswar -->
+<!ENTITY triangle         "&#x025B5;" ><!--alias ISOPUB utri -->
+<!ENTITY triangledown     "&#x025BF;" ><!--alias ISOPUB dtri -->
+<!ENTITY triangleleft     "&#x025C3;" ><!--alias ISOPUB ltri -->
+<!ENTITY trianglelefteq   "&#x022B4;" ><!--alias ISOAMSR ltrie -->
+<!ENTITY triangleq        "&#x0225C;" ><!--alias ISOAMSR trie -->
+<!ENTITY triangleright    "&#x025B9;" ><!--alias ISOPUB rtri -->
+<!ENTITY trianglerighteq  "&#x022B5;" ><!--alias ISOAMSR rtrie -->
+<!ENTITY TripleDot        "&#x020DB;" ><!--alias ISOTECH tdot -->
+<!ENTITY twoheadleftarrow "&#x0219E;" ><!--alias ISOAMSA Larr -->
+<!ENTITY twoheadrightarrow "&#x021A0;" ><!--alias ISOAMSA Rarr -->
+<!ENTITY ulcorner         "&#x0231C;" ><!--alias ISOAMSC ulcorn -->
+<!ENTITY Union            "&#x022C3;" ><!--alias ISOAMSB xcup -->
+<!ENTITY UnionPlus        "&#x0228E;" ><!--alias ISOAMSB uplus -->
+<!ENTITY UpArrow          "&#x02191;" ><!--alias ISONUM uarr -->
+<!ENTITY Uparrow          "&#x021D1;" ><!--alias ISOAMSA uArr -->
+<!ENTITY uparrow          "&#x02191;" ><!--alias ISONUM uarr -->
+<!ENTITY UpArrowDownArrow "&#x021C5;" ><!--alias ISOAMSA udarr -->
+<!ENTITY UpDownArrow      "&#x02195;" ><!--alias ISOAMSA varr -->
+<!ENTITY Updownarrow      "&#x021D5;" ><!--alias ISOAMSA vArr -->
+<!ENTITY updownarrow      "&#x02195;" ><!--alias ISOAMSA varr -->
+<!ENTITY UpEquilibrium    "&#x0296E;" ><!--alias ISOAMSA udhar -->
+<!ENTITY upharpoonleft    "&#x021BF;" ><!--alias ISOAMSA uharl -->
+<!ENTITY upharpoonright   "&#x021BE;" ><!--alias ISOAMSA uharr -->
+<!ENTITY UpperLeftArrow   "&#x02196;" ><!--alias ISOAMSA nwarr -->
+<!ENTITY UpperRightArrow  "&#x02197;" ><!--alias ISOAMSA nearr -->
+<!ENTITY upsilon          "&#x003C5;" ><!--alias ISOGRK3 upsi -->
+<!ENTITY UpTee            "&#x022A5;" ><!--alias ISOTECH perp -->
+<!ENTITY UpTeeArrow       "&#x021A5;" ><!--Alias mapstoup -->
+<!ENTITY upuparrows       "&#x021C8;" ><!--alias ISOAMSA uuarr -->
+<!ENTITY urcorner         "&#x0231D;" ><!--alias ISOAMSC urcorn -->
+<!ENTITY varepsilon       "&#x003B5;" ><!--alias ISOGRK3 epsiv -->
+<!ENTITY varkappa         "&#x003F0;" ><!--alias ISOGRK3 kappav -->
+<!ENTITY varnothing       "&#x02205;" ><!--alias ISOAMSO emptyv -->
+<!ENTITY varphi           "&#x003C6;" ><!--alias ISOGRK3 phiv -->
+<!ENTITY varpi            "&#x003D6;" ><!--alias ISOGRK3 piv -->
+<!ENTITY varpropto        "&#x0221D;" ><!--alias ISOAMSR vprop -->
+<!ENTITY varrho           "&#x003F1;" ><!--alias ISOGRK3 rhov -->
+<!ENTITY varsigma         "&#x003C2;" ><!--alias ISOGRK3 sigmav -->
+<!ENTITY varsubsetneq     "&#x0228A;&#x0FE00;" ><!--alias ISOAMSN vsubne -->
+<!ENTITY varsubsetneqq    "&#x02ACB;&#x0FE00;" ><!--alias ISOAMSN vsubnE -->
+<!ENTITY varsupsetneq     "&#x0228B;&#x0FE00;" ><!--alias ISOAMSN vsupne -->
+<!ENTITY varsupsetneqq    "&#x02ACC;&#x0FE00;" ><!--alias ISOAMSN vsupnE -->
+<!ENTITY vartheta         "&#x003D1;" ><!--alias ISOGRK3 thetav -->
+<!ENTITY vartriangleleft  "&#x022B2;" ><!--alias ISOAMSR vltri -->
+<!ENTITY vartriangleright "&#x022B3;" ><!--alias ISOAMSR vrtri -->
+<!ENTITY Vee              "&#x022C1;" ><!--alias ISOAMSB xvee -->
+<!ENTITY vee              "&#x02228;" ><!--alias ISOTECH or -->
+<!ENTITY Vert             "&#x02016;" ><!--alias ISOTECH Verbar -->
+<!ENTITY vert             "&#x0007C;" ><!--alias ISONUM verbar -->
+<!ENTITY VerticalBar      "&#x02223;" ><!--alias ISOAMSR mid -->
+<!ENTITY VerticalTilde    "&#x02240;" ><!--alias ISOAMSB wreath -->
+<!ENTITY VeryThinSpace    "&#x0200A;" ><!--space of width 1/18 em alias ISOPUB hairsp -->
+<!ENTITY Wedge            "&#x022C0;" ><!--alias ISOAMSB xwedge -->
+<!ENTITY wedge            "&#x02227;" ><!--alias ISOTECH and -->
+<!ENTITY wp               "&#x02118;" ><!--alias ISOAMSO weierp -->
+<!ENTITY wr               "&#x02240;" ><!--alias ISOAMSB wreath -->
+<!ENTITY zeetrf           "&#x02128;" ><!--zee transform -->

--- a/src/main/resources/dtd/archiving/1.2/mathml/mmlextra.ent
+++ b/src/main/resources/dtd/archiving/1.2/mathml/mmlextra.ent
@@ -1,0 +1,122 @@
+
+<!--
+     File mmlextra.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+-->
+
+<!ENTITY % plane1D  "&#38;#38;#x1D">
+
+<!ENTITY af               "&#x02061;" ><!--character showing function application in presentation tagging -->
+<!ENTITY aopf             "%plane1D;552;" ><!-- -->
+<!ENTITY asympeq          "&#x0224D;" ><!--Old ISOAMSR asymp (for HTML compatibility) -->
+<!ENTITY bopf             "%plane1D;553;" ><!-- -->
+<!ENTITY copf             "%plane1D;554;" ><!-- -->
+<!ENTITY Cross            "&#x02A2F;" ><!--cross or vector product -->
+<!ENTITY DD               "&#x02145;" ><!--D for use in differentials, e.g., within integrals -->
+<!ENTITY dd               "&#x02146;" ><!--d for use in differentials, e.g., within integrals -->
+<!ENTITY dopf             "%plane1D;555;" ><!-- -->
+<!ENTITY DownArrowBar     "&#x02913;" ><!--down arrow to bar -->
+<!ENTITY DownBreve        "&#x00311;" ><!--breve, inverted (non-spacing) -->
+<!ENTITY DownLeftRightVector "&#x02950;" ><!--left-down-right-down harpoon -->
+<!ENTITY DownLeftTeeVector "&#x0295E;" ><!--left-down harpoon from bar -->
+<!ENTITY DownLeftVectorBar "&#x02956;" ><!--left-down harpoon to bar -->
+<!ENTITY DownRightTeeVector "&#x0295F;" ><!--right-down harpoon from bar -->
+<!ENTITY DownRightVectorBar "&#x02957;" ><!--right-down harpoon to bar -->
+<!ENTITY ee               "&#x02147;" ><!--e use for the exponential base of the natural logarithms -->
+<!ENTITY EmptySmallSquare "&#x025FB;" ><!--empty small square -->
+<!ENTITY EmptyVerySmallSquare "&#x025AB;" ><!--empty small square -->
+<!ENTITY eopf             "%plane1D;556;" ><!-- -->
+<!ENTITY Equal            "&#x02A75;" ><!--two consecutive equal signs -->
+<!ENTITY FilledSmallSquare "&#x025FC;" ><!--filled small square -->
+<!ENTITY FilledVerySmallSquare "&#x025AA;" ><!--filled very small square -->
+<!ENTITY fopf             "%plane1D;557;" ><!-- -->
+<!ENTITY gopf             "%plane1D;558;" ><!-- -->
+<!ENTITY GreaterGreater   "&#x02AA2;" ><!--alias for GT -->
+<!ENTITY Hat              "&#x0005E;" ><!--circumflex accent -->
+<!ENTITY hopf             "%plane1D;559;" ><!-- -->
+<!ENTITY HorizontalLine   "&#x02500;" ><!--short horizontal line  -->
+<!ENTITY ic               "&#x02063;" ><!--short form of  &InvisibleComma; -->
+<!ENTITY ii               "&#x02148;" ><!--i for use as a square root of -1 -->
+<!ENTITY iopf             "%plane1D;55A;" ><!-- -->
+<!ENTITY it               "&#x02062;" ><!--marks multiplication when it is understood without a mark -->
+<!ENTITY jopf             "%plane1D;55B;" ><!-- -->
+<!ENTITY kopf             "%plane1D;55C;" ><!-- -->
+<!ENTITY larrb            "&#x021E4;" ><!--leftwards arrow to bar -->
+<!ENTITY LeftDownTeeVector "&#x02961;" ><!--down-left harpoon from bar -->
+<!ENTITY LeftDownVectorBar "&#x02959;" ><!--down-left harpoon to bar -->
+<!ENTITY LeftRightVector  "&#x0294E;" ><!--left-up-right-up harpoon -->
+<!ENTITY LeftTeeVector    "&#x0295A;" ><!--left-up harpoon from bar -->
+<!ENTITY LeftTriangleBar  "&#x029CF;" ><!--left triangle, vertical bar -->
+<!ENTITY LeftUpDownVector "&#x02951;" ><!--up-left-down-left harpoon -->
+<!ENTITY LeftUpTeeVector  "&#x02960;" ><!--up-left harpoon from bar -->
+<!ENTITY LeftUpVectorBar  "&#x02958;" ><!--up-left harpoon to bar -->
+<!ENTITY LeftVectorBar    "&#x02952;" ><!--left-up harpoon to bar -->
+<!ENTITY LessLess         "&#x02AA1;" ><!--alias for Lt -->
+<!ENTITY lopf             "%plane1D;55D;" ><!-- -->
+<!ENTITY mapstodown       "&#x021A7;" ><!--downwards arrow from bar -->
+<!ENTITY mapstoleft       "&#x021A4;" ><!--leftwards arrow from bar -->
+<!ENTITY mapstoup         "&#x021A5;" ><!--upwards arrow from bar -->
+<!ENTITY MediumSpace      "&#x0205F;" ><!--space of width 4/18 em -->
+<!ENTITY mopf             "%plane1D;55E;" ><!-- -->
+<!ENTITY nbump            "&#x0224E;&#x00338;" ><!--not bumpy equals -->
+<!ENTITY nbumpe           "&#x0224F;&#x00338;" ><!--not bumpy single equals -->
+<!ENTITY nesim            "&#x02242;&#x00338;" ><!--not equal or similar -->
+<!ENTITY NewLine          "&#x0000A;" ><!--force a line break; line feed -->
+<!ENTITY NoBreak          "&#x02060;" ><!--never break line here -->
+<!ENTITY nopf             "%plane1D;55F;" ><!-- -->
+<!ENTITY NotCupCap        "&#x0226D;" ><!--alias for &nasymp; -->
+<!ENTITY NotHumpEqual     "&#x0224F;&#x00338;" ><!--alias for &nbumpe; -->
+<!ENTITY NotLeftTriangleBar "&#x029CF;&#x00338;" ><!--not left triangle, vertical bar -->
+<!ENTITY NotNestedGreaterGreater "&#x02AA2;&#x00338;" ><!--not double greater-than sign -->
+<!ENTITY NotNestedLessLess "&#x02AA1;&#x00338;" ><!--not double less-than sign -->
+<!ENTITY NotRightTriangleBar "&#x029D0;&#x00338;" ><!--not vertical bar, right triangle -->
+<!ENTITY NotSquareSubset  "&#x0228F;&#x00338;" ><!--square not subset -->
+<!ENTITY NotSquareSuperset "&#x02290;&#x00338;" ><!--negated set-like partial order operator -->
+<!ENTITY NotSucceedsTilde "&#x0227F;&#x00338;" ><!--not succeeds or similar -->
+<!ENTITY oopf             "%plane1D;560;" ><!-- -->
+<!ENTITY OverBar          "&#x000AF;" ><!--over bar -->
+<!ENTITY OverBrace        "&#x0FE37;" ><!--over brace  -->
+<!ENTITY OverBracket      "&#x023B4;" ><!--over bracket -->
+<!ENTITY OverParenthesis  "&#x0FE35;" ><!--over parenthesis -->
+<!ENTITY planckh          "&#x0210E;" ><!--the ring (skew field) of quaternions -->
+<!ENTITY popf             "%plane1D;561;" ><!-- -->
+<!ENTITY Product          "&#x0220F;" ><!--alias for &prod; -->
+<!ENTITY qopf             "%plane1D;562;" ><!-- -->
+<!ENTITY rarrb            "&#x021E5;" ><!--leftwards arrow to bar -->
+<!ENTITY RightDownTeeVector "&#x0295D;" ><!--down-right harpoon from bar -->
+<!ENTITY RightDownVectorBar "&#x02955;" ><!--down-right harpoon to bar -->
+<!ENTITY RightTeeVector   "&#x0295B;" ><!--right-up harpoon from bar -->
+<!ENTITY RightTriangleBar "&#x029D0;" ><!--vertical bar, right triangle -->
+<!ENTITY RightUpDownVector "&#x0294F;" ><!--up-right-down-right harpoon -->
+<!ENTITY RightUpTeeVector "&#x0295C;" ><!--up-right harpoon from bar -->
+<!ENTITY RightUpVectorBar "&#x02954;" ><!--up-right harpoon to bar -->
+<!ENTITY RightVectorBar   "&#x02953;" ><!--up-right harpoon to bar -->
+<!ENTITY ropf             "%plane1D;563;" ><!-- -->
+<!ENTITY RoundImplies     "&#x02970;" ><!--round implies -->
+<!ENTITY RuleDelayed      "&#x029F4;" ><!--rule-delayed (colon right arrow) -->
+<!ENTITY sopf             "%plane1D;564;" ><!-- -->
+<!ENTITY Tab              "&#x00009;" ><!--tabulator stop; horizontal tabulation -->
+<!ENTITY ThickSpace       "&#x02009;&#x0200A;&#x0200A;" ><!--space of width 5/18 em -->
+<!ENTITY topf             "%plane1D;565;" ><!-- -->
+<!ENTITY UnderBar         "&#x00332;" ><!--combining low line -->
+<!ENTITY UnderBrace       "&#x0FE38;" ><!--under brace  -->
+<!ENTITY UnderBracket     "&#x023B5;" ><!--under bracket -->
+<!ENTITY UnderParenthesis "&#x0FE36;" ><!--under parenthesis -->
+<!ENTITY uopf             "%plane1D;566;" ><!-- -->
+<!ENTITY UpArrowBar       "&#x02912;" ><!--up arrow to bar -->
+<!ENTITY Upsilon          "&#x003A5;" ><!--ISOGRK1 Ugr, HTML4 Upsilon -->
+<!ENTITY VerticalLine     "&#x0007C;" ><!--alias ISONUM verbar -->
+<!ENTITY VerticalSeparator "&#x02758;" ><!--vertical separating operator -->
+<!ENTITY vopf             "%plane1D;567;" ><!-- -->
+<!ENTITY wopf             "%plane1D;568;" ><!-- -->
+<!ENTITY xopf             "%plane1D;569;" ><!-- -->
+<!ENTITY yopf             "%plane1D;56A;" ><!-- -->
+<!ENTITY ZeroWidthSpace   "&#x0200B;" ><!--zero width space -->
+<!ENTITY zopf             "%plane1D;56B;" ><!-- -->

--- a/src/main/resources/dtd/archiving/1.2/mathml2-qname-1.mod
+++ b/src/main/resources/dtd/archiving/1.2/mathml2-qname-1.mod
@@ -1,0 +1,286 @@
+<!-- ....................................................................... -->
+<!-- MathML Qualified Names Module  ........................................ -->
+<!-- file: mathml2-qname-1.mod
+
+     This is the Mathematical Markup Language (MathML) 2.0, an XML 
+     application for describing mathematical notation and capturing 
+     both its structure and content.
+
+     Copyright 1998-2000 W3C (MIT, INRIA, Keio), All Rights Reserved.
+     Revision: $Id: mathml2-qname-1.mod,v 1.2 2003/04/08 00:11:16 davidc Exp $ 
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ENTITIES MathML 2.0 Qualified Names 1.0//EN"
+       SYSTEM "mathml2-qname-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- MathML Qualified Names
+
+     This module is contained in two parts, labeled Section 'A' and 'B':
+
+       Section A declares parameter entities to support namespace-
+       qualified names, namespace declarations, and name prefixing 
+       for MathML.
+    
+       Section B declares parameter entities used to provide
+       namespace-qualified names for all MathML element types.
+
+     This module is derived from the XHTML Qualified Names Template module.
+-->
+
+<!-- Section A: XHTML XML Namespace Framework :::::::::::::::::::: -->
+
+<!ENTITY % NS.prefixed     "IGNORE" >
+<!ENTITY % MATHML.prefixed "%NS.prefixed;" >
+
+<!-- XLink ............... -->
+
+<!ENTITY % XLINK.prefix         "xlink" >		
+<!ENTITY % XLINK.xmlns "http://www.w3.org/1999/xlink" >
+<!ENTITY % XLINK.xmlns.attrib
+     "xmlns:%XLINK.prefix;  CDATA           #FIXED '%XLINK.xmlns;'"
+>
+
+<!-- W3C XML Schema ............... -->
+
+<!ENTITY % Schema.prefix         "xsi" >		
+<!ENTITY % Schema.xmlns "http://www.w3.org/2001/XMLSchema-instance" >
+<!ENTITY % Schema.xmlns.attrib
+     "xmlns:%Schema.prefix;  CDATA           #IMPLIED"
+>
+
+<!-- MathML .............. -->
+
+<!ENTITY % MATHML.xmlns    "http://www.w3.org/1998/Math/MathML" >
+<!ENTITY % MATHML.prefix   "m" >
+<![%MATHML.prefixed;[
+<!ENTITY % MATHML.xmlns.extra.attrib  "" >
+]]>
+<!ENTITY % MATHML.xmlns.extra.attrib 
+     "%XLINK.xmlns.attrib; 
+      %Schema.xmlns.attrib;" >
+
+<![%MATHML.prefixed;[
+<!ENTITY % MATHML.pfx  "%MATHML.prefix;:" >
+<!ENTITY % MATHML.xmlns.attrib
+     "xmlns:%MATHML.prefix;  CDATA   #FIXED '%MATHML.xmlns;'
+      %MATHML.xmlns.extra.attrib;"
+>
+]]>
+<!ENTITY % MATHML.pfx  "" >
+<!ENTITY % MATHML.xmlns.attrib
+     "xmlns        CDATA           #FIXED '%MATHML.xmlns;'
+      %MATHML.xmlns.extra.attrib;"
+>
+
+<![%NS.prefixed;[
+<!ENTITY % XHTML.xmlns.extra.attrib 
+     "%MATHML.xmlns.attrib;" >
+]]>
+<!ENTITY % XHTML.xmlns.extra.attrib
+     "%XLINK.xmlns.attrib;
+      %Schema.xmlns.attrib;"
+>
+
+<!-- Section B: MathML Qualified Names ::::::::::::::::::::::::::::: -->
+
+<!-- 9. This section declares parameter entities used to provide
+        namespace-qualified names for all MathML element types.
+-->
+
+<!ENTITY % abs.qname            "%MATHML.pfx;abs" >
+<!ENTITY % and.qname            "%MATHML.pfx;and" >
+<!ENTITY % annotation-xml.qname "%MATHML.pfx;annotation-xml" >
+<!ENTITY % annotation.qname     "%MATHML.pfx;annotation" >
+<!ENTITY % apply.qname          "%MATHML.pfx;apply" >
+<!ENTITY % approx.qname         "%MATHML.pfx;approx" >
+<!ENTITY % arccos.qname         "%MATHML.pfx;arccos" >
+<!ENTITY % arccosh.qname        "%MATHML.pfx;arccosh" >
+<!ENTITY % arccosh.qname        "%MATHML.pfx;arccosh" >
+<!ENTITY % arccot.qname         "%MATHML.pfx;arccot" >
+<!ENTITY % arccoth.qname        "%MATHML.pfx;arccoth" >
+<!ENTITY % arccsc.qname         "%MATHML.pfx;arccsc" >
+<!ENTITY % arccsch.qname        "%MATHML.pfx;arccsch" >
+<!ENTITY % arcsec.qname         "%MATHML.pfx;arcsec" >
+<!ENTITY % arcsech.qname        "%MATHML.pfx;arcsech" >
+<!ENTITY % arcsin.qname         "%MATHML.pfx;arcsin" >
+<!ENTITY % arcsinh.qname        "%MATHML.pfx;arcsinh" >
+<!ENTITY % arctan.qname         "%MATHML.pfx;arctan" >
+<!ENTITY % arctanh.qname        "%MATHML.pfx;arctanh" >
+<!ENTITY % arg.qname            "%MATHML.pfx;arg" >
+<!ENTITY % bvar.qname           "%MATHML.pfx;bvar" >
+<!ENTITY % card.qname           "%MATHML.pfx;card" >
+<!ENTITY % cartesianproduct.qname "%MATHML.pfx;cartesianproduct" >
+<!ENTITY % ceiling.qname         "%MATHML.pfx;ceiling" >
+<!ENTITY % ci.qname             "%MATHML.pfx;ci" >
+<!ENTITY % cn.qname             "%MATHML.pfx;cn" >
+<!ENTITY % codomain.qname       "%MATHML.pfx;codomain" >
+<!ENTITY % complexes.qname      "%MATHML.pfx;complexes" >
+<!ENTITY % compose.qname        "%MATHML.pfx;compose" >
+<!ENTITY % condition.qname      "%MATHML.pfx;condition" >
+<!ENTITY % conjugate.qname      "%MATHML.pfx;conjugate" >
+<!ENTITY % cos.qname            "%MATHML.pfx;cos" >
+<!ENTITY % cosh.qname           "%MATHML.pfx;cosh" >
+<!ENTITY % cot.qname            "%MATHML.pfx;cot" >
+<!ENTITY % coth.qname           "%MATHML.pfx;coth" >
+<!ENTITY % csc.qname            "%MATHML.pfx;csc" >
+<!ENTITY % csch.qname           "%MATHML.pfx;csch" >
+<!ENTITY % csymbol.qname        "%MATHML.pfx;csymbol" >
+<!ENTITY % curl.qname           "%MATHML.pfx;curl" >
+<!ENTITY % declare.qname        "%MATHML.pfx;declare" >
+<!ENTITY % degree.qname         "%MATHML.pfx;degree" >
+<!ENTITY % determinant.qname    "%MATHML.pfx;determinant" >
+<!ENTITY % diff.qname           "%MATHML.pfx;diff" >
+<!ENTITY % divergence.qname     "%MATHML.pfx;divergence" >
+<!ENTITY % divide.qname         "%MATHML.pfx;divide" >
+<!ENTITY % domain.qname         "%MATHML.pfx;domain" >
+<!ENTITY % domainofapplication.qname "%MATHML.pfx;domainofapplication" >
+<!ENTITY % emptyset.qname       "%MATHML.pfx;emptyset" >
+<!ENTITY % eq.qname             "%MATHML.pfx;eq" >
+<!ENTITY % equivalent.qname     "%MATHML.pfx;equivalent" >
+<!ENTITY % eulergamma.qname     "%MATHML.pfx;eulergamma" >
+<!ENTITY % exists.qname         "%MATHML.pfx;exists" >
+<!ENTITY % exp.qname            "%MATHML.pfx;exp" >
+<!ENTITY % exponentiale.qname   "%MATHML.pfx;exponentiale" >
+<!ENTITY % factorial.qname      "%MATHML.pfx;factorial" >
+<!ENTITY % factorof.qname       "%MATHML.pfx;factorof" >
+<!ENTITY % false.qname          "%MATHML.pfx;false" >
+<!ENTITY % floor.qname          "%MATHML.pfx;floor" >
+<!ENTITY % fn.qname             "%MATHML.pfx;fn" >
+<!ENTITY % forall.qname         "%MATHML.pfx;forall" >
+<!ENTITY % gcd.qname            "%MATHML.pfx;gcd" >
+<!ENTITY % geq.qname            "%MATHML.pfx;geq" >
+<!ENTITY % grad.qname           "%MATHML.pfx;grad" >
+<!ENTITY % gt.qname             "%MATHML.pfx;gt" >
+<!ENTITY % ident.qname          "%MATHML.pfx;ident" >
+<!ENTITY % image.qname          "%MATHML.pfx;image" >
+<!ENTITY % imaginary.qname      "%MATHML.pfx;imaginary" >
+<!ENTITY % imaginaryi.qname     "%MATHML.pfx;imaginaryi" >
+<!ENTITY % implies.qname        "%MATHML.pfx;implies" >
+<!ENTITY % in.qname             "%MATHML.pfx;in" >
+<!ENTITY % infinity.qname       "%MATHML.pfx;infinity" >
+<!ENTITY % int.qname            "%MATHML.pfx;int" >
+<!ENTITY % integers.qname       "%MATHML.pfx;integers" >
+<!ENTITY % intersect.qname      "%MATHML.pfx;intersect" >
+<!ENTITY % interval.qname       "%MATHML.pfx;interval" >
+<!ENTITY % inverse.qname        "%MATHML.pfx;inverse" >
+<!ENTITY % lambda.qname         "%MATHML.pfx;lambda" >
+<!ENTITY % laplacian.qname      "%MATHML.pfx;laplacian" >
+<!ENTITY % lcm.qname            "%MATHML.pfx;lcm" >
+<!ENTITY % leq.qname            "%MATHML.pfx;leq" >
+<!ENTITY % limit.qname          "%MATHML.pfx;limit" >
+<!ENTITY % list.qname           "%MATHML.pfx;list" >
+<!ENTITY % ln.qname             "%MATHML.pfx;ln" >
+<!ENTITY % log.qname            "%MATHML.pfx;log" >
+<!ENTITY % logbase.qname        "%MATHML.pfx;logbase" >
+<!ENTITY % lowlimit.qname       "%MATHML.pfx;lowlimit" >
+<!ENTITY % lt.qname             "%MATHML.pfx;lt" >
+<!ENTITY % maction.qname        "%MATHML.pfx;maction" >
+<!ENTITY % maligngroup.qname    "%MATHML.pfx;maligngroup" >
+<!ENTITY % malignmark.qname     "%MATHML.pfx;malignmark" >
+<!ENTITY % math.qname           "%MATHML.pfx;math" >
+<!ENTITY % matrix.qname         "%MATHML.pfx;matrix" >
+<!ENTITY % matrixrow.qname      "%MATHML.pfx;matrixrow" >
+<!ENTITY % max.qname            "%MATHML.pfx;max" >
+<!ENTITY % mean.qname           "%MATHML.pfx;mean" >
+<!ENTITY % median.qname         "%MATHML.pfx;median" >
+<!ENTITY % menclose.qname       "%MATHML.pfx;menclose" >
+<!ENTITY % merror.qname         "%MATHML.pfx;merror" >
+<!ENTITY % mfenced.qname        "%MATHML.pfx;mfenced" >
+<!ENTITY % mfrac.qname          "%MATHML.pfx;mfrac" >
+<!ENTITY % mglyph.qname         "%MATHML.pfx;mglyph" >
+<!ENTITY % mi.qname             "%MATHML.pfx;mi" >
+<!ENTITY % min.qname            "%MATHML.pfx;min" >
+<!ENTITY % minus.qname          "%MATHML.pfx;minus" >
+<!ENTITY % mlabeledtr.qname     "%MATHML.pfx;mlabeledtr" >
+<!ENTITY % mmultiscripts.qname  "%MATHML.pfx;mmultiscripts" >
+<!ENTITY % mn.qname             "%MATHML.pfx;mn" >
+<!ENTITY % mo.qname             "%MATHML.pfx;mo" >
+<!ENTITY % mode.qname           "%MATHML.pfx;mode" >
+<!ENTITY % moment.qname         "%MATHML.pfx;moment" >
+<!ENTITY % momentabout.qname    "%MATHML.pfx;momentabout" >
+<!ENTITY % mover.qname          "%MATHML.pfx;mover" >
+<!ENTITY % mpadded.qname        "%MATHML.pfx;mpadded" >
+<!ENTITY % mphantom.qname       "%MATHML.pfx;mphantom" >
+<!ENTITY % mprescripts.qname    "%MATHML.pfx;mprescripts" >
+<!ENTITY % mroot.qname          "%MATHML.pfx;mroot" >
+<!ENTITY % mrow.qname           "%MATHML.pfx;mrow" >
+<!ENTITY % ms.qname             "%MATHML.pfx;ms" >
+<!ENTITY % mspace.qname         "%MATHML.pfx;mspace" >
+<!ENTITY % msqrt.qname          "%MATHML.pfx;msqrt" >
+<!ENTITY % mstyle.qname         "%MATHML.pfx;mstyle" >
+<!ENTITY % msub.qname           "%MATHML.pfx;msub" >
+<!ENTITY % msubsup.qname        "%MATHML.pfx;msubsup" >
+<!ENTITY % msup.qname           "%MATHML.pfx;msup" >
+<!ENTITY % mtable.qname         "%MATHML.pfx;mtable" >
+<!ENTITY % mtd.qname            "%MATHML.pfx;mtd" >
+<!ENTITY % mtext.qname          "%MATHML.pfx;mtext" >
+<!ENTITY % mtr.qname            "%MATHML.pfx;mtr" >
+<!ENTITY % munder.qname         "%MATHML.pfx;munder" >
+<!ENTITY % munderover.qname     "%MATHML.pfx;munderover" >
+<!ENTITY % naturalnumbers.qname "%MATHML.pfx;naturalnumbers" >
+<!ENTITY % neq.qname            "%MATHML.pfx;neq" >
+<!ENTITY % none.qname           "%MATHML.pfx;none" >
+<!ENTITY % not.qname            "%MATHML.pfx;not" >
+<!ENTITY % notanumber.qname     "%MATHML.pfx;notanumber" >
+<!ENTITY % notin.qname          "%MATHML.pfx;notin" >
+<!ENTITY % notprsubset.qname    "%MATHML.pfx;notprsubset" >
+<!ENTITY % notsubset.qname      "%MATHML.pfx;notsubset" >
+<!ENTITY % or.qname             "%MATHML.pfx;or" >
+<!ENTITY % otherwise.qname      "%MATHML.pfx;otherwise" >
+<!ENTITY % outerproduct.qname   "%MATHML.pfx;outerproduct" >
+<!ENTITY % partialdiff.qname    "%MATHML.pfx;partialdiff" >
+<!ENTITY % pi.qname             "%MATHML.pfx;pi" >
+<!ENTITY % piece.qname          "%MATHML.pfx;piece" >
+<!ENTITY % piecewise.qname      "%MATHML.pfx;piecewise" >
+<!ENTITY % plus.qname           "%MATHML.pfx;plus" >
+<!ENTITY % power.qname          "%MATHML.pfx;power" >
+<!ENTITY % primes.qname         "%MATHML.pfx;primes" >
+<!ENTITY % product.qname        "%MATHML.pfx;product" >
+<!ENTITY % prsubset.qname       "%MATHML.pfx;prsubset" >
+<!ENTITY % quotient.qname       "%MATHML.pfx;quotient" >
+<!ENTITY % rationals.qname      "%MATHML.pfx;rationals" >
+<!ENTITY % real.qname           "%MATHML.pfx;real" >
+<!ENTITY % reals.qname          "%MATHML.pfx;reals" >
+<!ENTITY % reln.qname           "%MATHML.pfx;reln" >
+<!ENTITY % rem.qname            "%MATHML.pfx;rem" >
+<!ENTITY % root.qname           "%MATHML.pfx;root" >
+<!ENTITY % scalarproduct.qname  "%MATHML.pfx;scalarproduct" >
+<!ENTITY % sdev.qname           "%MATHML.pfx;sdev" >
+<!ENTITY % sec.qname            "%MATHML.pfx;sec" >
+<!ENTITY % sech.qname           "%MATHML.pfx;sech" >
+<!ENTITY % selector.qname       "%MATHML.pfx;selector" >
+<!ENTITY % semantics.qname      "%MATHML.pfx;semantics" >
+<!ENTITY % sep.qname            "%MATHML.pfx;sep" >
+<!ENTITY % set.qname            "%MATHML.pfx;set" >
+<!ENTITY % setdiff.qname        "%MATHML.pfx;setdiff" >
+<!ENTITY % sin.qname            "%MATHML.pfx;sin" >
+<!ENTITY % sinh.qname           "%MATHML.pfx;sinh" >
+<!ENTITY % subset.qname         "%MATHML.pfx;subset" >
+<!ENTITY % sum.qname            "%MATHML.pfx;sum" >
+<!ENTITY % tan.qname            "%MATHML.pfx;tan" >
+<!ENTITY % tanh.qname           "%MATHML.pfx;tanh" >
+<!ENTITY % tendsto.qname        "%MATHML.pfx;tendsto" >
+<!ENTITY % times.qname          "%MATHML.pfx;times" >
+<!ENTITY % transpose.qname      "%MATHML.pfx;transpose" >
+<!ENTITY % true.qname           "%MATHML.pfx;true" >
+<!ENTITY % union.qname          "%MATHML.pfx;union" >
+<!ENTITY % uplimit.qname        "%MATHML.pfx;uplimit" >
+<!ENTITY % variance.qname       "%MATHML.pfx;variance" >
+<!ENTITY % vector.qname         "%MATHML.pfx;vector" >
+<!ENTITY % vectorproduct.qname  "%MATHML.pfx;vectorproduct" >
+<!ENTITY % xor.qname            "%MATHML.pfx;xor" >
+
+
+<!-- ignores subsequent instantiation of this module when
+     used as external subset rather than module fragment.
+     NOTE: Do not modify this parameter entity, otherwise
+     a recursive parsing situation may result.
+-->
+<!ENTITY % mathml-qname.module "IGNORE" >
+
+<!-- end of template-qname-1.mod -->

--- a/src/main/resources/dtd/archiving/1.2/mathml2.dtd
+++ b/src/main/resources/dtd/archiving/1.2/mathml2.dtd
@@ -1,0 +1,2206 @@
+<!-- MathML 2.0 DTD  ....................................................... -->
+<!-- file: mathml2.dtd
+-->
+
+<!-- MathML 2.0 DTD
+
+     This is the Mathematical Markup Language (MathML) 2.0, an XML
+     application for describing mathematical notation and capturing
+     both its structure and content.
+
+     Copyright &#xa9; 1998-2003 W3C&#xae; (MIT, ERCIM, Keio), All Rights 
+     Reserved. W3C liability, trademark, document use and software
+     licensing rules apply. 
+
+     Permission to use, copy, modify and distribute the MathML 2.0 DTD and
+     its accompanying documentation for any purpose and without fee is
+     hereby granted in perpetuity, provided that the above copyright notice
+     and this paragraph appear in all copies.  The copyright holders make
+     no representation about the suitability of the DTD for any purpose.
+
+     It is provided "as is" without expressed or implied warranty.
+
+        Revision:   $Id: mathml2.dtd,v 1.12 2003/11/04 13:14:35 davidc Exp $
+
+     This entity may be identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//DTD MathML 2.0//EN"
+       SYSTEM "mathml2.dtd"
+
+     Revisions: editor and revision history at EOF
+-->
+<!-- Entity used to enable marked sections which enforces stricter		
+     checking of MathML syntax rules		
+-->
+<!ENTITY % MathMLstrict "IGNORE">		
+
+<!-- MathML Qualified Names module ............................... -->
+<!ENTITY % mathml-qname.module "INCLUDE" >
+<![%mathml-qname.module;[
+<!ENTITY % mathml-qname.mod
+     PUBLIC "-//W3C//ENTITIES MathML 2.0 Qualified Names 1.0//EN"
+            "mathml2-qname-1.mod" >
+%mathml-qname.mod;]]>
+
+<!-- if %NS.prefixed; is INCLUDE, include all NS attributes, 
+     otherwise just those associated with MathML
+-->
+<![%NS.prefixed;[
+  <!ENTITY % MATHML.NamespaceDecl.attrib 
+         "%NamespaceDecl.attrib;"
+>
+]]>
+<!ENTITY % MATHML.NamespaceDecl.attrib 
+     "%MATHML.xmlns.attrib;"
+>
+
+
+<!-- Attributes shared by all elements  .......................... -->
+
+<!ENTITY % MATHML.Common.attrib
+     "%MATHML.NamespaceDecl.attrib;
+      %XLINK.prefix;:href   CDATA           #IMPLIED		
+      %XLINK.prefix;:type   CDATA           #IMPLIED	
+      class        CDATA                    #IMPLIED
+      style        CDATA                    #IMPLIED
+      id           ID                       #IMPLIED
+      xref         IDREF                    #IMPLIED
+      other        CDATA                    #IMPLIED"
+>
+
+<!-- Presentation element set  ................................... -->
+
+<!-- Attribute definitions -->
+
+<!ENTITY % att-fontsize
+     "fontsize     CDATA                    #IMPLIED" >
+<!ENTITY % att-fontweight
+     "fontweight   ( normal | bold )        #IMPLIED" >
+<!ENTITY % att-fontstyle
+     "fontstyle    ( normal | italic )      #IMPLIED" >
+<!ENTITY % att-fontfamily
+     "fontfamily   CDATA                    #IMPLIED" >
+<!ENTITY % att-color
+     "color        CDATA                    #IMPLIED" >
+
+<!-- MathML2 typographically-distinguished symbol attributes -->
+
+<![%MathMLstrict;[
+  <!ENTITY % att-mathvariant
+     "mathvariant     ( normal | bold | italic | bold-italic | double-struck | 
+                        bold-fraktur | script | bold-script | fraktur |
+                        sans-serif | bold-sans-serif | sans-serif-italic |
+                        sans-serif-bold-italic | monospace )
+                                                                   #IMPLIED" >
+]]>
+<!ENTITY % att-mathvariant
+     "mathvariant     CDATA                    #IMPLIED" >
+<!ENTITY % att-mathsize
+     "mathsize     CDATA                    #IMPLIED" >
+<!ENTITY % att-mathcolor
+     "mathcolor     CDATA                    #IMPLIED" >
+<!ENTITY % att-mathbackground
+     "mathbackground     CDATA                    #IMPLIED" >
+
+<!ENTITY % att-fontinfo
+     "%att-fontsize;
+      %att-fontweight;
+      %att-fontstyle;
+      %att-fontfamily;
+      %att-color;
+      %att-mathvariant;
+      %att-mathsize;
+      %att-mathcolor;
+      %att-mathbackground;"
+>
+
+<!ENTITY % att-form
+     "form         ( prefix | infix | postfix )  #IMPLIED" >
+<!ENTITY % att-fence
+     "fence        ( true | false )         #IMPLIED" >
+<!ENTITY % att-separator
+     "separator    ( true | false )         #IMPLIED" >
+<!ENTITY % att-lspace
+     "lspace       CDATA                    #IMPLIED" >
+<!ENTITY % att-rspace
+     "rspace       CDATA                    #IMPLIED" >
+<!ENTITY % att-stretchy
+     "stretchy     ( true | false )         #IMPLIED" >
+<!ENTITY % att-symmetric
+     "symmetric    ( true | false )         #IMPLIED" >
+<!ENTITY % att-maxsize
+     "maxsize      CDATA                    #IMPLIED" >
+<!ENTITY % att-minsize
+     "minsize      CDATA                    #IMPLIED" >
+<!ENTITY % att-largeop
+     "largeop      ( true | false)          #IMPLIED" >
+<!ENTITY % att-movablelimits
+     "movablelimits ( true | false )        #IMPLIED" >
+<!ENTITY % att-accent
+     "accent       ( true | false )         #IMPLIED" >
+
+<!ENTITY % att-opinfo
+     "%att-form;
+      %att-fence;
+      %att-separator;
+      %att-lspace;
+      %att-rspace;
+      %att-stretchy;
+      %att-symmetric;
+      %att-maxsize;
+      %att-minsize;
+      %att-largeop;
+      %att-movablelimits;
+      %att-accent;"
+>
+<!ENTITY % att-width
+     "width        CDATA                    #IMPLIED" >
+<!ENTITY % att-height
+     "height       CDATA                    #IMPLIED" >
+<!ENTITY % att-depth
+     "depth        CDATA                    #IMPLIED" >
+<!ENTITY % att-linebreak
+     "linebreak    CDATA                    #IMPLIED" >
+<!ENTITY % att-sizeinfo
+     "%att-width;
+      %att-height;
+      %att-depth;"
+>
+<!ENTITY % att-lquote               
+     "lquote       CDATA                    #IMPLIED" >
+<!ENTITY % att-rquote               
+     "rquote       CDATA                    #IMPLIED" >
+<!ENTITY % att-linethickness        
+     "linethickness CDATA                   #IMPLIED" >
+<!ENTITY % att-scriptlevel          
+     "scriptlevel  CDATA                    #IMPLIED" >
+<!ENTITY % att-displaystyle         
+     "displaystyle ( true | false )         #IMPLIED" >
+<!ENTITY % att-scriptsizemultiplier 
+     "scriptsizemultiplier CDATA            #IMPLIED" >
+<!ENTITY % att-scriptminsize        
+     "scriptminsize CDATA                   #IMPLIED" >
+<!ENTITY % att-background           
+     "background   CDATA                    #IMPLIED" >
+<!ENTITY % att-veryverythinmathspace           
+     "veryverythinmathspace   CDATA         #IMPLIED" >
+<!ENTITY % att-verythinmathspace           
+     "verythinmathspace   CDATA             #IMPLIED" >
+<!ENTITY % att-thinmathspace           
+     "thinmathspace   CDATA                 #IMPLIED" >
+<!ENTITY % att-mediummathspace           
+     "mediummathspace   CDATA               #IMPLIED" >
+<!ENTITY % att-thickmathspace           
+     "thickmathspace   CDATA                #IMPLIED" >
+<!ENTITY % att-verythickmathspace           
+     "verythickmathspace   CDATA            #IMPLIED" >
+<!ENTITY % att-veryverythickmathspace           
+     "veryverythickmathspace   CDATA        #IMPLIED" >
+<!ENTITY % att-open                 
+     "open         CDATA                    #IMPLIED" >
+<!ENTITY % att-close                
+     "close        CDATA                    #IMPLIED" >
+<!ENTITY % att-separators          
+     "separators   CDATA                    #IMPLIED" >
+<!ENTITY % att-subscriptshift       
+     "subscriptshift CDATA                  #IMPLIED" >
+<!ENTITY % att-superscriptshift     
+     "superscriptshift CDATA                #IMPLIED" >
+<!ENTITY % att-accentunder          
+     "accentunder  ( true | false )         #IMPLIED" >
+<!ENTITY % att-align       
+     "align        CDATA                    #IMPLIED" >
+<![%MathMLstrict;[
+  <!ENTITY % att-numalign	
+     "numalign     ( left | center | right )         #IMPLIED" >
+  <!ENTITY % att-denomalign
+     "denomalign   ( left | center | right )         #IMPLIED" >
+]]>
+<!ENTITY % att-numalign		
+     "numalign        CDATA                    #IMPLIED" >		
+<!ENTITY % att-denomalign		
+     "denomalign        CDATA                    #IMPLIED" >		
+<!ENTITY % att-rowalign-list		
+     "rowalign     CDATA                    #IMPLIED" >		
+<!ENTITY % att-columnalign-list		
+     "columnalign  CDATA                    #IMPLIED" >		
+<![%MathMLstrict;[
+  <!ENTITY % att-rowalign
+     "rowalign     ( top | bottom |	center | baseline | axis )    #IMPLIED" >
+  <!ENTITY % att-columnalign
+     "columnalign  ( left | center | right )        #IMPLIED" >
+]]>
+<!ENTITY % att-rowalign      
+     "rowalign     CDATA                    #IMPLIED" >
+<!ENTITY % att-columnalign     
+     "columnalign  CDATA                    #IMPLIED" >
+<!ENTITY % att-columnwidth   
+     "columnwidth  CDATA                    #IMPLIED" >
+<!ENTITY % att-groupalign-list		
+     "groupalign   CDATA                    #IMPLIED" >		
+<![%MathMLstrict;[
+  <!ENTITY % att-groupalign
+     "groupalign   ( left | right | center | decimalpoint )   #IMPLIED" >
+]]>
+<!ENTITY % att-groupalign      
+     "groupalign   CDATA                    #IMPLIED" >
+<!ENTITY % att-alignmentscope 
+     "alignmentscope CDATA                  #IMPLIED" >
+<!ENTITY % att-rowspacing           
+     "rowspacing   CDATA                    #IMPLIED" >
+<!ENTITY % att-columnspacing      
+     "columnspacing CDATA                   #IMPLIED" >
+<!ENTITY % att-rowlines            
+     "rowlines     CDATA                    #IMPLIED" >
+<!ENTITY % att-columnlines        
+     "columnlines  CDATA                    #IMPLIED" >
+<!ENTITY % att-frame            
+     "frame       ( none | solid | dashed ) #IMPLIED" >
+<!ENTITY % att-side		
+     "side       ( left | right | leftoverlap | rightoverlap ) #IMPLIED" >		
+<!ENTITY % att-framespacing         
+     "framespacing CDATA                    #IMPLIED" >
+<!ENTITY % att-minlabelspacing		
+     "minlabelspacing CDATA                 #IMPLIED" >		
+<![%MathMLstrict;[
+  <!ENTITY % att-equalrows
+     "equalrows    ( true | false )         #IMPLIED" >
+  <!ENTITY % att-equalcolumns
+     "equalcolumns ( true | false )         #IMPLIED" >
+]]>
+<!ENTITY % att-equalrows        
+     "equalrows    CDATA                    #IMPLIED" >
+<!ENTITY % att-equalcolumns         
+     "equalcolumns CDATA                    #IMPLIED" >
+
+<!ENTITY % att-tableinfo            
+     "%att-align;
+      %att-rowalign-list;	
+      %att-columnalign-list;	
+      %att-columnwidth;
+      %att-groupalign-list;	
+      %att-alignmentscope;
+      %att-side;		
+      %att-rowspacing;
+      %att-columnspacing;
+      %att-rowlines;
+      %att-columnlines;
+      %att-width;		
+      %att-frame;
+      %att-framespacing;
+      %att-minlabelspacing;		
+      %att-equalrows;
+      %att-equalcolumns;
+      %att-displaystyle;" 
+>
+
+<!ENTITY % att-rowspan              
+     "rowspan      CDATA                    #IMPLIED" >
+<!ENTITY % att-columnspan           
+     "columnspan   CDATA                    #IMPLIED" >
+<!ENTITY % att-edge        
+     "edge         ( left | right )         #IMPLIED" >
+<!ENTITY % att-actiontype          
+     "actiontype   CDATA                    #IMPLIED" >
+<!ENTITY % att-selection       
+     "selection    CDATA                    #IMPLIED" >
+
+<!ENTITY % att-name                 
+     "name         CDATA                    #IMPLIED" >
+<!ENTITY % att-alt              
+     "alt          CDATA                    #IMPLIED" >
+<!ENTITY % att-index           
+     "index        CDATA                    #IMPLIED" >
+
+<![%MathMLstrict;[
+  <!ENTITY % att-bevelled
+     "bevelled      ( true | false )        #IMPLIED" >
+]]>
+<!ENTITY % att-bevelled       
+     "bevelled      CDATA                    #IMPLIED" >
+
+<!-- Presentation schemata with content -->
+
+<!ENTITY % ptoken                   
+     "%mi.qname; | %mn.qname; | %mo.qname;
+      | %mtext.qname; | %ms.qname;" >
+
+<!ATTLIST %mi.qname;
+      %MATHML.Common.attrib;
+      %att-fontinfo;
+>
+
+<!ATTLIST %mn.qname;      
+      %MATHML.Common.attrib; 
+      %att-fontinfo;
+>
+
+<!ATTLIST %mo.qname;     
+      %MATHML.Common.attrib; 
+      %att-fontinfo;
+      %att-opinfo;
+>
+
+<!ATTLIST %mtext.qname;  
+      %MATHML.Common.attrib;
+      %att-fontinfo;
+>
+
+<!ATTLIST %ms.qname;     
+      %MATHML.Common.attrib;
+      %att-fontinfo;
+      %att-lquote;
+      %att-rquote;
+>
+
+<!-- Empty presentation schemata -->
+
+<!ENTITY % petoken                  
+     "%mspace.qname;" >
+<!ELEMENT %mspace.qname;  EMPTY >
+
+<!ATTLIST %mspace.qname; 
+      %att-sizeinfo;
+      %att-linebreak;
+      %MATHML.Common.attrib;
+>
+
+<!-- Presentation: general layout schemata -->
+
+<!ENTITY % pgenschema               
+     "%mrow.qname; | %mfrac.qname; | %msqrt.qname; | %mroot.qname; 
+      | %menclose.qname; | %mstyle.qname; | %merror.qname; 
+      | %mpadded.qname; | %mphantom.qname; | %mfenced.qname;" >
+
+<!ATTLIST %mrow.qname;        
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %mfrac.qname;     
+      %MATHML.Common.attrib;
+      %att-bevelled;		
+      %att-numalign;		
+      %att-denomalign;		
+      %att-linethickness;
+>
+
+<!ATTLIST %msqrt.qname;     
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %menclose.qname;  
+      %MATHML.Common.attrib;
+      notation CDATA 'longdiv' >
+
+<!ATTLIST %mroot.qname;    
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %mstyle.qname;  
+      %MATHML.Common.attrib;
+      %att-fontinfo;
+      %att-opinfo;
+      %att-lquote;
+      %att-rquote;
+      %att-linethickness;
+      %att-scriptlevel;
+      %att-scriptsizemultiplier;
+      %att-scriptminsize;
+      %att-background;
+      %att-veryverythinmathspace;
+      %att-verythinmathspace;
+      %att-thinmathspace;
+      %att-mediummathspace;
+      %att-thickmathspace;
+      %att-verythickmathspace;
+      %att-veryverythickmathspace;
+      %att-open;
+      %att-close;
+      %att-separators;
+      %att-subscriptshift;
+      %att-superscriptshift;
+      %att-accentunder;
+      %att-tableinfo;
+      %att-rowspan;
+      %att-columnspan;
+      %att-edge;
+      %att-selection;
+      %att-bevelled;	
+      %att-height;		
+      %att-depth;		
+>
+
+<!ATTLIST %merror.qname;   
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %mpadded.qname;     
+      %MATHML.Common.attrib;
+      %att-sizeinfo;
+      %att-lspace;
+>
+
+<!ATTLIST %mphantom.qname;      
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %mfenced.qname;     
+      %MATHML.Common.attrib;
+      %att-open;
+      %att-close;
+      %att-separators;
+>
+
+<!-- Presentation layout schemata: scripts and limits -->
+
+<!ENTITY % pscrschema               
+     "%msub.qname; | %msup.qname; | %msubsup.qname; | %munder.qname; 
+      | %mover.qname; | %munderover.qname; | %mmultiscripts.qname;" >
+
+<!ATTLIST %msub.qname;      
+      %MATHML.Common.attrib;
+      %att-subscriptshift;
+>
+
+<!ATTLIST %msup.qname;         
+      %MATHML.Common.attrib;
+      %att-superscriptshift;
+>
+
+<!ATTLIST %msubsup.qname;    
+      %MATHML.Common.attrib;
+      %att-subscriptshift;
+      %att-superscriptshift;
+>
+
+<!ATTLIST %munder.qname;   
+      %MATHML.Common.attrib;
+      %att-accentunder;
+>
+
+<!ATTLIST %mover.qname;   
+      %MATHML.Common.attrib;
+      %att-accent;
+>
+
+<!ATTLIST %munderover.qname;   
+      %MATHML.Common.attrib;
+      %att-accent;
+      %att-accentunder;
+>
+
+<!ATTLIST %mmultiscripts.qname;   
+      %MATHML.Common.attrib;
+      %att-subscriptshift;
+      %att-superscriptshift;
+>
+
+<!-- Presentation layout schemata: empty elements for scripts -->
+
+<!ENTITY % pscreschema              
+     "%mprescripts.qname; | %none.qname;" >
+
+<!ELEMENT %mprescripts.qname;  EMPTY >
+<!ATTLIST %mprescripts.qname;   
+      %MATHML.xmlns.attrib; >
+
+<!ELEMENT %none.qname;  EMPTY >
+<!ATTLIST %none.qname;    
+      %MATHML.xmlns.attrib; >
+
+<!-- Presentation layout schemata: tables -->
+
+<![%MathMLstrict;[
+<!-- in strict mode only allow mtable at top level.
+     mtr ,mlabledtr and mtd only allowed inside mtable.
+-->
+  <!ENTITY % ptabschema    "%mtable.qname;" >
+]]>
+
+<!ENTITY % ptabschema               
+     "%mtable.qname; | %mtr.qname; | %mlabeledtr.qname; | %mtd.qname;" >
+
+<!ATTLIST %mtable.qname;
+      %MATHML.Common.attrib;
+      %att-tableinfo;
+>
+
+<!ATTLIST %mtr.qname;    
+      %MATHML.Common.attrib;
+      %att-rowalign;
+      %att-columnalign-list;	
+      %att-groupalign-list;	
+>
+
+<!ATTLIST %mlabeledtr.qname;  
+      %MATHML.Common.attrib;
+      %att-rowalign;
+      %att-columnalign-list;	
+      %att-groupalign-list;	
+>
+
+<!ATTLIST %mtd.qname;   
+      %MATHML.Common.attrib;
+      %att-rowalign;
+      %att-columnalign;
+      %att-groupalign-list;	
+      %att-rowspan;
+      %att-columnspan;
+>
+<!ENTITY % plschema                 
+     "%pgenschema; | %pscrschema; | %ptabschema;" >
+
+<!-- Empty presentation layout schemata -->
+
+<!ENTITY % peschema                 
+     "%maligngroup.qname; | %malignmark.qname;" >
+
+<!ELEMENT %malignmark.qname;  EMPTY >
+
+<!ATTLIST %malignmark.qname;  
+      %att-edge; >
+
+<!ELEMENT %maligngroup.qname;  EMPTY >
+<!ATTLIST %maligngroup.qname;  
+      %MATHML.Common.attrib;
+      %att-groupalign;
+>
+
+
+<!ELEMENT %mglyph.qname;  EMPTY >
+<!ATTLIST %mglyph.qname;    
+      %att-alt;
+      %att-fontfamily;
+      %att-index; >
+
+<!-- Presentation action schemata -->
+
+<!ENTITY % pactions                 
+     "%maction.qname;" >
+<!ATTLIST %maction.qname;    
+      %MATHML.Common.attrib;
+      %att-actiontype;
+      %att-selection;
+>
+
+<!-- The following entity for substitution into
+     content constructs excludes elements that
+     are not valid as expressions.
+-->
+
+<!ENTITY % PresInCont               
+     "%ptoken; | %petoken; |
+      %plschema; | %peschema; | %pactions;" >
+
+<!-- Presentation entity: all presentation constructs -->
+
+
+<![%MathMLstrict;[
+<!-- In strict mode don't allow prescripts and none at top level.-->
+  <!ENTITY % Presentation "%PresInCont;">             
+]]>
+<!ENTITY % Presentation             
+     "%ptoken; | %petoken; | %pscreschema; |
+      %plschema; | %peschema; | %pactions;">
+
+<!-- Content element set  ........................................ -->
+
+<!-- Attribute definitions -->
+
+<!ENTITY % att-base                 
+     "base         CDATA                    '10'" >
+<!ENTITY % att-closure              
+     "closure      CDATA                    'closed'" >
+<!ENTITY % att-definition           
+     "definitionURL CDATA                   ''" >
+<!ENTITY % att-encoding             
+     "encoding     CDATA                    ''" >
+<!ENTITY % att-nargs             
+     "nargs        CDATA                    '1'" >
+<!ENTITY % att-occurrence           
+     "occurrence   CDATA                    'function-model'" >
+<!ENTITY % att-order   
+     "order        CDATA                    'numeric'" >
+<!ENTITY % att-scope                
+     "scope        CDATA                    'local'" >
+<!ENTITY % att-type                 
+     "type         CDATA                    #IMPLIED" >
+
+<!-- Content elements: leaf nodes -->
+
+<!ENTITY % ctoken               
+     "%csymbol.qname; | %ci.qname; | %cn.qname;" >
+
+<!ATTLIST %ci.qname;     
+      %MATHML.Common.attrib;
+      %att-type;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ATTLIST %csymbol.qname;   
+      %MATHML.Common.attrib;
+      %att-encoding;
+      %att-type;
+      %att-definition;
+>
+
+<!ATTLIST %cn.qname;    
+      %MATHML.Common.attrib;
+      %att-type;
+      %att-base;
+      %att-definition;
+      %att-encoding;
+>
+
+<!-- Content elements: specials -->
+
+<!ENTITY % cspecial                 
+     "%apply.qname; | %reln.qname; |
+      %lambda.qname;" >
+
+<!ATTLIST %apply.qname;   
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %reln.qname;   
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %lambda.qname;      
+      %MATHML.Common.attrib;
+>
+
+<!-- Content elements: others -->
+
+<!ENTITY % cother                   
+     "%condition.qname; | %declare.qname; | %sep.qname;" >
+
+<!ATTLIST %condition.qname;     
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %declare.qname;    
+      %MATHML.Common.attrib;
+      %att-type;
+      %att-scope;
+      %att-nargs;
+      %att-occurrence;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %sep.qname;  EMPTY >
+<!ATTLIST %sep.qname;         
+      %MATHML.xmlns.attrib; >
+
+<!-- Content elements: semantic mapping -->
+
+<![%MathMLstrict;[
+<!-- in strict mode only allow semantics at top level.
+     annotation and annotation-xml only allowed in semantics
+-->
+  <!ENTITY % csemantics  "%semantics.qname;" >
+]]>
+<!ENTITY % csemantics               
+     "%semantics.qname; | %annotation.qname; |
+      %annotation-xml.qname;" >
+
+<!ATTLIST %semantics.qname;  
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ATTLIST %annotation.qname;  
+      %MATHML.Common.attrib;
+      %att-encoding;
+>
+
+<!ATTLIST %annotation-xml.qname; 
+      %MATHML.Common.attrib;
+      %att-encoding;
+>
+
+<!-- Content elements: constructors -->
+
+<!ENTITY % cconstructor             
+     "%interval.qname; | %list.qname; | %matrix.qname; 
+      | %matrixrow.qname; | %set.qname; | %vector.qname;
+      | %piecewise.qname; " >
+
+<!ATTLIST %interval.qname;   
+      %MATHML.Common.attrib;
+      %att-closure;
+>
+
+<!ATTLIST %set.qname;        
+      %MATHML.Common.attrib;
+      %att-type;
+>
+
+<!ATTLIST %list.qname;          
+      %MATHML.Common.attrib;
+      %att-order;
+>
+
+<!ATTLIST %vector.qname;    
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %matrix.qname;    
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %matrixrow.qname;     
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %piecewise.qname;   
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %piece.qname;   
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %otherwise.qname;   
+      %MATHML.Common.attrib;
+>
+
+
+<!-- Content elements: symbols -->
+
+<!ENTITY % c0ary              
+    "%integers.qname; |
+     %reals.qname; |
+     %rationals.qname; |
+     %naturalnumbers.qname; |
+     %complexes.qname; |
+     %primes.qname; |
+     %exponentiale.qname; |
+     %imaginaryi.qname; |
+     %notanumber.qname; |
+     %true.qname; |
+     %false.qname; |
+     %emptyset.qname; |
+     %pi.qname; |
+     %eulergamma.qname; |
+     %infinity.qname;" >
+
+<!ELEMENT %integers.qname;  EMPTY >
+<!ATTLIST %integers.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %reals.qname;  EMPTY >
+<!ATTLIST %reals.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %rationals.qname;  EMPTY >
+<!ATTLIST %rationals.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %naturalnumbers.qname;  EMPTY >
+<!ATTLIST %naturalnumbers.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %complexes.qname;  EMPTY >
+<!ATTLIST %complexes.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %primes.qname;  EMPTY >
+<!ATTLIST %primes.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %exponentiale.qname;  EMPTY >
+<!ATTLIST %exponentiale.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %imaginaryi.qname;  EMPTY >
+<!ATTLIST %imaginaryi.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %notanumber.qname;  EMPTY >
+<!ATTLIST %notanumber.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %true.qname;  EMPTY >
+<!ATTLIST %true.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %false.qname;  EMPTY >
+<!ATTLIST %false.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %emptyset.qname;  EMPTY >
+<!ATTLIST %emptyset.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %pi.qname;  EMPTY >
+<!ATTLIST %pi.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %eulergamma.qname;  EMPTY >
+<!ATTLIST %eulergamma.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %infinity.qname;  EMPTY >
+<!ATTLIST %infinity.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!-- Content elements: operators -->
+
+<!ENTITY % cfuncop1ary              
+     "%inverse.qname; | %ident.qname;|
+      %domain.qname; |  %codomain.qname; | 
+      %image.qname;  " >
+
+<!ELEMENT %inverse.qname;  EMPTY >
+<!ATTLIST %inverse.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %domain.qname;  EMPTY >
+<!ATTLIST %domain.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %codomain.qname;  EMPTY >
+<!ATTLIST %codomain.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %image.qname;  EMPTY >
+<!ATTLIST %image.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+
+
+<!ENTITY % cfuncopnary              
+     "%fn.qname; | %compose.qname;" >
+
+<!ATTLIST %fn.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %ident.qname;  EMPTY >
+<!ATTLIST %ident.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %compose.qname;  EMPTY >
+<!ATTLIST %compose.qname;  
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % carithop1ary             
+     "%abs.qname; | %conjugate.qname; | %exp.qname; | %factorial.qname; |
+      %arg.qname; | %real.qname; | %imaginary.qname; |
+      %floor.qname; | %ceiling.qname;" >
+
+<!ELEMENT %exp.qname;  EMPTY >
+<!ATTLIST %exp.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %abs.qname;  EMPTY >
+<!ATTLIST %abs.qname;        
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arg.qname;  EMPTY >
+<!ATTLIST %arg.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %real.qname;  EMPTY >
+<!ATTLIST %real.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %imaginary.qname;  EMPTY >
+<!ATTLIST %imaginary.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %conjugate.qname;  EMPTY >
+<!ATTLIST %conjugate.qname;  
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %factorial.qname;  EMPTY >
+<!ATTLIST %factorial.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+
+<!ELEMENT %floor.qname;  EMPTY >
+<!ATTLIST %floor.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %ceiling.qname;  EMPTY >
+<!ATTLIST %ceiling.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+<!ENTITY % carithop1or2ary          
+     "%minus.qname;" >
+
+<!ELEMENT %minus.qname;  EMPTY >
+<!ATTLIST %minus.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % carithop2ary             
+     "%quotient.qname; | %divide.qname; | %power.qname; | %rem.qname;" >
+
+<!ELEMENT %quotient.qname;  EMPTY >
+<!ATTLIST %quotient.qname;       
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %divide.qname;  EMPTY >
+<!ATTLIST %divide.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %power.qname;  EMPTY >
+<!ATTLIST %power.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %rem.qname;  EMPTY >
+<!ATTLIST %rem.qname;       
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % carithopnary             
+     "%plus.qname; | %times.qname; | %max.qname; 
+      | %min.qname; | %gcd.qname; | %lcm.qname;" >
+
+<!ELEMENT %plus.qname;  EMPTY >
+<!ATTLIST %plus.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %max.qname;  EMPTY >
+<!ATTLIST %max.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %min.qname;  EMPTY >
+<!ATTLIST %min.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %times.qname;  EMPTY >
+<!ATTLIST %times.qname;      
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %gcd.qname;  EMPTY >
+<!ATTLIST %gcd.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %lcm.qname;  EMPTY >
+<!ATTLIST %lcm.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % carithoproot             
+     "%root.qname;" >
+
+<!ELEMENT %root.qname;  EMPTY >
+<!ATTLIST %root.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % clogicopquant            
+     "%exists.qname; | %forall.qname;" >
+
+<!ELEMENT %exists.qname;  EMPTY >
+<!ATTLIST %exists.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %forall.qname;  EMPTY >
+<!ATTLIST %forall.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % clogicopnary             
+     "%and.qname; | %or.qname; | %xor.qname;" >
+
+<!ELEMENT %and.qname;  EMPTY >
+<!ATTLIST %and.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %or.qname;  EMPTY >
+<!ATTLIST %or.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %xor.qname;  EMPTY >
+<!ATTLIST %xor.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % clogicop1ary             
+     "%not.qname;" >
+
+<!ELEMENT %not.qname;  EMPTY >
+<!ATTLIST %not.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % clogicop2ary             
+     "%implies.qname;" >
+
+<!ELEMENT %implies.qname;  EMPTY >
+<!ATTLIST %implies.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % ccalcop                  
+     "%log.qname; | %int.qname; | %diff.qname; | %partialdiff.qname; |
+      %divergence.qname; | %grad.qname; | %curl.qname; | %laplacian.qname;" >
+
+<!ELEMENT %divergence.qname;  EMPTY >
+<!ATTLIST %divergence.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %grad.qname;  EMPTY >
+<!ATTLIST %grad.qname;  
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %curl.qname;  EMPTY >
+<!ATTLIST %curl.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %laplacian.qname;  EMPTY >
+<!ATTLIST %laplacian.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %log.qname;  EMPTY >
+<!ATTLIST %log.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %int.qname;  EMPTY >
+<!ATTLIST %int.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %diff.qname;  EMPTY >
+<!ATTLIST %diff.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %partialdiff.qname;  EMPTY >
+<!ATTLIST %partialdiff.qname;  
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % ccalcop1ary              
+     "%ln.qname;" >
+
+<!ELEMENT %ln.qname;  EMPTY >
+<!ATTLIST %ln.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % csetop1ary               
+     "%card.qname;" >
+
+<!ELEMENT %card.qname;  EMPTY >
+<!ATTLIST %card.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % csetop2ary               
+     "%setdiff.qname;" >
+
+<!ELEMENT %setdiff.qname;  EMPTY >
+<!ATTLIST %setdiff.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % csetopnary               
+     "%union.qname; | %intersect.qname; | %cartesianproduct.qname; " >
+
+<!ELEMENT %union.qname;  EMPTY >
+<!ATTLIST %union.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %intersect.qname;  EMPTY >
+<!ATTLIST %intersect.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %cartesianproduct.qname;  EMPTY >
+<!ATTLIST %cartesianproduct.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % cseqop                   
+     "%sum.qname; | %product.qname; | %limit.qname;" >
+
+<!ELEMENT %sum.qname;  EMPTY >
+<!ATTLIST %sum.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %product.qname;  EMPTY >
+<!ATTLIST %product.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %limit.qname;  EMPTY >
+<!ATTLIST %limit.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % ctrigop                  
+     "%sin.qname; | %cos.qname; | %tan.qname; 
+      | %sec.qname; | %csc.qname; | %cot.qname; 
+      | %sinh.qname; | %cosh.qname; | %tanh.qname; 
+      | %sech.qname; | %csch.qname; | %coth.qname; 
+      | %arcsin.qname; | %arccos.qname; | %arctan.qname;
+      | %arccosh.qname; | %arccot.qname; | %arccoth.qname;
+      | %arccsc.qname; | %arccsch.qname; | %arcsec.qname;
+      | %arcsech.qname; | %arcsinh.qname; | %arctanh.qname;
+      " >
+
+<!ELEMENT %sin.qname;  EMPTY >
+<!ATTLIST %sin.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %cos.qname;  EMPTY >
+<!ATTLIST %cos.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %tan.qname;  EMPTY >
+<!ATTLIST %tan.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %sec.qname;  EMPTY >
+<!ATTLIST %sec.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %csc.qname;  EMPTY >
+<!ATTLIST %csc.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %cot.qname;  EMPTY >
+<!ATTLIST %cot.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %sinh.qname;  EMPTY >
+<!ATTLIST %sinh.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %cosh.qname;  EMPTY >
+<!ATTLIST %cosh.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %tanh.qname;  EMPTY >
+<!ATTLIST %tanh.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %sech.qname;  EMPTY >
+<!ATTLIST %sech.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %csch.qname;  EMPTY >
+<!ATTLIST %csch.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %coth.qname;  EMPTY >
+<!ATTLIST %coth.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arcsin.qname;  EMPTY >
+<!ATTLIST %arcsin.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arccos.qname;  EMPTY >
+<!ATTLIST %arccos.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arctan.qname;  EMPTY >
+<!ATTLIST %arctan.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arccosh.qname;  EMPTY >
+<!ATTLIST %arccosh.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+
+<!ELEMENT %arccot.qname;  EMPTY >
+<!ATTLIST %arccot.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arccoth.qname;  EMPTY >
+<!ATTLIST %arccoth.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+
+<!ELEMENT %arccsc.qname;  EMPTY >
+<!ATTLIST %arccsc.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arccsch.qname;  EMPTY >
+<!ATTLIST %arccsch.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arcsec.qname;  EMPTY >
+<!ATTLIST %arcsec.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arcsech.qname;  EMPTY >
+<!ATTLIST %arcsech.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arcsinh.qname;  EMPTY >
+<!ATTLIST %arcsinh.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arctanh.qname;  EMPTY >
+<!ATTLIST %arctanh.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+
+
+<!ENTITY % cstatopnary              
+     "%mean.qname; | %sdev.qname; |
+      %variance.qname; | %median.qname; |
+      %mode.qname;" >
+
+<!ELEMENT %mean.qname;  EMPTY >
+<!ATTLIST %mean.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %sdev.qname;  EMPTY >
+<!ATTLIST %sdev.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %variance.qname;  EMPTY >
+<!ATTLIST %variance.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %median.qname;  EMPTY >
+<!ATTLIST %median.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %mode.qname;  EMPTY >
+<!ATTLIST %mode.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % cstatopmoment            
+     "%moment.qname;" >
+
+<!ELEMENT %moment.qname;  EMPTY >
+<!ATTLIST %moment.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % clalgop1ary              
+     "%determinant.qname; |
+      %transpose.qname;" >
+
+<!ELEMENT %determinant.qname;  EMPTY >
+<!ATTLIST %determinant.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %transpose.qname;  EMPTY >
+<!ATTLIST %transpose.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % clalgop2ary              
+     "%vectorproduct.qname; 
+      | %scalarproduct.qname; 
+      | %outerproduct.qname;" >
+
+<!ELEMENT %vectorproduct.qname;  EMPTY >
+<!ATTLIST %vectorproduct.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %scalarproduct.qname;  EMPTY >
+<!ATTLIST %scalarproduct.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %outerproduct.qname;  EMPTY >
+<!ATTLIST %outerproduct.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % clalgopnary              
+     "%selector.qname;" >
+
+<!ELEMENT %selector.qname;  EMPTY >
+<!ATTLIST %selector.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!-- Content elements: relations -->
+
+<!ENTITY % cgenrel2ary             
+     "%neq.qname; | %factorof.qname;" >
+
+<!ELEMENT %neq.qname;  EMPTY >
+<!ATTLIST %neq.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %factorof.qname;  EMPTY >
+<!ATTLIST %factorof.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % cgenrelnary              
+     "%eq.qname; | %leq.qname; | %lt.qname; | %geq.qname; 
+      | %gt.qname;| %equivalent.qname; | %approx.qname;" >
+
+<!ELEMENT %eq.qname;  EMPTY >
+<!ATTLIST %eq.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %equivalent.qname;  EMPTY >
+<!ATTLIST %equivalent.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %approx.qname;  EMPTY >
+<!ATTLIST %approx.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %gt.qname;  EMPTY >
+<!ATTLIST %gt.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %lt.qname;  EMPTY >
+<!ATTLIST %lt.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %geq.qname;  EMPTY >
+<!ATTLIST %geq.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %leq.qname;  EMPTY >
+<!ATTLIST %leq.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % csetrel2ary              
+     "%in.qname; | %notin.qname; | %notsubset.qname; | %notprsubset.qname;" >
+
+<!ELEMENT %in.qname;  EMPTY >
+<!ATTLIST %in.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %notin.qname;  EMPTY >
+<!ATTLIST %notin.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %notsubset.qname;  EMPTY >
+<!ATTLIST %notsubset.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %notprsubset.qname;  EMPTY >
+<!ATTLIST %notprsubset.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % csetrelnary       
+     "%subset.qname; | %prsubset.qname;" >
+
+<!ELEMENT %subset.qname;  EMPTY >
+<!ATTLIST %subset.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %prsubset.qname;  EMPTY >
+<!ATTLIST %prsubset.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % cseqrel2ary              
+     "%tendsto.qname;" >
+
+<!ELEMENT %tendsto.qname;  EMPTY >
+<!ATTLIST %tendsto.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+      %att-type;
+>
+
+<!-- Content elements: quantifiers -->
+
+<!ENTITY % cquantifier            
+     "%lowlimit.qname; | %uplimit.qname; | %bvar.qname; 
+      | %degree.qname; | %logbase.qname;
+      | %momentabout.qname; | %domainofapplication.qname; " >
+
+<!ATTLIST %lowlimit.qname;
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %uplimit.qname;
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %bvar.qname;
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %degree.qname;
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %logbase.qname;
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %momentabout.qname;
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %domainofapplication.qname;
+      %MATHML.Common.attrib;
+>
+
+<!-- Operator groups -->
+
+<!ENTITY % cop1ary                  
+     "%cfuncop1ary; | %carithop1ary; | %clogicop1ary; |
+      %ccalcop1ary; | %ctrigop; | %clalgop1ary; |
+      %csetop1ary;" >
+
+<!ENTITY % cop2ary                  
+     "%carithop2ary; | %clogicop2ary;| %clalgop2ary; | %csetop2ary;" >
+
+<!ENTITY % copnary                  
+     "%cfuncopnary; | %carithopnary; | %clogicopnary; |
+      %csetopnary; | %cstatopnary; | %clalgopnary;" >
+
+<!ENTITY % copmisc                  
+     "%carithoproot; | %carithop1or2ary; | %ccalcop; |
+      %cseqop; | %cstatopmoment; | %clogicopquant;" >
+
+<!-- Relation groups -->
+
+<!ENTITY % crel2ary                 
+     "%cgenrel2ary; | %csetrel2ary; | %cseqrel2ary;" >
+
+<!ENTITY % crelnary                 
+     "%cgenrelnary; | %csetrelnary;" >
+
+<!-- Content constructs: all -->
+
+<!ENTITY % Content                  
+     "%ctoken; | %cspecial; | %cother; | %csemantics; | %c0ary;
+      | %cconstructor; | %cquantifier; | %cop1ary; | %cop2ary; 
+      | %copnary; |%copmisc; | %crel2ary; | %crelnary;" >
+
+<!-- Content constructs for substitution in presentation structures -->
+
+<!ENTITY % ContInPres               
+     "%ci.qname; |%csymbol.qname;| %cn.qname; | %c0ary; |
+      %apply.qname; | %fn.qname; |
+      %lambda.qname; | %reln.qname; |
+      %cconstructor; |
+      %semantics.qname; |%declare.qname;" >
+
+<!-- ............................................................. -->
+<!-- Recursive definition for content of expressions. Include
+     presentation constructs at lowest level so presentation
+     layout schemata hold presentation or content elements.
+     Include content constructs at lowest level so content
+     elements hold PCDATA or presentation elements at leaf
+     level (for permitted substitutable elements in context)
+-->
+<![%MathMLstrict;[
+<!-- in strict mode don't allow presentation in content
+     except where allowed by chapter 5:
+     ci, cn, csymbol, semantics
+-->
+  <!ENTITY % ContentExpression  "(%Content;)*" >
+  <!ENTITY % semanticsContentExpression        
+       "(%Content; | %PresInCont; |
+         %annotation.qname; | %annotation-xml.qname;)*" >
+]]>
+<!ENTITY % ContentExpression        
+     "(%Content; | %PresInCont;)*" >
+<!ENTITY % semanticsContentExpression    "%ContentExpression;">    
+
+
+<!ENTITY % PresExpression      
+     "(%Presentation; | %ContInPres;)*" >
+<!ENTITY % MathExpression           
+     "(%PresInCont; | %ContInPres;)*" >
+
+<!-- PCDATA or MathML character elements -->
+<!ENTITY % MathMLCharacters         
+     "#PCDATA | %mglyph.qname; " >
+
+<!-- Content elements: tokens                       -->
+<!-- (may contain embedded presentation constructs) -->
+
+<!ELEMENT %ci.qname;                 (%MathMLCharacters; | %PresInCont;)* >
+<!ELEMENT %csymbol.qname;            (%MathMLCharacters; | %PresInCont;)* >
+<!ELEMENT %cn.qname;                 (%MathMLCharacters; | %sep.qname; | %PresInCont;)* >
+
+<!-- Content elements: special -->
+
+<!ELEMENT %apply.qname;              (%ContentExpression;) >
+<!ELEMENT %reln.qname;               (%ContentExpression;) >
+<!ELEMENT %lambda.qname;             (%ContentExpression;) >
+
+<!-- Content elements: other -->
+
+<!ELEMENT %condition.qname;          (%ContentExpression;) >
+<!ELEMENT %declare.qname;            (%ContentExpression;) >
+
+<!-- Content elements: semantics -->
+
+<!ELEMENT %semantics.qname;          (%semanticsContentExpression;) >
+<!ENTITY % Annotation.content  "( #PCDATA )" >
+<!ELEMENT %annotation.qname;         %Annotation.content; >
+
+<!ENTITY % Annotation-xml.content "ANY" >
+<!ELEMENT %annotation-xml.qname;     %Annotation-xml.content; >
+
+<!-- Content elements: constructors -->
+
+<!ELEMENT %interval.qname;           (%ContentExpression;) >
+<!ELEMENT %set.qname;                (%ContentExpression;) >
+<!ELEMENT %list.qname;               (%ContentExpression;) >
+<!ELEMENT %vector.qname;             (%ContentExpression;) >
+<!ELEMENT %matrix.qname;             (%ContentExpression;) >
+<!ELEMENT %matrixrow.qname;          (%ContentExpression;) >
+
+<!ELEMENT %piecewise.qname;          ((%piece.qname;)*, (%otherwise.qname;)? ) >
+<!ELEMENT %piece.qname;              (%ContentExpression;) >
+<!ELEMENT %otherwise.qname;          (%ContentExpression;) >
+
+<!-- Content elements: operator (user-defined) -->
+
+<!ELEMENT %fn.qname;                 (%ContentExpression;) >
+
+<!-- Content elements: quantifiers -->
+
+<!ELEMENT %lowlimit.qname;           (%ContentExpression;) >
+<!ELEMENT %uplimit.qname;            (%ContentExpression;) >
+<!ELEMENT %bvar.qname;               (%ContentExpression;) >
+<!ELEMENT %degree.qname;             (%ContentExpression;) >
+<!ELEMENT %logbase.qname;            (%ContentExpression;) >
+<!ELEMENT %momentabout.qname;        (%ContentExpression;) >
+<!ELEMENT %domainofapplication.qname; (%ContentExpression;) >
+
+<!-- ............................................................. -->
+<!-- Presentation layout schemata contain tokens,
+     layout and content schemata.
+-->
+
+
+
+<![%MathMLstrict;[
+<!-- In strict mode enforce mfrac has exactly two children
+      same for msub etc -->
+  <!ENTITY % onePresExpression
+       "(%Presentation; | %ContInPres;)" >
+  <!ENTITY % twoPresExpression
+       "(%onePresExpression;,%onePresExpression;)" >
+  <!ENTITY % threePresExpression
+       "(%onePresExpression;,%onePresExpression;,%onePresExpression;)" >
+  <!ENTITY % mtrPresExpression
+       "(%mtr.qname;|%mlabeledtr.qname;)*" >
+  <!ENTITY % mtdPresExpression
+       "(%mtd.qname;)*" >
+  <!ENTITY % prscrPresExpression " (%onePresExpression;,
+  ((%onePresExpression;|%none.qname;),(%onePresExpression;|%none.qname;))*,
+  (%mprescripts.qname;,
+  ((%onePresExpression;|%none.qname;),(%onePresExpression;|%none.qname;))*)?
+  )">
+]]>
+
+
+<!-- By default keep them as they were in MathML 2.0  -->
+<!ENTITY % onePresExpression   "%PresExpression;">
+<!ENTITY % twoPresExpression   "%PresExpression;">
+<!ENTITY % threePresExpression "%PresExpression;">
+<!ENTITY % mtrPresExpression   "%PresExpression;">
+<!ENTITY % mtdPresExpression   "%PresExpression;">
+<!ENTITY % prscrPresExpression "%PresExpression;">
+
+<!ELEMENT %mstyle.qname;             (%PresExpression;) >
+<!ELEMENT %merror.qname;             (%PresExpression;) >
+<!ELEMENT %mphantom.qname;           (%PresExpression;) >
+<!ELEMENT %mrow.qname;               (%PresExpression;) >
+<!ELEMENT %mfrac.qname;              (%twoPresExpression;) >
+<!ELEMENT %msqrt.qname;              (%PresExpression;) >
+<!ELEMENT %menclose.qname;           (%PresExpression;) >
+<!ELEMENT %mroot.qname;              (%twoPresExpression;) >
+<!ELEMENT %msub.qname;               (%twoPresExpression;) >
+<!ELEMENT %msup.qname;               (%twoPresExpression;) >
+<!ELEMENT %msubsup.qname;            (%threePresExpression;) >
+<!ELEMENT %mmultiscripts.qname;      (%prscrPresExpression;) >
+<!ELEMENT %munder.qname;             (%twoPresExpression;) >
+<!ELEMENT %mover.qname;              (%twoPresExpression;) >
+<!ELEMENT %munderover.qname;         (%threePresExpression;) >
+<!ELEMENT %mtable.qname;             (%mtrPresExpression;) >
+<!ELEMENT %mtr.qname;                (%mtdPresExpression;) >
+<!ELEMENT %mlabeledtr.qname;         (%mtdPresExpression;) >
+<!ELEMENT %mtd.qname;                (%PresExpression;) >
+<!ELEMENT %maction.qname;            (%PresExpression;) >
+<!ELEMENT %mfenced.qname;            (%PresExpression;) >
+<!ELEMENT %mpadded.qname;            (%PresExpression;) >
+
+<!-- Presentation elements contain PCDATA or malignmark constructs. -->
+
+<!ELEMENT %mi.qname;                 (%MathMLCharacters; |
+      %malignmark.qname;)* >
+<!ELEMENT %mn.qname;                 (%MathMLCharacters; |
+      %malignmark.qname;)* >
+<!ELEMENT %mo.qname;                 (%MathMLCharacters; |
+      %malignmark.qname;)* >
+<!ELEMENT %mtext.qname;              (%MathMLCharacters; |
+      %malignmark.qname;)* >
+<!ELEMENT %ms.qname;                 (%MathMLCharacters; |
+      %malignmark.qname;)* >
+
+<!-- Browser interface definition  ............................... -->
+
+<!-- Attributes for top-level element "math" -->
+
+<!ENTITY % att-macros               
+     "macros       CDATA                    #IMPLIED" >
+<!ENTITY % att-mode                 
+     "mode         CDATA                    #IMPLIED" >
+<![%MathMLstrict;[
+  <!ENTITY % att-display
+     "display      ( block | inline )                    'inline'" >
+]]>
+<!ENTITY % att-display                
+     "display      CDATA                    #IMPLIED" >
+
+<!ENTITY % att-schemalocation               
+     "%Schema.prefix;:schemaLocation CDATA  #IMPLIED">		
+
+<!ENTITY % att-topinfo          
+     "%MATHML.Common.attrib;
+      %att-schemalocation;		
+      %att-macros;
+      %att-mode;
+      %att-display;" >
+
+<!-- Attributes for browser interface element -->
+
+<!ENTITY % att-baseline             
+     "baseline     CDATA                    #IMPLIED" >
+<!ENTITY % att-overflow            
+     "overflow  ( scroll | elide | truncate | scale ) 'scroll'" >
+<!ENTITY % att-altimg               
+     "altimg       CDATA                    #IMPLIED" >
+<!ENTITY % att-alttext           
+     "alttext      CDATA                    #IMPLIED" >
+
+<!ENTITY % att-browif           
+     "%att-type;
+      %att-name;
+      %att-height;
+      %att-width;
+      %att-baseline;
+      %att-overflow;
+      %att-altimg;
+      %att-alttext;" >
+
+<!-- ............................................................. -->
+<!-- The top-level element "math" contains MathML encoded
+     mathematics. The "math" element has the browser info
+     attributes iff it is also the browser interface element.
+-->
+
+<!ELEMENT %math.qname;               (%MathExpression;) >
+
+<!ATTLIST %math.qname;
+      %att-topinfo;
+      %att-browif; >
+
+<!-- MathML Character Entities .............................................. -->
+<!ENTITY % mathml-charent.module "INCLUDE" >
+<![%mathml-charent.module;[
+<!-- Entity sets from ISO Technical Report 9573-13 ..... -->
+
+<!ENTITY % ent-isoamsa
+      PUBLIC "-//W3C//ENTITIES Added Math Symbols: Arrow Relations for MathML 2.0//EN"
+             "iso9573-13/isoamsa.ent" >
+%ent-isoamsa;
+
+<!ENTITY % ent-isoamsb
+      PUBLIC "-//W3C//ENTITIES Added Math Symbols: Binary Operators for MathML 2.0//EN"
+             "iso9573-13/isoamsb.ent" >
+%ent-isoamsb;
+
+<!ENTITY % ent-isoamsc
+      PUBLIC "-//W3C//ENTITIES Added Math Symbols: Delimiters for MathML 2.0//EN"
+             "iso9573-13/isoamsc.ent" >
+%ent-isoamsc;
+
+<!ENTITY % ent-isoamsn
+      PUBLIC "-//W3C//ENTITIES Added Math Symbols: Negated Relations for MathML 2.0//EN"
+             "iso9573-13/isoamsn.ent" >
+%ent-isoamsn;
+
+<!ENTITY % ent-isoamso
+      PUBLIC "-//W3C//ENTITIES Added Math Symbols: Ordinary for MathML 2.0//EN"
+             "iso9573-13/isoamso.ent" >
+%ent-isoamso;
+
+<!ENTITY % ent-isoamsr
+      PUBLIC "-//W3C//ENTITIES Added Math Symbols: Relations for MathML 2.0//EN"
+             "iso9573-13/isoamsr.ent" >
+%ent-isoamsr;
+
+<!ENTITY % ent-isogrk3
+      PUBLIC "-//W3C//ENTITIES Greek Symbols for MathML 2.0//EN"
+             "iso9573-13/isogrk3.ent" >
+%ent-isogrk3;
+
+<!ENTITY % ent-isomfrk
+      PUBLIC "-//W3C//ENTITIES Math Alphabets: Fraktur for MathML 2.0//EN"
+             "iso9573-13/isomfrk.ent" >
+%ent-isomfrk;
+
+<!ENTITY % ent-isomopf
+      PUBLIC "-//W3C//ENTITIES Math Alphabets: Open Face for MathML 2.0//EN"
+             "iso9573-13/isomopf.ent" >
+%ent-isomopf;
+
+<!ENTITY % ent-isomscr
+      PUBLIC "-//W3C//ENTITIES Math Alphabets: Script for MathML 2.0//EN"
+             "iso9573-13/isomscr.ent" >
+%ent-isomscr;
+
+<!ENTITY % ent-isotech
+      PUBLIC "-//W3C//ENTITIES General Technical for MathML 2.0//EN"
+             "iso9573-13/isotech.ent" >
+%ent-isotech;
+
+<!-- Entity sets from informative annex to ISO 8879:1986 (SGML) ....... -->
+
+<!ENTITY % ent-isobox
+      PUBLIC "-//W3C//ENTITIES Box and Line Drawing for MathML 2.0//EN"
+             "iso8879/isobox.ent" >
+%ent-isobox;
+
+<!ENTITY % ent-isocyr1
+      PUBLIC "-//W3C//ENTITIES Russian Cyrillic for MathML 2.0//EN"
+             "iso8879/isocyr1.ent" >
+%ent-isocyr1;
+
+<!ENTITY % ent-isocyr2
+      PUBLIC "-//W3C//ENTITIES Non-Russian Cyrillic for MathML 2.0//EN"
+             "iso8879/isocyr2.ent" >
+%ent-isocyr2;
+
+<!ENTITY % ent-isodia
+      PUBLIC "-//W3C//ENTITIES Diacritical Marks for MathML 2.0//EN"
+             "iso8879/isodia.ent" >
+%ent-isodia;
+
+<!ENTITY % ent-isolat1
+      PUBLIC "-//W3C//ENTITIES Added Latin 1 for MathML 2.0//EN"
+             "iso8879/isolat1.ent" >
+%ent-isolat1;
+
+<!ENTITY % ent-isolat2
+      PUBLIC "-//W3C//ENTITIES Added Latin 2 for MathML 2.0//EN"
+             "iso8879/isolat2.ent" >
+%ent-isolat2;
+
+<!ENTITY % ent-isonum
+      PUBLIC "-//W3C//ENTITIES Numeric and Special Graphic for MathML 2.0//EN"
+             "iso8879/isonum.ent" >
+%ent-isonum;
+
+<!ENTITY % ent-isopub
+      PUBLIC "-//W3C//ENTITIES Publishing for MathML 2.0//EN"
+             "iso8879/isopub.ent" >
+%ent-isopub;
+
+<!-- New characters defined by MathML ............................ -->
+
+<!ENTITY % ent-mmlextra
+      PUBLIC "-//W3C//ENTITIES Extra for MathML 2.0//EN"
+             "mathml/mmlextra.ent" >
+%ent-mmlextra;
+
+<!-- MathML aliases for characters defined above ................. -->
+
+<!ENTITY % ent-mmlalias
+      PUBLIC "-//W3C//ENTITIES Aliases for MathML 2.0//EN"
+             "mathml/mmlalias.ent" >
+%ent-mmlalias;
+
+<!-- end of MathML Character Entity section -->]]>
+
+<!-- Revision History:
+
+       Initial draft (syntax = XML) 1997-05-09
+          Stephen Buswell
+       Revised 1997-05-14
+          Robert Miner
+       Revised 1997-06-29 and 1997-07-02
+          Stephen Buswell
+       Revised 1997-12-15
+          Stephen Buswell
+       Revised 1998-02-08
+          Stephen Buswell
+       Revised 1998-04-04
+          Stephen Buswell
+       Entities and small revisions 1999-02-21
+          David Carlisle
+       Added attribute definitionURL to ci and cn 1999-10-11
+          Nico Poppelier
+       Additions for MathML 2  1999-12-16
+          David Carlisle
+       Namespace support 2000-01-14
+          David Carlisle
+       XHTML Compatibility 2000-02-23
+          Murray Altheim
+       New content elements 2000-03-26
+          David Carlisle
+       Further revisions for MathML2 CR draft 2000-07-11
+          David Carlisle
+       Further revisions for MathML2 CR draft 2000-10-31		
+          David Carlisle		
+       Revisions for Unicode 3.2  2002-05-21		
+          David Carlisle		
+       Add width and side attributes to mtable (to align with the specification)  2002-06-05		
+          David Carlisle		
+       Use %XLINK.prefix rather than hardwired xlink:, add xlink:type 2002-06-12		
+          David Carlisle		
+       Add missing numalign and denomalign attributes for mfrac 2002-07-05		
+          David Carlisle		
+       Add MathMLstrict entity and related extra constraints 2002-12-05		
+          David Carlisle		
+       Add support for xi:schemaLocation 2003-04-05		
+          David Carlisle		
+       Removed actiontype from mstyle (to match spec) 2003-04-07		
+          David Carlisle		
+       Additional constraints for MathMLstrict code (From Simon		
+          Pepping on www-math list) 2003-05-22		
+          David Carlisle		
+       Add missing minlabelspacing attribute (From Simon		
+          Pepping on www-math list) 2003-05-22		
+          David Carlisle		
+       Removed restricted menclose notation checking from MathMLstrict 2003-09-08		
+          David Carlisle		
+
+-->
+
+<!-- end of MathML 2.0 DTD  ................................................ -->
+<!-- ....................................................................... -->
+

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/BITS-embedded-index2.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/BITS-embedded-index2.ent.rng
@@ -1,0 +1,393 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    BITS Embedded Index Element Module -->
+<!-- VERSION:   BITS 2.1 -->
+<!-- DATE:      April 2018 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD BITS Embedded Index Element Module v2.1 20180401//EN"
+  Delivered as file "BITS-embedded-index2.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     Book Interchange Tag Suite -->
+<!---->
+<!-- PURPOSE:    Defines the index terms to be embedded into the -->
+<!-- narrative of a document so that an Index can be -->
+<!-- created programmatically. -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This DTD was created as a superset customization -->
+<!-- of the ANSI/NISO JATS Z39.96-2012 Version 1.0 -->
+<!-- Journal Article Tag Set. -->
+<!---->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of books or book-like -->
+<!-- material for archiving and transferring -->
+<!-- such material between archives or they may create -->
+<!-- a custom XML DTD from the BITS Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and new DTD-specific customization -->
+<!-- modules to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the BITS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the Book Interchange Tag Suite (BITS). -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the Book Interchange Tag Suite -->
+<!-- (BITS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- April 2012 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the National -->
+<!-- National Center for Biotechnology Information -->
+<!-- (NCBI), a center of the US National Library of -->
+<!-- Medicine (NLM). -->
+<!---->
+<!-- The BITS Book Interchange DTD is built from the -->
+<!-- Journal Archiving and Interchange DTD of the -->
+<!-- ANSI/NISO Journal Article Tag Suite (JATS) -->
+<!-- Version 1.1d1 (Z39.96-2015). -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- bits@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+    4. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.     =============================================================
+       BITS Version 2.0                (DAL/BTU) v2.0  (2015-12-25)
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, and BITS modified to use
+       the most recent version. No other changes to BITS were made.
+  
+    3. BITS remained version "2.0" but became "v2.0 20151225"
+       JATS became version "1.1" and "v1.1 20151215"
+  
+      =============================================================
+       BITS Version 2.0                (DAL/BTU) v2.0  (2015-03-15)
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-03-01)
+  
+       BITS was modified, based on user feedback collected in 2014 
+       and January/February 2015, according to the decisions
+       made by the BITS Working Group. This DTD represents current 
+       BITS and an interim version of the non-normative JATS DTD 
+       Suite (version 1.1), as an indication to JATS users of 
+       the decisions that have been made by the JATS Standing
+       Committee. 
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+    2. BITS became version "2.0" and   "v2.0 20150630"
+       JATS became version "1.1" and "v1.1 20150301"
+  
+       =============================================================
+       BITS Version 1.1                (DAL/BTU) v1.1    (2014-09-30)
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2  (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    1. BITS became version "1.1" and   "v1.1 20140930//EN"
+       JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+-->
+<!-- ============================================================= -->
+<!-- PARAMETER ENTITIES FOR ATTRIBUTE LISTS -->
+<!-- ============================================================= -->
+<!-- INDEX-TERM ATTRIBUTES -->
+<!--
+  Attribute list for <index-term> element.
+  Names the specific indexes in which this term
+  should be used. Contains an index name or
+  series of index names for an embedded
+  index.
+-->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="index-term-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="index-type">
+        <data type="NMTOKENS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- INDEX-TERM RANGE END ATTRIBUTES -->
+  <!--
+    Attribute list for <index-term-range-end>
+    element.
+  -->
+  <define name="index-term-range-end-atts">
+    <ref name="jats-common-atts"/>
+    <attribute name="rid">
+      <data type="IDREF"/>
+    </attribute>
+  </define>
+  <!-- SEE ATTRIBUTES -->
+  <!-- Attribute list for <see> element. -->
+  <define name="see-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="rid">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- SEE-ALSO ATTRIBUTES -->
+  <!-- Attribute list for <see-also> element. -->
+  <define name="see-also-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="rid">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ============================================================= -->
+  <!-- INDEX ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- INDEX TERM MODEL -->
+  <!--
+    Content model for the embedded index term
+    <index-term> element.
+  -->
+  <define name="index-term-model">
+    <ref name="term"/>
+    <choice>
+      <ref name="index-term"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="see"/>
+          <ref name="see-also"/>
+        </choice>
+      </zeroOrMore>
+    </choice>
+  </define>
+  <!-- INDEX TERM -->
+  <!--
+    The index term to be embedded into the
+    narrative of a document so that an Index
+    can be created programmatically. An
+    <index-term> is either a single target point
+    or the start of an index range. When it is the
+    start of a range, an @id attribute is
+    required, so that the <index-term-range-end>
+    element can point to the start of the range.
+    Details at:
+    http://jats.nlm.nih.gov/extensions/bits/2.1/index.html?elem=index-term
+  -->
+  <define name="index-term">
+    <element name="index-term">
+      <ref name="index-term-attlist"/>
+      <ref name="index-term-model"/>
+    </element>
+  </define>
+  <define name="index-term-attlist" combine="interleave">
+    <ref name="index-term-atts"/>
+  </define>
+  <!-- INDEX TERM RANGE END MODEL -->
+  <!--
+    Content model for the embedded index term
+    <index-term> element.
+  -->
+  <define name="index-term-range-end-model">
+    <empty/>
+  </define>
+  <!-- INDEX TERM RANGE END -->
+  <!--
+    An index term embedded into the narrative
+    of a document may be either a single point
+    target or the start of a range. When the
+    <index-term> is the start of a range, the
+    @rid attribute of an <index-term-range-end>
+    must point to the @id of the <index-term>.
+    Remarks: This is an EMPTY element, since all
+    the information naming the index term is
+    already present in the <index-term> element
+    to which this element points.
+    Details at:
+    http://jats.nlm.nih.gov/extensions/bits/2.1/index.html?elem=index-term-range-end
+  -->
+  <define name="index-term-range-end">
+    <element name="index-term-range-end">
+      <ref name="index-term-range-end-attlist"/>
+      <ref name="index-term-range-end-model"/>
+    </element>
+  </define>
+  <define name="index-term-range-end-attlist" combine="interleave">
+    <ref name="index-term-range-end-atts"/>
+  </define>
+  <!-- SEE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <see> element.
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-phrase; is an
+    inline mix, the OR bar is already there.
+  -->
+  <define name="see-elements">
+    <choice>
+      <ref name="simple-phrase"/>
+      <ref name="block-math.class"/>
+      <ref name="simple-display-noalt.class"/>
+    </choice>
+  </define>
+  <!-- SEE -->
+  <!--
+    Used in an embedded index entry to hold
+    preferred terms that make "See" references
+    in a generated index.
+    Details at:
+    http://jats.nlm.nih.gov/extensions/bits/2.1/index.html?elem=see
+  -->
+  <define name="see">
+    <element name="see">
+      <ref name="see-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="see-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="see-attlist" combine="interleave">
+    <ref name="see-atts"/>
+  </define>
+  <!-- SEE-ALSO ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <see-also> element.
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-phrase; is an
+    inline mix, the OR bar is already there.
+  -->
+  <define name="see-also-elements">
+    <choice>
+      <ref name="simple-phrase"/>
+      <ref name="block-math.class"/>
+      <ref name="simple-display-noalt.class"/>
+    </choice>
+  </define>
+  <!-- SEE-ALSO TERM -->
+  <!--
+    Used in an embedded index entry to hold
+    preferred terms that make "See Also"
+    references in a generated index.
+    Details at:
+    http://jats.nlm.nih.gov/extensions/bits/2.1/index.html?elem=see-also
+  -->
+  <define name="see-also">
+    <element name="see-also">
+      <ref name="see-also-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="see-also-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="see-also-attlist" combine="interleave">
+    <ref name="see-also-atts"/>
+  </define>
+</grammar>
+<!-- ================== End BITS Embedded Index Elements ========= -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-XHTMLtablesetup1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-XHTMLtablesetup1.ent.rng
@@ -1,0 +1,572 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    XHTML Table Setup Module -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) JATS DTD Suite XHTML Table Setup Module v1.2 20190208//EN"
+       Delivered as file "JATS-XHTMLtablesetup1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Provides the organization for using the XHTML 1.1 -->
+<!-- table model -->
+<!---->
+<!-- CONTAINS:   1) Invokes the inline style attribute module -->
+<!-- to pick up the "style" attribute -->
+<!-- 2) Overrides to standard parameter entities used -->
+<!-- in the XHTML 1.1 table model -->
+<!-- 3) Invokes the XHTML 1.1 table model -->
+<!---->
+<!-- MODULES REQUIRED: -->
+<!-- 1) XHTML inline style module -->
+<!-- (-%xhtml-inlstyle-1.mod;) -->
+<!-- 2) XHTML 1.1 table model (-%xhtml-table-1.mod;) -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- December 2002 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- This module is part of the JATS DTD Suite. The -->
+<!-- Suite is a continuation of work done by NCBI, -->
+<!-- Mulberry Technologies, and Inera Inc. on the NLM -->
+<!--              Journal Archiving and Interchange DTD Suite, which -->
+<!-- was originally released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   21. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   20. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   19. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   18. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   17. JATS became version "1.2d1" and "v1.2d1 20170631"
+  
+      =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+   16. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+   15. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   14. JATS became version "1.1d3" and "v1.1d3 20150301"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   13. TABLE ATTRIBUTES
+       - Added @specific-use to the attributes for <table>,
+         primarily for use when <table> is used inside <alternatives>.
+       - This entailed creating a new PE "additional-table-atts",
+         which is defined and called AFTER the full table setup,
+         so that XML tools that do not recognize a 2nd ATTLIST for
+         an element will lose only the @specific-use. This new PE
+         could also be sued to add other attributes to an XHTML-
+         inspired <table>.
+  
+   12. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+   11. CAPTION ATTRIBUTES - This module has been changed to alter
+        the mechanism by which the @style attribute is associated 
+        with the element <caption>. 
+            Previously, the <caption> element's base attributes  
+        were declared in the JATS-display.ent module and additional 
+        attributes (in the published XHTML, only @style) for it 
+        were declared in the XHTML Table Module. The @style 
+        attribute is now declared with all the other <caption>
+        attributes in the  JATS-display.ent module, and the caption 
+        attributes in the XHTML table model have been set to IGNORE. 
+        This was done to prevent duplicate (harmless but annoying)
+        attribute warning messages. 
+  
+             CAUTION: If your XHTML customization has added attributes
+                      by redefining the parameter entity 
+                              "Core.extra.attrib"
+                      you will need to uncomment the lines in this
+                      module that add that parameter entity to the
+                      contents of the <caption> attribute list.
+                      Otherwise, your new attributes will not be
+                      added to <caption>. When you uncomment this
+                      line, you will get a duplicative attribute
+                      warning message on the @style attribute,
+                      which you may ignore.  
+  
+   10. GLOBAL ATTRIBUTES - Added the new parameter entity 
+           %jats-common-atts;
+       to every element in this module. This PE adds (for now) the
+       @id attribute and the @xml:base attribute to every element,
+       whether metadata or narrative.
+       Since the @id in this parameter entity is optional, a second
+       parameter entity jats-common-atts-id-required was also added.
+       The two are kept in sync with the jats-base-atts parameter 
+       entity.
+       This added an attribute list to the parameter entity 
+       "Common.attrib".
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    5. OASIS NAMESPACE - Added the OASIS table namespace handling,
+       which, by default, places a namespace prefix of "oasis" on
+       the OASIS CALS Exchange Table Model.
+        - Added call to JATS-oasis-namespace.ent (which sets up
+            the OASIS namespace URI and the prefix "oasis")
+        - Added  %oasis.xmlns.attrib; attribute to <article>
+        - Altered the custom classes module to use the new
+           namespaced OASIS element names for <table> and <tbody>
+           (%otable.qname; and %otbody.qname;)
+       NOTE: The XHTML table material was not removed, so both table
+       models still work (using <table> and <oasis:table> respectively.
+  
+    4. Updated the DTD-version attribute to "1.0" and the formal
+       public identifier to the date: "v1.0 20120330//EN".
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    3. Updated the DTD-version attribute to "0.4" 
+  
+    2. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- SET UP FOR THE XHTML 1.1 TABLE MODULE -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- THE XHTML TABLE STYLE ATTRIBUTE MODULE -->
+<!-- ============================================================= -->
+<!-- XHTML TABLE INLINE STYLE MODULE -->
+<!--
+                      This module declares the 'style' attribute,
+          used to support inline style markup for the
+          <td> and <tr> elements. Copyright 1998-2005
+          W3C (MIT, ERCIM, Keio), All Rights Reserved.
+          Revision: $Id: xhtml-inlstyle-1.mod,v 4.0
+          2001/04/02 22:42:49 altheim Exp $
+          PUBLIC identifier
+          "-//W3C//ENTITIES XHTML Inline Style 1.0//EN"
+          SYSTEM identifier
+  "http://www.w3.org/MarkUp/DTD/xhtml-inlstyle-1.mod"
+-->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="">
+  <include href="xhtml-inlstyle-1.mod.rng"/>
+  <!-- ============================================================= -->
+  <!-- DEFAULTS FOR TABLE ELEMENT NAMES -->
+  <!-- ============================================================= -->
+  <define name="caption.qname">
+    <ref name="caption"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- DEFAULTS FOR DATATYPE PARAMETER ENTITIES -->
+  <!-- ============================================================= -->
+  <define name="Text.datatype">
+    <data type="string"/>
+  </define>
+  <define name="Number.datatype">
+    <data type="string"/>
+  </define>
+  <define name="MultiLength.datatype">
+    <data type="string"/>
+  </define>
+  <define name="Length.datatype">
+    <data type="string"/>
+  </define>
+  <define name="Pixels.datatype">
+    <data type="string"/>
+  </define>
+  <define name="Character.datatype">
+    <data type="string"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- DEFAULTS FOR ATTRIBUTE PARAMETER ENTITIES -->
+  <!-- ============================================================= -->
+  <!-- COMMON ATTRIBUTES (used all over) -->
+  <!--
+    style      Defined in the PE -%Core.extra.attrib; and
+    used to support inline style markup. This
+    attribute is defined in the XHTML Table
+    Inline Style Module called in with the PE:
+       -%xhtml-inlstyle-1.mod
+    which must be invoked before the attribute
+    PE is used. 
+    Warning: The definitions below will lead to
+    the element <caption> having the attributes
+    @id and @content-type defined twice. This is
+    just a validity warning, not an error and 
+    should be ignored.
+  -->
+  <define name="Common.attrib">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <ref name="Core.extra.attrib"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- OVER-RIDES TO REMOVE CAPTION -->
+  <!-- ============================================================= -->
+  <!-- CAPTION FOR A TABLE -->
+  <!--
+    Modification of the standard XHMTL model
+    Removed the definition of caption, so the
+    element would not be multiply defined
+  -->
+  <!-- CAPTION ATTRIBUTES -->
+  <!-- Attributes for <caption> element -->
+  <!--
+    In the lines directly above this declaration,
+    the attribute list for caption, as defined
+    in the XHTML Table Model, has been removed
+    using the IGNORE mechanism. This was done 
+    to prevent duplicate (harmless but annoying)
+    attribute warning messages. 
+    
+    CAUTION: If your XHTML customization has
+    redefined the parameter entity 
+               "Core.extra.attrib"
+    you will need to uncomment the lines
+    below. You will get a duplicative attribute
+    warning message on the @style attribute,
+    which you may ignore.
+  -->
+  <!--
+    <!ENTITY % caption-atts
+                            "%Core.extra.attrib;                         >
+  -->
+  <!-- ============================================================= -->
+  <!-- OVER-RIDES FOR CONTENT PARAMETER ENTITIES -->
+  <!-- ============================================================= -->
+  <!-- INLINE ELEMENTS -->
+  <!--
+    Modification of the standard XHMTL model
+    for inline elements used in the <caption>
+    Set to the null because the <caption>
+    element is now inside the table wrapper,
+    not inside the table, as the original XHTML
+    table intended
+  -->
+  <!-- CONTENTS OF A TABLE CELL -->
+  <!--
+    Modification of the standard XHMTL model
+    used for the content of tables cells <th>
+    and <td>
+  -->
+  <define name="Flow.mix">
+    <ref name="inside-cell"/>
+  </define>
+  <!-- CONTENTS OF A TABLE -->
+  <!--
+    Modification of the standard XHMTL model
+    This has been modified from the XHTML model
+    to remove the <caption> element from the
+    <table> model, since in the JATS DTD Suite 
+    modular library, the <caption> element is part  
+    of the Table Wrapper <table-wrap> element. 
+    No other changes were made to the XHTML table 
+    content model.
+  -->
+  <define name="table.content">
+    <choice>
+      <zeroOrMore>
+        <ref name="col"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="colgroup"/>
+      </zeroOrMore>
+    </choice>
+    <choice>
+      <group>
+        <optional>
+          <ref name="thead"/>
+        </optional>
+        <optional>
+          <ref name="tfoot"/>
+        </optional>
+        <oneOrMore>
+          <ref name="tbody"/>
+        </oneOrMore>
+      </group>
+      <oneOrMore>
+        <ref name="tr"/>
+      </oneOrMore>
+    </choice>
+  </define>
+  <!-- ============================================================= -->
+  <!-- THE XHTML V1.1 TABLE INVOCATION -->
+  <!-- ============================================================= -->
+  <!-- XHTML TABLE MODEL -->
+  <!--
+    This module declares element types and
+          attributes used to provide table markup
+          similar to HTML 4, including features that
+          enable better accessibility for non-visual
+          user agents. This is the XHTML reformulation
+          of HTML as a modular XML application.
+          Copyright 1998-2005 W3C (MIT, ERCIM, Keio),
+          All Rights Reserved.
+          Revision: $Id: xhtml-table-1.mod,v 4.1
+          2001/04/10 09:42:30 altheim Exp $ SMI
+          PUBLIC identifier
+          "-//W3C//ELEMENTS XHTML Tables 1.0//EN"
+          SYSTEM identifier:
+    "http://www.w3.org/MarkUp/DTD/xhtml-table-1.mod"
+  -->
+  <include href="xhtml-table-1.mod.rng"/>
+  <!-- ============================================================= -->
+  <!-- ADDITIONAL ATTRIBUTE(S) FOR TABLE -->
+  <!-- ============================================================= -->
+  <define name="additional-table-atts">
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <define name="table-attlist" combine="interleave">
+    <ref name="additional-table-atts"/>
+  </define>
+</grammar>
+<!-- ================== End XHTML Table Setup Module ============= -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-ali-namespace1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-ali-namespace1.ent.rng
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    ALI Namespace Module (NISO RP-22-2015) -->
+<!-- NISO Access License and Indicators (ALI) -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS ALI Namespace Module v1.2 20190208//EN"
+       Delivered as file "JATS-ali-namespace1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Establish the prefix for the NISO Access and -->
+<!-- Indicators elements (prefix "ali:"). -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- February 2015 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- The Journal Publishing DTD is built from the -->
+<!-- Journal Archiving and Interchange DTD Suite. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+    6. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+    5. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+    4. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed. 
+  
+     =============================================================
+       JATS Version 1.2d2 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d2  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+    3. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d2" and "v1.2d2 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+    2. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+      =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+    1. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+  
+       Details concerning ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+       RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- ALI NAMESPACE SETUP -->
+<!-- ============================================================= -->
+<!-- NAME ALI NAMESPACE BASE URI -->
+<!--
+  Set the ALI namespace URI,as named in
+  NISO RP-22-2015
+-->
+<!-- NAME ALI NAMESPACE PREFIX -->
+<!--
+  Set the namespace prefix for the ALI
+  elements to the JATS-named prefix "ali". 
+  Implementor's Note: This parameter entity
+  should always be set, even if you need to turn
+  off the namespace prefix.
+-->
+<!-- NAME OASIS NAMESPACE PREFIX -->
+<!--
+  Construct the ALI namespace prefix to be 
+  used in the xmlns pseudo-attribute from:
+    - the word "xmlns", 
+    - a colon, and 
+    - the prefix just defined in %ali.prefix;
+-->
+<!-- DEFAULT ALI NAMESPACE -->
+<!--
+  The default namespace to be used when
+  calling in the ALI elements. This is set on 
+  the article level as well as on the ALI
+  elements themselves.
+  Implementor's Note: The parameter entity is
+  constructed from the parameter entities set 
+  above.
+-->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <define name="ali.xmlns.attrib">
+    <empty/>
+  </define>
+</grammar>
+<!-- ================== End ALI Namespace Setup  ================= -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-archivearticle1.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-archivearticle1.rng
@@ -1,0 +1,390 @@
+<?xml version="1.0" encoding="utf-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <include href="JATS-ali-namespace1.ent.rng"/>
+  <include href="JATS-common-atts1.ent.rng"/>
+  <include href="JATS-archivecustom-classes1.ent.rng"/>
+  <include href="JATS-default-classes1.ent.rng"/>
+  <include href="JATS-archivecustom-mixes1.ent.rng"/>
+  <include href="JATS-default-mixes1.ent.rng"/>
+  <include href="JATS-archivecustom-models1.ent.rng"/>
+  <include href="JATS-common1.ent.rng"/>
+  <include href="JATS-articlemeta1.ent.rng"/>
+  <include href="JATS-backmatter1.ent.rng"/>
+  <include href="JATS-display1.ent.rng"/>
+  <include href="JATS-format1.ent.rng"/>
+  <include href="JATS-funding1.ent.rng"/>
+  <include href="JATS-journalmeta1.ent.rng"/>
+  <include href="JATS-link1.ent.rng"/>
+  <include href="JATS-list1.ent.rng"/>
+  <include href="JATS-math1.ent.rng"/>
+  <include href="JATS-nlmcitation1.ent.rng"/>
+  <include href="JATS-para1.ent.rng"/>
+  <include href="JATS-phrase1.ent.rng"/>
+  <include href="JATS-references1.ent.rng"/>
+  <include href="JATS-related-object1.ent.rng"/>
+  <include href="JATS-section1.ent.rng"/>
+  <include href="BITS-embedded-index2.ent.rng"/>
+  <include href="JATS-mathmlsetup1.ent.rng"/>
+  <include href="JATS-XHTMLtablesetup1.ent.rng"/>
+  <include href="JATS-chars1.ent.rng"/>
+  <define name="dtd-version">
+    <optional>
+      <attribute name="dtd-version" a:defaultValue="1.2">
+        <value type="string" datatypeLibrary="">1.2</value>
+      </attribute>
+    </optional>
+  </define>
+  <define name="article-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="article-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang" a:defaultValue="en">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="dtd-version"/>
+    <ref name="XLINK.xmlns.attrib"/>
+    <ref name="MATHML.xmlns.attrib"/>
+    <ref name="ali.xmlns.attrib"/>
+    <ref name="Schema.xmlns.attrib"/>
+    <optional>
+      <attribute name="xsi:noNamespaceSchemaLocation"/>
+    </optional>
+  </define>
+  <define name="back-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <define name="body-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <define name="front-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <define name="front-stub-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <define name="sub-article-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="article-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="response-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="response-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="article-short-model">
+    <choice>
+      <ref name="front"/>
+      <ref name="front-stub"/>
+    </choice>
+    <optional>
+      <ref name="body"/>
+    </optional>
+    <optional>
+      <ref name="back"/>
+    </optional>
+    <optional>
+      <ref name="floats-group"/>
+    </optional>
+  </define>
+  <define name="article-full-model">
+    <ref name="front"/>
+    <optional>
+      <ref name="body"/>
+    </optional>
+    <optional>
+      <ref name="back"/>
+    </optional>
+    <optional>
+      <ref name="floats-group"/>
+    </optional>
+    <choice>
+      <zeroOrMore>
+        <ref name="sub-article"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="response"/>
+      </zeroOrMore>
+    </choice>
+  </define>
+  <define name="article">
+    <element name="article">
+      <ref name="article-attlist"/>
+      <ref name="article-full-model"/>
+    </element>
+  </define>
+  <define name="article-attlist" combine="interleave">
+    <ref name="article-atts"/>
+  </define>
+  <define name="front-model">
+    <optional>
+      <ref name="journal-meta"/>
+    </optional>
+    <ref name="article-meta"/>
+    <zeroOrMore>
+      <choice>
+        <ref name="list.class"/>
+        <ref name="front.class"/>
+        <ref name="front-back.class"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="front">
+    <element name="front">
+      <ref name="front-attlist"/>
+      <ref name="front-model"/>
+    </element>
+  </define>
+  <define name="front-attlist" combine="interleave">
+    <ref name="front-atts"/>
+  </define>
+  <define name="body-model">
+    <zeroOrMore>
+      <ref name="para-level"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="sec-level"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="sig-block"/>
+    </optional>
+  </define>
+  <define name="body">
+    <element name="body">
+      <ref name="body-attlist"/>
+      <ref name="body-model"/>
+    </element>
+  </define>
+  <define name="body-attlist" combine="interleave">
+    <ref name="body-atts"/>
+  </define>
+  <define name="back-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="title"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="doc-back-matter-mix"/>
+    </zeroOrMore>
+  </define>
+  <define name="back">
+    <element name="back">
+      <ref name="back-attlist"/>
+      <ref name="back-model"/>
+    </element>
+  </define>
+  <define name="back-attlist" combine="interleave">
+    <ref name="back-atts"/>
+  </define>
+  <define name="sub-article-model">
+    <choice>
+      <ref name="front"/>
+      <ref name="front-stub"/>
+    </choice>
+    <optional>
+      <ref name="body"/>
+    </optional>
+    <optional>
+      <ref name="back"/>
+    </optional>
+    <optional>
+      <ref name="floats-group"/>
+    </optional>
+    <choice>
+      <zeroOrMore>
+        <ref name="sub-article"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="response"/>
+      </zeroOrMore>
+    </choice>
+  </define>
+  <define name="sub-article">
+    <element name="sub-article">
+      <ref name="sub-article-attlist"/>
+      <ref name="sub-article-model"/>
+    </element>
+  </define>
+  <define name="sub-article-attlist" combine="interleave">
+    <ref name="sub-article-atts"/>
+  </define>
+  <define name="front-stub-model">
+    <zeroOrMore>
+      <ref name="article-id"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="article-version.class"/>
+    </optional>
+    <optional>
+      <ref name="article-categories"/>
+    </optional>
+    <optional>
+      <ref name="title-group"/>
+    </optional>
+    <zeroOrMore>
+      <choice>
+        <ref name="contrib-group.class"/>
+        <ref name="aff-alternatives.class"/>
+        <ref name="x.class"/>
+      </choice>
+    </zeroOrMore>
+    <optional>
+      <ref name="author-notes"/>
+    </optional>
+    <choice>
+      <zeroOrMore>
+        <ref name="pub-date.class"/>
+      </zeroOrMore>
+      <optional>
+        <ref name="pub-date-not-available"/>
+      </optional>
+    </choice>
+    <zeroOrMore>
+      <ref name="volume"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="volume-id"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="volume-series"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="issue"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="issue-id"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="issue-title"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="issue-sponsor"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="issue-part"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="volume-issue-group"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="isbn"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="supplement"/>
+    </optional>
+    <optional>
+      <choice>
+        <group>
+          <optional>
+            <ref name="fpage"/>
+            <optional>
+              <ref name="lpage"/>
+            </optional>
+          </optional>
+          <optional>
+            <ref name="page-range"/>
+          </optional>
+        </group>
+        <ref name="elocation-id"/>
+      </choice>
+    </optional>
+    <zeroOrMore>
+      <choice>
+        <ref name="address-link.class"/>
+        <ref name="product"/>
+        <ref name="supplementary-material"/>
+      </choice>
+    </zeroOrMore>
+    <optional>
+      <ref name="history"/>
+    </optional>
+    <optional>
+      <ref name="pub-history"/>
+    </optional>
+    <optional>
+      <ref name="permissions"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="self-uri"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="related-article.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="abstract.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="trans-abstract"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="kwd-group.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="funding-group"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="support-group"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="conference"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="counts"/>
+    </optional>
+    <optional>
+      <ref name="custom-meta-group"/>
+    </optional>
+  </define>
+  <define name="front-stub">
+    <element name="front-stub">
+      <ref name="front-stub-attlist"/>
+      <ref name="front-stub-model"/>
+    </element>
+  </define>
+  <define name="front-stub-attlist" combine="interleave">
+    <ref name="front-stub-atts"/>
+  </define>
+  <define name="response">
+    <element name="response">
+      <ref name="response-attlist"/>
+      <ref name="article-short-model"/>
+    </element>
+  </define>
+  <define name="response-attlist" combine="interleave">
+    <ref name="response-atts"/>
+  </define>
+  <start>
+    <choice>
+      <ref name="article"/>
+    </choice>
+  </start>
+</grammar>

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-archivecustom-classes1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-archivecustom-classes1.ent.rng
@@ -1,0 +1,400 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Journal Archiving DTD Customize Classes Module -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Classes Module v1.2 20190208//EN"
+  Delivered as file "JATS-archivecustom-classes1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     Journal Archiving and Interchange DTD of the -->
+<!-- JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    To declare the Parameter Entities (PEs) used to -->
+<!-- over-ride the JATS DTD Suite default named -->
+<!-- element classes. -->
+<!---->
+<!-- Note: Since PEs must be declared before they -->
+<!-- are used, this module must be called before the -->
+<!-- content modules that declare elements, and before -->
+<!-- the default classes module. -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This DTD was created from the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- August 2004 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- The Journal Archiving and Interchange DTD is -->
+<!-- built from the JATS DTD Suite. -->
+<!---->
+<!-- This DTD and the Suite are a continuation of -->
+<!-- the work done by NCBI, Mulberry Technologies, -->
+<!-- and Inera Inc. on the NLM Journal Archiving -->
+<!-- and Interchange DTD Suite, which was originally -->
+<!-- released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   13. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   12. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   11. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed. 
+  
+       =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+    10. JATS "1.2d1" and "v1.2d1 20170631" became
+        JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+    9. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+      =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+    8. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    7. JATS became version "1.1d3" and "v1.1 20150301//EN"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    6. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    5. CITATION ALTERNATIVES - Added a new element 
+       <citation-alternatives> to the citation.class. The element
+       will hold, for example, a single citation in multiple
+       languages or a single citation tagged as a <mixed-citation>
+       complete with punctuation and spacing and also as an
+       <element-citation> with all punctuation and spacing removed.
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    4. Updated the DTD-version attribute to "0.4" 
+  
+    3. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+             http://jats.nlm.nih.gov/0.4.
+  
+    2. AFFILIATION ALTERNATIVES - Added the element <aff-alternatives>
+       to contrib-info.class to hold multiple <aff>s that are
+       representations of a single affiliation, for example, the name
+       of an institution in two languages or two scripts.
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- METADATA CLASSES (articlemeta.ent) -->
+<!-- ============================================================= -->
+<!-- CONTRIBUTOR INFORMATION CLASS -->
+<!--
+  Metadata about a contributor
+  Added <fn>
+-->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <define name="contrib-info.class">
+    <choice>
+      <ref name="address"/>
+      <ref name="aff"/>
+      <ref name="aff-alternatives"/>
+      <ref name="author-comment"/>
+      <ref name="bio"/>
+      <ref name="email"/>
+      <ref name="etal"/>
+      <ref name="ext-link"/>
+      <ref name="fn"/>
+      <ref name="on-behalf-of"/>
+      <ref name="role"/>
+      <ref name="uri"/>
+      <ref name="xref"/>
+    </choice>
+  </define>
+  <!-- ============================================================= -->
+  <!-- CITATION CLASSES (references.ent) -->
+  <!-- ============================================================= -->
+  <!-- CITATION CLASS ELEMENTS -->
+  <!--
+    Reference to an external document, as used
+    within, for example, the text of a
+    paragraph
+  -->
+  <define name="citation.class">
+    <choice>
+      <ref name="citation-alternatives"/>
+      <ref name="element-citation"/>
+      <ref name="mixed-citation"/>
+      <ref name="nlm-citation"/>
+    </choice>
+  </define>
+  <!-- CITATION MINUS ALTERNATIVES CLASS ELEMENTS -->
+  <!--
+    All the citation elements except the
+    <citation-alternatives> element.
+  -->
+  <define name="citation-minus-alt.class">
+    <choice>
+      <ref name="element-citation"/>
+      <ref name="mixed-citation"/>
+      <ref name="nlm-citation"/>
+    </choice>
+  </define>
+  <!-- CITATION ADDITIONS CLASS ELEMENTS -->
+  <!--
+    Elements that are not part of the broader
+    -references.class, but that need to be part
+    of the model for citations.
+  -->
+  <define name="citation-additions.class">
+    <ref name="string-date"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PRESENTATION INFO CLASSES -->
+  <!-- ============================================================= -->
+  <!-- X-GENERATED PUNCTUATION CLASS -->
+  <!--
+    Class containing a single element that will
+    hold generated punctuation or other
+    generatable text, for example, the commas or
+    semicolons between keywords.
+  -->
+  <define name="x.class">
+    <ref name="x"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- STRUCTURAL ELEMENT CLASSES -->
+  <!-- ============================================================= -->
+  <!-- REST OF PARAGRAPH CLASS -->
+  <!--
+    Information for the reader that is at the
+    same structural level as a Paragraph.
+  -->
+  <define name="rest-of-para.class">
+    <choice>
+      <ref name="ack"/>
+      <ref name="disp-quote"/>
+      <ref name="speech"/>
+      <ref name="statement"/>
+      <ref name="verse-group"/>
+    </choice>
+  </define>
+</grammar>
+<!-- ================== End Archiving Classes Customization ====== -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-archivecustom-mixes1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-archivecustom-mixes1.ent.rng
@@ -1,0 +1,530 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Journal Archiving DTD Customize Mixes Module -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Mixes Module v1.2 20190208//EN"
+  Delivered as file "JATS-archivecustom-mixes1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     Journal Archiving and Interchange DTD of the -->
+<!-- JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    To declare the Parameter Entities (PEs) used to -->
+<!-- over-ride the JATS DTD Suite default named, -->
+<!-- general purpose mixes. (Mixes for particular -->
+<!-- elements are declared in the Archive Custom -->
+<!-- Models module.) -->
+<!---->
+<!-- Note: Since PEs must be declared before they -->
+<!-- are used, this module must be called before the -->
+<!-- default mixes modules (%default-mixes;) -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This DTD was created from the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- August 2004 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- The Journal Archiving and Interchange DTD is -->
+<!-- built from the JATS DTD Suite. -->
+<!---->
+<!-- This DTD and the Suite are a continuation of -->
+<!-- the work done by NCBI, Mulberry Technologies, -->
+<!-- and Inera Inc. on the NLM Journal Archiving -->
+<!-- and Interchange DTD Suite, which was originally -->
+<!-- released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   14. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   13. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   12. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed. 
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   11. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   10. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+      =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+    9. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    8. JATS became version "1.1d3" and "v1.1d3 20150301"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    7. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    6. PARAGRAPH IN TABLE CELL - Added <p> to the contents of
+       table cells, through %inside-cell; (using
+       %nothing-but-para.class;).
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    5. RELATED OBJECT - Added <related-object> everywhere
+       <related-article> was used.
+  
+    4. PARA-LEVEL PARAMETER ENTITY CONFLICT - Changed the parameter
+       entity %para-level; to use the PE %nothing-but-para.class;,
+       removing the similar PE "just-para.class;". It is possible to 
+       add element(s) to %just-para.class;, so that the added element(s)
+       may be used everywhere <p> is used. Such elements would also be
+       named in %block-display.class;. This would lead to a conflict
+       in %para-level; if both %just-para.class; and
+       %block-display.class; named <p>. So %just-para.class; is replaced
+       here in %para-level;. This is backward compatible for all XML
+       documents. If a JATS customization has modified %just-para.class;
+       they may need to change their customization to accommodate.
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    3. Updated the DTD-version attribute to "0.4" 
+  
+    2. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+             http://jats.nlm.nih.gov/0.4.
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- ELEMENT MIXES FOR USE IN CONTENT MODELS -->
+<!-- (MIXES ARE COMPOSED USING CLASSES) -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- EXCEPTION: A MIX USED IN OTHER MIXES -->
+<!-- ============================================================= -->
+<!-- ALL PHRASE-LEVEL ELEMENTS -->
+<!--
+  This Parameter Entity contains all of the
+  phrase-level elements in the entire
+  Archival Tag Set EXCEPT THE <break> element.
+  MAINTENANCE NOTE:
+  Since this is used inside other mixes
+  (like a class and unlike all other mixes)
+  all-phrase must
+    - be declared first in this module.
+    - does not start with an OR bar, as all
+      other inline mixes do
+-->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <define name="all-phrase">
+    <choice>
+      <ref name="address-link.class"/>
+      <ref name="article-link.class"/>
+      <ref name="appearance.class"/>
+      <ref name="emphasis.class"/>
+      <ref name="inline-display.class"/>
+      <ref name="inline-math.class"/>
+      <ref name="math.class"/>
+      <ref name="phrase.class"/>
+      <ref name="simple-link.class"/>
+      <ref name="subsup.class"/>
+      <ref name="x.class"/>
+    </choice>
+  </define>
+  <!-- ============================================================= -->
+  <!-- TABLE ELEMENT MIXES -->
+  <!-- ============================================================= -->
+  <!-- INSIDE TABLE CELL ELEMENTS -->
+  <!--
+    Mixed with #PCDATA inside a table cell, such
+    as a <td> or <th> element in the XHTML table
+    model, the <entry> element in the OASIS CALS
+    table model, etc.  This PE will be used as the
+    value of %Flow.mix;, %paracon;, etc.
+    MAINTENANCE NOTE: Inside cell is an exception,
+    an inline mix that does not start with an OR
+    bar. This is because is used within the
+    PE -%Flow.mix;, which is an inline mix
+    defined in the course of the XHTML Table DTD,
+    a DTD not under control of this DTD Suite.
+  -->
+  <define name="inside-cell">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="block-math.class"/>
+      <ref name="break.class"/>
+      <ref name="chem-struct-wrap.class"/>
+      <ref name="citation.class"/>
+      <ref name="list.class"/>
+      <ref name="nothing-but-para.class"/>
+      <ref name="simple-display-noalt.class"/>
+    </choice>
+  </define>
+  <!-- ============================================================= -->
+  <!--                     BACK MATTER ELEMENT MIXES(%backmatter.ent;) -->
+  <!-- ============================================================= -->
+  <!-- DOCUMENT BACK MATTER ELEMENTS -->
+  <!--
+    Back Matter Elements used by a full document
+    such as a journal article. This is an element
+    grouping rather than a class. These
+    elements may also appear in the content models
+    of structural elements, such as back matter.
+  -->
+  <define name="doc-back-matter-mix">
+    <choice>
+      <ref name="back.class"/>
+      <ref name="front-back.class"/>
+      <ref name="sec.class"/>
+    </choice>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PARAGRAPH-LEVEL ELEMENT MIXES -->
+  <!-- ============================================================= -->
+  <!-- PARAGRAPH-LEVEL ELEMENTS -->
+  <!--
+    Elements that may be used at the same
+    structural level as a paragraph, for
+    example inside a Section
+    Note: There a major overlap between this
+    parameter entity and that for the elements
+    that are at the same level as a paragraph.
+    Inline elements appear only inside a
+    paragraph, but block elements such as quotes
+    and lists may appear either within a
+    paragraph or at the same level as a
+    paragraph. This serves a requirement in a
+    repository DTD, since some incoming material
+    will have restricted such elements to only
+    inside a paragraph,  some incoming material
+    will have restricted them to only outside a
+    paragraph and some may allow them in both
+    places. Thus the DTD must allow for them to
+    be in either or both.
+  -->
+  <define name="para-level">
+    <choice>
+      <ref name="block-display.class"/>
+      <ref name="block-math.class"/>
+      <ref name="list.class"/>
+      <ref name="math.class"/>
+      <ref name="nothing-but-para.class"/>
+      <ref name="related-article.class"/>
+      <ref name="rest-of-para.class"/>
+      <ref name="x.class"/>
+    </choice>
+  </define>
+  <!-- ============================================================= -->
+  <!-- INLINE ELEMENT MIXES -->
+  <!-- ============================================================= -->
+  <!-- EMPHASIS MIX ELEMENTS -->
+  <!--
+    Elements that may be used inside most of the
+    emphasis class elements
+  -->
+  <define name="emphasized-text">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="break.class"/>
+    </choice>
+  </define>
+  <!-- JUST RENDITION -->
+  <!--
+    Only the simplest of the typographic
+    emphasis elements, as well as subscript and
+    superscript.  Usually used in a model that
+    allows #PCDATA and this restricted mixture.
+    This mix may be stripped down to only
+    subscript and superscript by some, more
+    restrictive DTDs.
+    MAINTENANCE NOTE:  This Parameter Entity
+    and the related PE "rendition-plus" have
+    been put in place to restrict the amount of
+    variability that a person modifying the DTD
+    through PE redefinition can achieve. Some
+    elements have been set #PCDATA plus one PE
+    and some have been set to #PCDATA plus the
+    other in an effort to allow designers to
+    modify entire groups of elements, but not
+    to change similar models individually .
+  -->
+  <define name="just-rendition">
+    <ref name="all-phrase"/>
+  </define>
+  <!-- RENDITION MARKUP PLUS -->
+  <!--
+    Only the simplest of the typographic
+    emphasis elements, as well as subscript and
+    superscript.  Usually used in a model that
+    allows #PCDATA and this restricted mixture.
+    This mix may be enhanced slightly in some
+    more permissive DTDs, and should always
+    contain at least typographic emphasis,
+    subscript, and superscript.
+    MAINTENANCE NOTE: This Parameter Entity
+    and the related PE "just-rendition" have
+    been put in place to restrict the amount of
+    variability that a person modifying the DTD
+    through PE redefinition can achieve. Some
+    elements have been set #PCDATA plus one PE
+    and some have been set to #PCDATA plus the
+    other in an effort to allow designers to
+    modify entire groups of elements, but not
+    to individually change similar models.
+    modify entire groups of elements, but not
+    to change similar models individually .
+  -->
+  <define name="rendition-plus">
+    <ref name="all-phrase"/>
+  </define>
+  <!-- SIMPLE PHRASE-LEVEL TEXTUAL ELEMENTS -->
+  <!--
+    Elements that may be used almost anywhere
+    text is used, for example, inside a title.
+    Simple text plus inline display and math
+    elements.
+  -->
+  <define name="simple-phrase">
+    <ref name="all-phrase"/>
+  </define>
+  <!-- SIMPLE TEXTUAL CONTENT -->
+  <!--
+    Elements that may be used inside elements
+    that are really expected to be #PCDATA and
+    not to contain any of these things.
+    Note that in the original, this contained
+    no math and no links, thus is was even
+    simpler than %simple-phrase; (As of 2004,
+    the two are the same.) s
+  -->
+  <define name="simple-text">
+    <ref name="all-phrase"/>
+  </define>
+</grammar>
+<!-- ================== End Archiving DTD Mixes Customization ==== -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-archivecustom-models1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-archivecustom-models1.ent.rng
@@ -1,0 +1,2040 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Journal Archiving DTD Customize Content and -->
+<!-- Attributes Module -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Content and Attributes Module v1.2 20190208//EN"
+  Delivered as file "JATS-archivecustom-models1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     Journal Archiving and Interchange DTD of the -->
+<!-- JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    To declare the Parameter Entities (PEs) used to -->
+<!-- over-ride the content models, parts of content -->
+<!-- models, or attribute lists of the JATS DTD Suite -->
+<!---->
+<!-- Or-groups within models should use mixes or -->
+<!-- classes rather than name elements directly. -->
+<!---->
+<!-- Note: Since PEs must be declared before they -->
+<!-- are used, this module must be called before the -->
+<!-- content modules that declare elements. -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This DTD was created from the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- August 2004 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- The Journal Archiving and Interchange DTD is -->
+<!-- built from the JATS DTD Suite. -->
+<!---->
+<!-- This DTD and the Suite are a continuation of -->
+<!-- the work done by NCBI, Mulberry Technologies, -->
+<!-- and Inera Inc. on the NLM Journal Archiving -->
+<!-- and Interchange DTD Suite, which was originally -->
+<!-- released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   43. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   42. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   41. ASSIGNING AUTHORITY - Added @assigning-authority to the
+       following elements, so that the type-of-identifier and
+       the party-responsible-for-identifier could both be
+       recorded. Previously, these values were both assigned to
+       the attribute @pub-id-type.
+          - <article-id>
+          - Note: <pub-id> already had @assigning-authority
+  
+   40. NON-MONETARY SUPPORT - Inside <article-meta> added new
+       <support-group> to hold both funding and
+       non-monetary support descriptions. <support-group> is 
+       both a peer to <funding-group> (backward compatibility)
+       and contains <funding-group>.
+  
+   39. PUBLICATION DATE-NOT-AVAILABLE - Inside <article-meta>, 
+       <front-stub>, <event>, and <event-desc>
+       added new element <pub-date-not-available>, as an 
+       alternative to <pub-date>. The meaning is that a 
+       publication date was (for whatever reason) not available. 
+       Presence of the element says nothing about publication 
+       status.
+  
+   38. DATE IN CITATION - Superscript and subscript added to
+       <date-in-citation>.
+  
+   37. CONFERENCE DATE - Face markup (face-markup.class) 
+       added to <conf-date>.
+  
+   36. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed. 
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   35. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+  
+   34. X - both <inline-graphic> and <private-char> added to 
+       elements allowed in <x>.
+  
+   33. INLINE FORMULA - Added accessibility elements <alt-text> and
+       <long-desc> to the model of inline formula, by adding the 
+       access.class PE.
+  
+   32. ARTICLE META MODEL
+       - ARTICLE VERSION - Added new element <article-version>
+         inside <article-metadata> to hold one version number for  
+         the article. <article-version> element may repeat inside
+         <article-version-alternatives> to hold version numbers 
+         from different systems.
+  
+       - NO DATE - <pub-date> (optional repeatable) is now
+         followed by the optional new element 
+         <pub-date-not-available>. 
+  
+       - PUBLICATION HISTORY - Added new element based on BITS,
+         <pub-history>, to hold <event>s as <history> holds
+         <date>s. New internal elements: <event>, <event-desc>
+  
+   31. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+      =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+   30. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   29. JATS became version "1.1d3" and "v1.1d3 20150301"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   28.  RUBY MODEL CHANGED TO MATCH HTML5
+        - changed the Ruby content model to allow only a single
+          Ruby annotation on a single Ruby base:
+              (rb, (rt | (rp, rt, rp)) )
+          The Ruby textual annotation may take a pair of
+          Ruby parentheses, but these are optional.
+  
+   27. ATTRIBUTES FOR PUB-ID
+     - Added the linking attributes (optional version) to <pub-id> , 
+       so that a <pub-id> that is a DOI, for example, can carry the 
+       linking attributes and be made into a live link. In this use
+       of <pub-id>, the element is acting both as an identifier
+       and as a link.
+     - Added new attribute @assigning-authority to <pub-id>, to
+       carry new values such as "CrossRef" and to take some of the
+       semantic burden off the '@pub-id-type' attribute, when
+       values are organizations such as "Genbank" or "PDB".
+  
+   26. <OBJECT-ID> INSIDE <TRANS-ABSTRACT>
+       Allowed <object-id> at the beginning of <trans-abstract>, 
+       so that abstracts could be given DOIs.
+  
+   25. <VOLUME> INSIDE <ARTICLE-META>
+     - Allowed <volume> to repeat inside <article-meta>, the types to 
+       be distinguished using @content-type
+     - Added new optional element <volume-issue-group> inside 
+       <article-meta) following all volume and issue elements
+       to hold volume-issue pairs (or n-tuples) when a second
+       and subsequent <volume> has its own related issue
+       numbers.
+  
+   24. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+   23. NEW <era> ELEMENT
+       Added <era> through date-parts.class to:
+        - <conf-date>
+        - <date-in-citation>
+        - <pub-date>
+        - <string-date>
+        - access-date (deprecated
+        - time-stamp (deprecated)
+  
+   22. INSTITUTIONS TO STANDARDS ORGANIZATIONS
+       Added the elements <institution-wrap> to the following elements
+       through the institution-wrap.class:
+        - <copyright-holder>
+        - <std-organization>
+  
+   21. RUBY ANNOTATIONS - Overrode the default JATS inclusions, to
+       change the more restricted face-markup class to the 
+       Archive-specific all Phrase. Elements change:
+        - <rb> Ruby Base (through %rb-elements;)
+  
+   20. GLOBAL ATTRIBUTES - Added the new parameter entity 
+           %jats-common-atts;
+       to every element in this module. This PE adds (for now) the
+       @id attribute and the @xml:base attribute to every element,
+       whether metadata or narrative.
+       Since the @id in this parameter entity is optional, a second
+       parameter entity jats-common-atts-id-required was also added.
+       The two are kept in sync with the jats-base-atts parameter 
+       entity.
+  
+   19. ABSTRACTS AND KEYWORDS ON NEW STRUCTURES
+       - Added <abstract> (through %abstract.class;) and <kwd-group> 
+         (through %kwd-group.class;) to the following elements:
+          - disp-formula (through %disp-formula-elements;)
+  
+       - Changed "abstract*" to "(%abstract.class;)*"
+         and "kwd-group*" to "(%kwd-group.class;)*" since those
+         classes now exist. Elements should have a limited number of
+         ways to be invoked.
+          - article-meta (through %article-meta-model;)
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+   18. RELATED OBJECT - Added <related-object> everywhere
+       <related-article> was used, including inside 
+       <article-meta> using article-meta-model.
+  
+   17. CONTRIBUTOR MODEL - Added "contrib-id.class" to the 
+       <contrib> model, to hold identifiers for people,
+       such as publishers-specific IDs,  and ORCIDs.
+  
+   16. VERSE-LINE ELEMENTS - Added the PE %verse-line-elements to
+       this module because the default expanded, and Archiving did
+       not need to expand as it already was expanded.
+  
+   14. DATE ATTRIBUTES - Added attributes to <date> through @date-atts: 
+         a) @iso-8601-date - ISO 8601 standard date format
+            of the publication date. Format  YYYY-MM-DDThh:mm:ss 
+         b) @calendar - Name of the calendar used (@calendar) in
+            naming this publication date (such as "Gregorian", 
+            "Japanese" (Emperor years), or "Islamic").
+         c) Added @publication-format, so that both publication
+            dates and history dates can separate the format of the
+            publication from the version/lifecycle event. Thus
+            both an "article" and a "manuscript" might be received.
+  
+   13. STANDARDS ORGANIZATION - Added std-organization-elements
+       to increase what was allowed in the names of standards bodies.
+  
+   12. XREF REF TYPES - #9 below says "XREF ATTRIBUTES - Removed 
+       the %xref-atts PE from this module since the regular version 
+       (in xlink3.ent(?)) was equally inclusive. But it is NOT. 
+       Brought back %xref-atts;
+  
+   11. ISSN-L ELEMENTS - Added <x> TO <issn-l> via 
+       %issn-l-elements;
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+   10. Updated the DTD-version attribute to "0.4" 
+  
+    9. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+             http://jats.nlm.nih.gov/0.4.
+  
+    7. XREF ATTRIBUTES - Removed the %xref-atts PE from this module
+       since the regular version (in xlink3.ent(?)) was equally 
+       inclusive. See #12 above.
+  
+    6. ISSUE - Allowed to repeat inside <article-meta>
+  
+    5. AFFILIATION ALTERNATIVES - Added the element <aff-alternatives>
+       to <article-meta> through %article meta-model;. This element
+       will hold multiple <aff>s that are a representation of a
+       single affiliation, for example, the name of an institution
+       in two languages or two scripts.
+  
+    4. PERSON-GROUP - Became a mixed-content model, so the parameter
+       entity %person-group-model: was changed to
+       %person-group-elements;, which will be mixed with #PCDATA
+       as defined in references.ent. The PE person-group-model has
+       been retained in references.ent for compatibility, but has been
+       set to the mixed model using person-group-elements.
+  
+    3. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+       @xml:lang to %display-atts;. Also added these attributes
+       to the following over-rides:
+        - article-id through article-id-atts (@specific-user only)
+        - award-id through award-id-atts (both)
+        - date through date-atts (@specific-use only)
+        - funding-statement through funding-statement-atts (both)
+        - pub-id through pub-id-atts (@specific-use only)
+        - trans-title through pub-id-atts (@specific-use only;
+           @xml:lang already)
+        - xref through xref-atts (both)
+  
+    2. STRING-DATE - Added <string-date> back to the following
+       elements using %citation-additions.class;. It was accidentally
+       deleted during the 3.0 revision of -references.class:
+        - product         (%product-elements;)
+        - related-article (%related-article-elements;)
+        - related-object  (%related-object-elements;)
+        - funding-statement through funding-statement-atts (both)
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- INLINE MIXES TO OVER-RIDE CONTENT MODELS -->
+<!--                     (ELEMENTS TO BE ADDED TO #PCDATA IN MODELS) -->
+<!-- ============================================================= -->
+<!-- ABBREVIATION ELEMENTS -->
+<!--
+  The elements that can be included along with
+  data characters inside the content model of
+  the <abbrev> element
+-->
+<grammar xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="abbrev-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="def.class"/>
+    </choice>
+  </define>
+  <!-- ACCESS DATE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the Access Date <access-date> element
+  -->
+  <define name="access-date-elements">
+    <choice>
+      <ref name="date-parts.class"/>
+      <ref name="x.class"/>
+    </choice>
+  </define>
+  <!-- AFFILIATION ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <aff> element
+  -->
+  <define name="aff-elements">
+    <choice>
+      <ref name="address.class"/>
+      <ref name="all-phrase"/>
+      <ref name="break.class"/>
+      <ref name="label.class"/>
+    </choice>
+  </define>
+  <!-- ANONYMOUS ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    an <anonymous> element
+  -->
+  <define name="anonymous-elements">
+    <ref name="all-phrase"/>
+  </define>
+  <!-- ARTICLE TITLE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <article-title> element.
+  -->
+  <define name="article-title-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="break.class"/>
+    </choice>
+  </define>
+  <!-- CHEMICAL STRUCTURE ELEMENTS -->
+  <!--
+    Those elements that may mix with the data
+    characters inside a Chemical Structure
+    <chem-struct>
+  -->
+  <define name="chem-struct-elements">
+    <choice>
+      <ref name="access.class"/>
+      <ref name="all-phrase"/>
+      <ref name="break.class"/>
+      <ref name="id.class"/>
+      <ref name="label.class"/>
+      <ref name="list.class"/>
+      <ref name="simple-display-noalt.class"/>
+    </choice>
+  </define>
+  <!-- CITATION ELEMENTS -->
+  <!--
+    Content for both types of citation. These
+    elements may be mixed with #PCDATA in the
+    <mixed-citation> element (in which all
+    punctuation and spacing are left intact), and
+    they also constitute the choices that can be
+    used to form the all-element-content of the
+    <element-citation> element (in which
+    punctuation and spacing are removed).
+    Design Note: All inline mixes begin with an
+    OR bar.
+  -->
+  <define name="citation-elements">
+    <choice>
+      <ref name="article-link.class"/>
+      <ref name="appearance.class"/>
+      <ref name="citation-additions.class"/>
+      <ref name="emphasis.class"/>
+      <ref name="inline-display.class"/>
+      <ref name="inline-math.class"/>
+      <ref name="label.class"/>
+      <ref name="math.class"/>
+      <ref name="phrase.class"/>
+      <ref name="references.class"/>
+      <ref name="simple-link.class"/>
+      <ref name="subsup.class"/>
+      <ref name="x.class"/>
+    </choice>
+  </define>
+  <!-- COLLABORATIVE (GROUP) AUTHOR ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <collab> element. This is essentially
+    %all-phrase; plus contrib-info and break.
+    All-phase is not used because of
+    duplication clashes with the
+    -contrib-info.class;
+  -->
+  <define name="collab-elements">
+    <choice>
+      <ref name="article-link.class"/>
+      <ref name="address.class"/>
+      <ref name="appearance.class"/>
+      <ref name="break.class"/>
+      <ref name="contrib-group.class"/>
+      <ref name="contrib-info.class"/>
+      <ref name="emphasis.class"/>
+      <ref name="inline-display.class"/>
+      <ref name="inline-math.class"/>
+      <ref name="math.class"/>
+      <ref name="phrase.class"/>
+      <ref name="subsup.class"/>
+      <ref name="x.class"/>
+    </choice>
+  </define>
+  <!-- COMPOUND KEYWORD PART ELEMENTS -->
+  <!--
+    Elements to be mixed with data characters
+    inside the <compound-kwd-part> element
+  -->
+  <define name="compound-kwd-part-elements">
+    <choice>
+      <ref name="break.class"/>
+      <ref name="all-phrase"/>
+    </choice>
+  </define>
+  <!-- CONFERENCE DATE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <conf-date> element
+  -->
+  <define name="conf-date-elements">
+    <choice>
+      <ref name="date-parts.class"/>
+      <ref name="face-markup.class"/>
+      <ref name="x.class"/>
+    </choice>
+  </define>
+  <!-- COMMENT ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the Comment in a Citation <comment> element.
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-phrase; is an
+    inline mix, the OR bar is already there.
+  -->
+  <define name="comment-elements">
+    <ref name="all-phrase"/>
+  </define>
+  <!-- COPYRIGHT HOLDER ELEMENTS -->
+  <!--
+    Elements to be mixed with data characters
+    inside the content model for the
+    <copyright-holder> element.
+  -->
+  <define name="copyright-holder-elements">
+    <choice>
+      <ref name="institution-wrap.class"/>
+      <ref name="subsup.class"/>
+      <ref name="x.class"/>
+    </choice>
+  </define>
+  <!-- COPYRIGHT STATEMENT ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <copyright-statement>
+  -->
+  <define name="copyright-statement-elements">
+    <ref name="all-phrase"/>
+  </define>
+  <!-- CORRESPONDENCE INFORMATION ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the correspondence information.
+  -->
+  <define name="corresp-elements">
+    <choice>
+      <ref name="address.class"/>
+      <ref name="all-phrase"/>
+      <ref name="break.class"/>
+      <ref name="label.class"/>
+    </choice>
+  </define>
+  <!-- COUNTRY ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the country element.
+  -->
+  <define name="country-elements">
+    <ref name="x.class"/>
+  </define>
+  <!-- DATE IN CITATION ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the Date Inside Citation <date-in-citation>
+    element
+  -->
+  <define name="date-in-citation-elements">
+    <choice>
+      <ref name="date-parts.class"/>
+      <ref name="emphasis.class"/>
+      <ref name="subsup.class"/>
+      <ref name="x.class"/>
+    </choice>
+  </define>
+  <!-- FORMULA, DISPLAY ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <disp-formula>
+  -->
+  <define name="disp-formula-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="abstract.class"/>
+      <ref name="access.class"/>
+      <ref name="break.class"/>
+      <ref name="display-back-matter.class"/>
+      <ref name="kwd-group.class"/>
+      <ref name="label.class"/>
+      <ref name="simple-display-noalt.class"/>
+    </choice>
+  </define>
+  <!-- EMAIL ADDRESS ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <email> element
+  -->
+  <define name="email-elements">
+    <ref name="all-phrase"/>
+  </define>
+  <!-- ET AL ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    an <etal> element
+  -->
+  <define name="etal-elements">
+    <ref name="all-phrase"/>
+  </define>
+  <!-- EXTERNAL LINK ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    an <ext-link>
+  -->
+  <define name="ext-link-elements">
+    <ref name="all-phrase"/>
+  </define>
+  <!-- FUNDING STATEMENT ELEMENTS -->
+  <!-- Model for the <funding-statement> element -->
+  <define name="funding-statement-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="funding.class"/>
+    </choice>
+  </define>
+  <!-- HISTORY ELEMENTS -->
+  <!--
+    Elements that may be mixed with data
+    characters inside the model for <history>
+    when <history> is modeled as a mixed content
+    element.
+  -->
+  <define name="history-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="break.class"/>
+      <ref name="date.class"/>
+    </choice>
+  </define>
+  <!-- FORMULA, INLINE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <inline-formula> element.
+  -->
+  <define name="inline-formula-elements">
+    <choice>
+      <ref name="access.class"/>
+      <ref name="all-phrase"/>
+    </choice>
+  </define>
+  <!-- INLINE SUPPLEMENTARY MATERIAL ELEMENTS -->
+  <!--
+                        The elements that can be included along with
+    data characters inside the content model of
+    the <inline-supplementary-material> element
+  -->
+  <define name="inline-supplementary-material-elements">
+    <choice>
+      <ref name="access.class"/>
+      <ref name="all-phrase"/>
+    </choice>
+  </define>
+  <!-- INSTITUTION NAME ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <institution> element
+  -->
+  <define name="institution-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="break.class"/>
+    </choice>
+  </define>
+  <!-- ISBN ELEMENTS -->
+  <!--
+    Elements for use with data characters inside
+    the model for the <isbn> element
+  -->
+  <define name="isbn-elements">
+    <ref name="x.class"/>
+  </define>
+  <!-- ISSN ELEMENTS -->
+  <!--
+    Elements for use with data characters inside
+    the model for the <issn> element
+  -->
+  <define name="issn-elements">
+    <ref name="x.class"/>
+  </define>
+  <!-- ISSN-L ELEMENTS -->
+  <!--
+    Elements for use with data characters inside
+    the model for the <issn-l> element
+  -->
+  <define name="issn-l-elements">
+    <ref name="x.class"/>
+  </define>
+  <!-- ISSUE TITLE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <issue-title> element
+  -->
+  <define name="issue-title-elements">
+    <ref name="all-phrase"/>
+  </define>
+  <!-- KEYWORD CONTENT ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a keyword.
+  -->
+  <define name="kwd-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="break.class"/>
+    </choice>
+  </define>
+  <!-- LABEL ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <label> element
+  -->
+  <define name="label-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="break.class"/>
+    </choice>
+  </define>
+  <!-- LINK ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    linking element such as <xref>, <target>,
+    and <ext-link>
+  -->
+  <define name="link-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="break.class"/>
+    </choice>
+  </define>
+  <!-- LONG DESCRIPTION ELEMENTS -->
+  <!--
+    Elements to be mixed with data characters
+    inside the <long-desc> element
+  -->
+  <define name="long-desc-elements">
+    <ref name="x.class"/>
+  </define>
+  <!-- METADATA DATA NAME ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <meta-name> element
+  -->
+  <define name="meta-name-elements">
+    <ref name="all-phrase"/>
+  </define>
+  <!-- METADATA DATA VALUE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <meta-value> element
+  -->
+  <define name="meta-value-elements">
+    <ref name="all-phrase"/>
+  </define>
+  <!-- NAMED CONTENT ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <named-content> element
+  -->
+  <define name="named-content-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="block-display-noalt.class"/>
+      <ref name="block-math.class"/>
+      <ref name="list.class"/>
+      <ref name="rest-of-para.class"/>
+    </choice>
+  </define>
+  <!-- PARAGRAPH ELEMENTS -->
+  <!--
+    Elements that may be used within a paragraph
+    in a mixed content model with #PCDATA.
+    Design Note: There is a major overlap between
+    this parameter entity and the mix for elements
+    that are at the same level as a paragraph.
+    Inline elements appear only inside a
+    paragraph, but block elements such as quotes
+    and lists may appear either within a
+    paragraph or at the same level as a
+    paragraph. This serves a requirement in a
+    repository DTD, since some incoming material
+    will have restricted such elements to only
+    inside a paragraph, some incoming material
+    will have restricted them to only outside a
+    paragraph and some may allow them in both
+    places. Thus the DTD must allow for them to
+    be in either or both.
+  -->
+  <define name="p-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="block-display-noalt.class"/>
+      <ref name="block-math.class"/>
+      <ref name="citation.class"/>
+      <ref name="funding.class"/>
+      <ref name="list.class"/>
+      <ref name="rest-of-para.class"/>
+    </choice>
+  </define>
+  <!-- PERSON GROUP ELEMENTS -->
+  <!--
+                        Elements to be mixed with #PCDATA characters
+    within the Person Group element
+    (name class include <string-name> in this
+    tag set.
+  -->
+  <define name="person-group-elements">
+    <choice>
+      <ref name="name.class"/>
+      <ref name="person-group-info.class"/>
+      <ref name="x.class"/>
+    </choice>
+  </define>
+  <!-- PREFORMATTED TEXT ELEMENTS -->
+  <!--
+    Elements that may be used, along with data
+    characters, inside the content model for the
+    <preformat> element, in which whitespace,
+    such as tabs, line feeds, and spaces will
+    be preserved.
+  -->
+  <define name="preformat-elements">
+    <choice>
+      <ref name="access.class"/>
+      <ref name="all-phrase"/>
+      <ref name="display-back-matter.class"/>
+    </choice>
+  </define>
+  <!-- PRODUCT ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <product> element
+    (Note: all-phrase was replicated and not
+    used directly because the article-link.class
+    elements are repeated in -references.class
+    and therefore cause duplication.
+  -->
+  <define name="product-elements">
+    <choice>
+      <ref name="article-link.class"/>
+      <ref name="appearance.class"/>
+      <ref name="break.class"/>
+      <ref name="citation-additions.class"/>
+      <ref name="emphasis.class"/>
+      <ref name="inline-display.class"/>
+      <ref name="inline-math.class"/>
+      <ref name="label.class"/>
+      <ref name="math.class"/>
+      <ref name="phrase.class"/>
+      <ref name="price.class"/>
+      <ref name="references.class"/>
+      <ref name="simple-link.class"/>
+      <ref name="subsup.class"/>
+      <ref name="x.class"/>
+    </choice>
+  </define>
+  <!-- PUBLISHER'S LOCATION ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <publisher-loc> element
+  -->
+  <define name="publisher-loc-elements">
+    <choice>
+      <ref name="address.class"/>
+      <ref name="all-phrase"/>
+      <ref name="break.class"/>
+    </choice>
+  </define>
+  <!-- RELATED ARTICLE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <related-article> element.
+    (Note: all-phrase was replicated and not
+    used directly because the article-link.class
+    elements are repeated in -references.class
+    and therefore cause duplication.)
+  -->
+  <define name="related-article-elements">
+    <choice>
+      <ref name="article-link.class"/>
+      <ref name="appearance.class"/>
+      <ref name="break.class"/>
+      <ref name="citation-additions.class"/>
+      <ref name="emphasis.class"/>
+      <ref name="inline-display.class"/>
+      <ref name="inline-math.class"/>
+      <ref name="journal-id.class"/>
+      <ref name="label.class"/>
+      <ref name="math.class"/>
+      <ref name="phrase.class"/>
+      <ref name="references.class"/>
+      <ref name="simple-link.class"/>
+      <ref name="subsup.class"/>
+      <ref name="x.class"/>
+    </choice>
+  </define>
+  <!-- RELATED OBJECT ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <related-object> element.
+    (Note: all-phrase was replicated and not
+    used directly because the article-link.class
+    elements are repeated in -references.class
+    and therefore cause duplication.)
+  -->
+  <define name="related-object-elements">
+    <choice>
+      <ref name="article-link.class"/>
+      <ref name="appearance.class"/>
+      <ref name="break.class"/>
+      <ref name="citation-additions.class"/>
+      <ref name="emphasis.class"/>
+      <ref name="inline-display.class"/>
+      <ref name="inline-math.class"/>
+      <ref name="label.class"/>
+      <ref name="math.class"/>
+      <ref name="phrase.class"/>
+      <ref name="references.class"/>
+      <ref name="simple-link.class"/>
+      <ref name="subsup.class"/>
+      <ref name="x.class"/>
+    </choice>
+  </define>
+  <!-- ROLE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <role>
+    Design Note: All inline mixes begin with an
+    OR bar; since %rendition-plus; is an
+    inline mix, the OR bar is already there.
+  -->
+  <define name="role-elements">
+    <ref name="all-phrase"/>
+  </define>
+  <!-- SELF-URI ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <self-uri> element
+  -->
+  <define name="self-uri-elements">
+    <ref name="all-phrase"/>
+  </define>
+  <!-- SIGNATURE BLOCK ELEMENTS -->
+  <!--
+    Elements to be mixed with data characters
+    inside the content model for the
+    <sig-block> element.
+  -->
+  <define name="sig-block-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="break.class"/>
+      <ref name="contrib.class"/>
+      <ref name="just-base-display-noalt.class"/>
+      <ref name="person-group-info.class"/>
+      <ref name="sig.class"/>
+    </choice>
+  </define>
+  <!-- SIGNATURE ELEMENTS -->
+  <!--
+    Elements to be mixed with data characters
+    inside the content model for the
+    <sig> element.
+  -->
+  <define name="sig-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="break.class"/>
+      <ref name="just-base-display-noalt.class"/>
+    </choice>
+  </define>
+  <!-- SIZE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the size element.
+  -->
+  <define name="size-elements">
+    <ref name="x.class"/>
+  </define>
+  <!-- SOURCE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <source> element
+  -->
+  <define name="source-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="break.class"/>
+    </choice>
+  </define>
+  <!-- SPEAKER ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a speaker.
+  -->
+  <define name="speaker-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="person-name.class"/>
+    </choice>
+  </define>
+  <!-- STANDARDS ORGANIZATION ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    <std-organization>.
+  -->
+  <define name="std-organization-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="institution-wrap.class"/>
+      <ref name="break.class"/>
+    </choice>
+  </define>
+  <!-- STRING DATE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <string-date> element
+  -->
+  <define name="string-date-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="date-parts.class"/>
+    </choice>
+  </define>
+  <!-- STRING NAME ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <string-name> element
+  -->
+  <define name="string-name-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="person-name.class"/>
+    </choice>
+  </define>
+  <!-- STRUCTURAL TITLE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <title> element
+  -->
+  <define name="struct-title-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="break.class"/>
+      <ref name="citation.class"/>
+    </choice>
+  </define>
+  <!-- STYLED CONTENT ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <styled-content> element
+  -->
+  <define name="styled-content-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="block-display-noalt.class"/>
+      <ref name="block-math.class"/>
+      <ref name="list.class"/>
+      <ref name="rest-of-para.class"/>
+    </choice>
+  </define>
+  <!-- SUBJECT GROUPING NAME ELEMENTS -->
+  <!--
+    Elements that may be used, along with data
+    characters inside the content model of the
+    <subject> element
+  -->
+  <define name="subject-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="break.class"/>
+    </choice>
+  </define>
+  <!-- DEFINITION LIST: TERM ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <term>.
+  -->
+  <define name="term-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="block-math.class"/>
+      <ref name="chem-struct-wrap.class"/>
+      <ref name="simple-display-noalt.class"/>
+    </choice>
+  </define>
+  <!-- TEXTUAL FORM ELEMENTS -->
+  <!--
+    Model for the <textual-form> element.
+    Added <label>
+  -->
+  <define name="textual-form-elements">
+    <choice>
+      <ref name="emphasis.class"/>
+      <ref name="inline-display-noalt.class"/>
+      <ref name="label.class"/>
+      <ref name="math.class"/>
+      <ref name="phrase-content.class"/>
+      <ref name="subsup.class"/>
+    </choice>
+  </define>
+  <!-- TIME STAMP ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <time-stamp>.
+  -->
+  <define name="time-stamp-elements">
+    <choice>
+      <ref name="date-parts.class"/>
+      <ref name="x.class"/>
+    </choice>
+  </define>
+  <!-- TITLE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    title elements such as <title>, <subtitle>,
+    <trans-title>, etc.
+  -->
+  <define name="title-elements">
+    <choice>
+      <ref name="all-phrase"/>
+      <ref name="break.class"/>
+    </choice>
+  </define>
+  <!-- VERSE-LINE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <verse-line>
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-text; is an inline
+    mix, the OR bar is already there.
+  -->
+  <define name="verse-line-elements">
+    <ref name="simple-text"/>
+  </define>
+  <!-- X ELEMENTS -->
+  <!-- Elements for use inside the <x> element -->
+  <define name="x-elements">
+    <choice>
+      <ref name="emphasis.class"/>
+      <ref name="inline-display-noalt.class"/>
+      <ref name="phrase-content.class"/>
+      <ref name="subsup.class"/>
+      <ref name="x.class"/>
+    </choice>
+  </define>
+  <!-- ============================================================= -->
+  <!-- RUBY MARKUP -->
+  <!-- ============================================================= -->
+  <!-- RUBY BASE ELEMENTS -->
+  <!--
+    Those elements that may mix with the data
+    characters inside a Ruby Base <rb> 
+    element.
+  -->
+  <define name="rb-elements">
+    <ref name="all-phrase"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- DUPLICATES NEEDED FOR OVER-RIDES -->
+  <!-- (models unchanged from common.ent but -->
+  <!-- needed below) -->
+  <!-- ============================================================= -->
+  <!-- COMMON ATTRIBUTES -->
+  <!--
+    These lists of attributes will be added to 
+    nearly every element, in both the document 
+    metadata and the document body, of the entire 
+    Tag Set:
+      - including table elements for both the 
+          XHTML-inspired and OASIS-inspired
+          table model elements
+      - excluding only <mml:math> and 
+          <xi:include> (whose namespaces JATS
+          does not control).
+       Great care should be taken to use these
+    attributes judiciously, not as a shortcut to
+    thinking through where an attribute should be
+    used. Potential use cases include adding
+    @xml:lang or some RDFa attribute to every 
+    elements.
+  -->
+  <!-- JATS BASE ATTRIBUTES -->
+  <!--
+    Holds all the common attributes except @id.
+    Used to keep the two common attribute lists 
+    in sync. To add a global attribute, modify
+    this list.
+  -->
+  <!-- JATS COMMON ATTRIBUTES -->
+  <!--
+    Holds all the common attributes, as defined in
+    the base attribute parameter entity, plus an
+    optional @id.
+  -->
+  <!-- JATS COMMON ATTRIBUTES (ID REQUIRED) -->
+  <!--
+    Holds all the common attributes, as defined in
+    the base attribute parameter entity, plus a 
+    required @id.
+  -->
+  <!-- MIGHT LINK XLINK ATTRIBUTES -->
+  <!--
+    Used for elements which may need to link to
+    external sources or other objects within
+    the document, but may not necessarily act
+    as a link at all.  The attribute
+    "xlink:href" identifies the object to which
+    the link points.
+  -->
+  <define name="might-link-atts">
+    <optional>
+      <attribute name="xlink:type">
+        <choice>
+          <value>simple</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xlink:href"/>
+    </optional>
+    <optional>
+      <attribute name="xlink:role"/>
+    </optional>
+    <optional>
+      <attribute name="xlink:title"/>
+    </optional>
+    <optional>
+      <attribute name="xlink:show">
+        <choice>
+          <value>embed</value>
+          <value>new</value>
+          <value>none</value>
+          <value>other</value>
+          <value>replace</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xlink:actuate">
+        <choice>
+          <value>none</value>
+          <value>onLoad</value>
+          <value>onRequest</value>
+          <value>other</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ============================================================= -->
+  <!-- SECTION OPTIONAL TITLE MODEL -->
+  <!-- ============================================================= -->
+  <!-- CONTENT MODEL FOR AN UNTITLED SECTION -->
+  <!--
+    The model for a section-like structure that
+    may or may not have an initial title
+  -->
+  <define name="sec-opt-title-model">
+    <optional>
+      <ref name="sec-meta"/>
+    </optional>
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="para-level"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="sec-level"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="sec-back-matter-mix"/>
+    </zeroOrMore>
+  </define>
+  <!-- ============================================================= -->
+  <!-- OVER-RIDES OF CONTENT MODELS (FULL MODELS) -->
+  <!-- ============================================================= -->
+  <!-- ARTICLE METADATA MODEL -->
+  <!--
+    Content model for the metadata that is
+    specific to the article.
+  -->
+  <define name="article-meta-model">
+    <zeroOrMore>
+      <ref name="article-id"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="article-version.class"/>
+    </optional>
+    <optional>
+      <ref name="article-categories"/>
+    </optional>
+    <optional>
+      <ref name="title-group"/>
+    </optional>
+    <zeroOrMore>
+      <choice>
+        <ref name="contrib-group.class"/>
+        <ref name="aff-alternatives.class"/>
+        <ref name="x.class"/>
+      </choice>
+    </zeroOrMore>
+    <optional>
+      <ref name="author-notes"/>
+    </optional>
+    <choice>
+      <zeroOrMore>
+        <ref name="pub-date.class"/>
+      </zeroOrMore>
+      <optional>
+        <ref name="pub-date-not-available"/>
+      </optional>
+    </choice>
+    <zeroOrMore>
+      <ref name="volume"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="volume-id"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="volume-series"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="issue"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="issue-id"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="issue-title"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="issue-sponsor"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="issue-part"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="volume-issue-group"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="isbn"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="supplement"/>
+    </optional>
+    <optional>
+      <choice>
+        <group>
+          <optional>
+            <ref name="fpage"/>
+            <optional>
+              <ref name="lpage"/>
+            </optional>
+          </optional>
+          <optional>
+            <ref name="page-range"/>
+          </optional>
+        </group>
+        <ref name="elocation-id"/>
+      </choice>
+    </optional>
+    <zeroOrMore>
+      <choice>
+        <ref name="address-link.class"/>
+        <ref name="product"/>
+        <ref name="supplementary-material"/>
+      </choice>
+    </zeroOrMore>
+    <optional>
+      <ref name="history"/>
+    </optional>
+    <optional>
+      <ref name="pub-history"/>
+    </optional>
+    <optional>
+      <ref name="permissions"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="self-uri"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="related-article.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="abstract.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="trans-abstract"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="kwd-group.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="funding-group"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="support-group"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="conference"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="counts"/>
+    </optional>
+    <optional>
+      <ref name="custom-meta-group"/>
+    </optional>
+  </define>
+  <!-- ADDRESS MODEL -->
+  <!-- Content model for the <address> element -->
+  <define name="address-model">
+    <zeroOrMore>
+      <choice>
+        <ref name="address.class"/>
+        <ref name="address-link.class"/>
+        <ref name="label.class"/>
+        <ref name="x.class"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <!-- APPENDIX MODEL -->
+  <!--
+    Content model for the <app> element. The
+    section model already contains parentheses.
+    Made initial <title> optional.
+  -->
+  <define name="app-model">
+    <ref name="sec-opt-title-model"/>
+    <optional>
+      <ref name="permissions"/>
+    </optional>
+  </define>
+  <!-- AUTHOR NOTES MODEL -->
+  <!-- Content model for an <author-notes> element. -->
+  <define name="author-notes-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <oneOrMore>
+      <choice>
+        <ref name="corresp.class"/>
+        <ref name="fn-link.class"/>
+        <ref name="just-para.class"/>
+        <ref name="x.class"/>
+      </choice>
+    </oneOrMore>
+  </define>
+  <!-- CONFERENCE MODEL -->
+  <!-- Content model for the <conference> element -->
+  <define name="conference-model">
+    <zeroOrMore>
+      <choice>
+        <ref name="conference.class"/>
+        <ref name="x.class"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <!-- CONTRIBUTOR GROUP MODEL -->
+  <!--                     Content model for the <title-group> element -->
+  <define name="contrib-group-model">
+    <oneOrMore>
+      <choice>
+        <ref name="contrib.class"/>
+        <ref name="contrib-info.class"/>
+        <ref name="x.class"/>
+      </choice>
+    </oneOrMore>
+  </define>
+  <!-- CONTRIBUTOR MODEL -->
+  <!-- Content model for the <contrib> element -->
+  <define name="contrib-model">
+    <zeroOrMore>
+      <choice>
+        <ref name="contrib-id.class"/>
+        <ref name="name.class"/>
+        <ref name="degree.class"/>
+        <ref name="contrib-info.class"/>
+        <ref name="x.class"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <!-- DEFINITION LIST: DEFINITION ITEM MODEL -->
+  <!-- Content model of a <def-item> -->
+  <define name="def-item-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="term"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="def.class"/>
+        <ref name="x.class"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <!-- DEFINITION LIST MODEL -->
+  <!-- Content model for the <def-list> element -->
+  <define name="def-list-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <optional>
+      <ref name="term-head"/>
+    </optional>
+    <optional>
+      <ref name="def-head"/>
+    </optional>
+    <zeroOrMore>
+      <choice>
+        <ref name="def-item.class"/>
+        <ref name="x.class"/>
+      </choice>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="def-list.class"/>
+    </zeroOrMore>
+  </define>
+  <!-- FOOTNOTE GROUP MODEL -->
+  <!--
+    Content model for the <fn-group> element
+    Added an <x> as alternative to <fn>.
+  -->
+  <define name="fn-group-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <oneOrMore>
+      <choice>
+        <ref name="fn-link.class"/>
+        <ref name="x.class"/>
+      </choice>
+    </oneOrMore>
+  </define>
+  <!-- HISTORY MODEL -->
+  <!-- Content model for the <history> element -->
+  <define name="history-model">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="history-elements"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <!-- KEYWORD GROUP MODEL -->
+  <!-- Content model for a <kwd-group> element -->
+  <define name="kwd-group-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <choice>
+      <oneOrMore>
+        <choice>
+          <ref name="kwd.class"/>
+          <ref name="x.class"/>
+        </choice>
+      </oneOrMore>
+      <zeroOrMore>
+        <ref name="unstructured-kwd-group.class"/>
+      </zeroOrMore>
+    </choice>
+  </define>
+  <!-- LIST MODEL -->
+  <!-- Content model for the <list> element -->
+  <define name="list-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <oneOrMore>
+      <choice>
+        <ref name="list-item.class"/>
+        <ref name="x.class"/>
+      </choice>
+    </oneOrMore>
+  </define>
+  <!-- PUBLICATION DATE MODEL -->
+  <!-- Content model for the element <pub-date> -->
+  <define name="pub-date-model">
+    <zeroOrMore>
+      <choice>
+        <ref name="date-parts.class"/>
+        <ref name="string-date.class"/>
+        <ref name="x.class"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <!-- REFERENCE ITEM MODEL -->
+  <!-- Content model for the <ref> element -->
+  <define name="ref-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <oneOrMore>
+      <choice>
+        <ref name="citation.class"/>
+        <ref name="note.class"/>
+        <ref name="x.class"/>
+      </choice>
+    </oneOrMore>
+  </define>
+  <!-- REFERENCE LIST MODEL -->
+  <!-- Content model for the <ref-list> element -->
+  <define name="ref-list-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <zeroOrMore>
+      <choice>
+        <ref name="para-level"/>
+        <ref name="ref.class"/>
+      </choice>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="ref-list.class"/>
+    </zeroOrMore>
+  </define>
+  <!-- RUBY WRAPPER Model -->
+  <!-- Content model for the <ruby> element -->
+  <define name="ruby-model">
+    <ref name="rb"/>
+    <choice>
+      <ref name="rt"/>
+      <group>
+        <ref name="rp"/>
+        <ref name="rt"/>
+        <ref name="rp"/>
+      </group>
+    </choice>
+  </define>
+  <!-- CONTENT MODEL FOR A STRUCTURAL SECTION -->
+  <!-- The model for a Section <sec> -->
+  <define name="sec-model">
+    <optional>
+      <ref name="sec-meta"/>
+    </optional>
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="para-level"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="sec-level"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="sec-back-matter-mix"/>
+    </zeroOrMore>
+  </define>
+  <!-- TABLE WRAP FOOTER MODEL -->
+  <!--
+    Content model for the <table-wrap-foot>
+    element
+  -->
+  <define name="table-wrap-foot-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <oneOrMore>
+      <choice>
+        <ref name="just-para.class"/>
+        <ref name="fn-group.class"/>
+        <ref name="fn-link.class"/>
+        <ref name="display-back-matter.class"/>
+        <ref name="x.class"/>
+      </choice>
+    </oneOrMore>
+  </define>
+  <!-- TRANSLATED ABSTRACT MODEL -->
+  <!-- Content model for an <trans-abstract> element. -->
+  <define name="trans-abstract-model">
+    <zeroOrMore>
+      <ref name="id.class"/>
+    </zeroOrMore>
+    <ref name="sec-opt-title-model"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- OVER-RIDES OF ATTRIBUTE LISTS -->
+  <!-- ============================================================= -->
+  <!-- ARTICLE IDENTIFIER ATTRIBUTES -->
+  <!-- Attributes for the <article-id> element -->
+  <define name="article-id-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="pub-id-type"/>
+    </optional>
+    <optional>
+      <attribute name="assigning-authority"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- AWARD IDENTIFIER ATTRIBUTES -->
+  <!-- Attributes for the <award-group> element -->
+  <define name="award-id-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="rid">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="award-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- DATE (HISTORICAL) ATTRIBUTES -->
+  <define name="date-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="date-type"/>
+    </optional>
+    <optional>
+      <attribute name="publication-format"/>
+    </optional>
+    <optional>
+      <attribute name="iso-8601-date"/>
+    </optional>
+    <optional>
+      <attribute name="calendar"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- FUNDING STATEMENT ATTRIBUTES -->
+  <!--                     Attributes for the <funding-source> element -->
+  <define name="funding-statement-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="rid">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- PUBLICATION IDENTIFIER ATTRIBUTES -->
+  <!-- Attributes for the <pub-id> element -->
+  <define name="pub-id-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="pub-id-type"/>
+    </optional>
+    <optional>
+      <attribute name="assigning-authority"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- TRANSLATED TITLE GROUP ATTRIBUTES -->
+  <!--
+    Attribute list for the <trans-title-group>
+    Made xml:lang optional.
+  -->
+  <define name="trans-title-group-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- X(CROSS) REFERENCE ATTRIBUTES -->
+  <!-- Attribute list for cross references -->
+  <define name="xref-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="ref-type"/>
+    </optional>
+    <optional>
+      <attribute name="alt"/>
+    </optional>
+    <optional>
+      <attribute name="rid">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+</grammar>
+<!-- ================== End Archiving Content/ATT Over-rides ===== -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-articlemeta1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-articlemeta1.ent.rng
@@ -1,0 +1,2746 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Journal Article Metadata Elements -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) JATS DTD Suite Journal Article Metadata Elements v1.2 20190208//EN"
+       Delivered as file "JATS-articlemeta1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Names all elements used to describe the journal -->
+<!-- in which the journal article is published. -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- December 2002 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- This module is part of the JATS DTD Suite. The -->
+<!-- Suite is a continuation of work done by NCBI, -->
+<!-- Mulberry Technologies, and Inera Inc. on the NLM -->
+<!--              Journal Archiving and Interchange DTD Suite, which -->
+<!-- was originally released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   45. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   44. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   43. PUB-ID-TYPE - @pub-id-type changed back to a fixed list from 
+       CDATA, reversing the decision of Version 1.2d1. Although 
+       the value list is unchanged, best practice will be documented
+       as using @pub-id-type for type and @assigning-authority
+       for the responsible agency.
+         - for <article-id>
+  
+   42. ASSIGNING AUTHORITY - Added @assigning-authority to the
+       following elements, so that the type-of-identifier and
+       the party-responsible-for-identifier could both be
+       recorded. Previously, these values were both assigned to
+       the attribute @pub-id-type.
+           - <article-id>
+  
+   41. NON-MONETARY SUPPORT - Inside <article-meta> added new
+       <support-group> to hold both funding and
+       non-monetary support descriptions. <support-group> is 
+       both a peer to <funding-group> (backward compatibility)
+       and contains <funding-group>.
+  
+   40. PUBLICATION DATE-NOT-AVAILABLE - Inside <article-meta>, 
+       <front-stub>, <event>, and <event-desc>
+       added new element <pub-date-not-available>, as an 
+       alternative to <pub-date>. The meaning is that a 
+       publication date was (for whatever reason) not available. 
+       Presence of the element says nothing about publication 
+       status.
+  
+   39. VOCABULARY/TAXONOMY ATTRIBUTES - Added 2 new attributes for
+       naming (and possibly linking to) general or controlled
+       taxonomy, vocabulary, index, database or other source of
+       terms (@vocab, and @vocab-identifier) to these
+       elements (which could already take the attributes
+       @vocab-term and @vocab-term-identifier):
+          - <kwd>
+          - <compound-kwd>
+          - <nested-kwd>
+          - <subject>
+          - <compound-subject>
+  
+   38. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   37. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   36. EVENTS - 
+        - Added <event>, which will reside only inside
+          <pub-history>. 
+        - Added <pub-history> to hold <event>s. Unlike in BITS, 
+          <pub-history> will contain ONLY <event>s.
+        - Took <event> attributes from BITS. 
+        - Added <article-version> to model of <event>.
+  
+   35. PUB-ID-TYPE - @pub-id-type changed from a fixed list to
+       CDATA for all usages of the attribute.
+  
+   34. ARTICLE META MODEL
+       - NO DATE - <pub-date> (optional repeatable) is now
+         followed by the optional new element 
+         <pub-date-not-available>. 
+  
+       - ARTICLE VERSION - Added new element <article-version>
+         inside <article-meta> to hold one version number for  
+         the article. <article-version> element may repeat inside
+         new element <article-version-alternatives> to hold 
+         version numbers for this article from different systems.
+  
+       - PUBLICATION HISTORY - Added new element based on BITS,
+         <pub-history>, to hold <event>s as <history> holds
+         <date>s. New internal elements: <event>, <event-desc>
+  
+   33. VOCABULARY/TAXONOMY ATTRIBUTES - Added 4 new attributes for
+       naming (and possibly linking to) a general or controlled
+       taxonomy, vocabulary, index, database or other source of
+       terms: @vocab, @vocab-identifier, @vocab-term, and
+       @vocab-term-identifier
+  
+        - Attributes @vocab and @vocab-identifier were 
+          added to the elements:
+          - <kwd-group>
+          - <subj-group>
+          - <unstructured-kwd-group>
+  
+        - Attributes @vocab-term and @vocab-term-identifier were
+          added to the elements:
+          - <kwd>
+          - <compound-kwd>
+          - <nested-kwd>
+          - <subject>
+          - <compound-subject>
+  
+   32. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+       =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+   31. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   30. JATS became version "1.1d3" and "v1.1d3 20150301"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   29. <VOLUME> INSIDE <ARTICLE-META>
+  
+     - Allowed <volume> to repeat inside <article-meta>, the types to 
+       be distinguished using @content-type
+  
+     - Added new optional element <volume-issue-group> inside 
+       <article-meta) following all volume and issue elements
+       to hold volume-issue pairs (or n-tuples) when a second
+       and subsequent <volume> has its own related issue
+       information.
+  
+     - Made <issue> repeatable, for those who choose not to use
+       the new wrapper element.
+  
+   28. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+   27. NEW <era> ELEMENT
+       Added <era> through date-model
+        - <pub-date>
+  
+   26. GLOBAL ATTRIBUTES - Added the new parameter entity 
+           %jats-common-atts;
+       to every element in this module. This PE adds (for now) the
+       @id attribute and the @xml:base attribute to every element,
+       whether metadata or narrative.
+       Since the @id in this parameter entity is optional, a second
+       parameter entity jats-common-atts-id-required was also added.
+       The two are kept in sync with the jats-base-atts parameter 
+       entity.
+       This added a new attribute list to:
+        - article-categories
+        - article-meta
+        - counts
+        - history
+        - title-group                          
+  
+   25. ABSTRACTS AND KEYWORDS
+         Changed "abstract*" to "(%abstract.class;)*"
+         and "kwd-group*" to "(%kwd-group.class;)*" since those
+         classes now exist. Elements should have a limited number of
+         ways to be invoked.
+          - article-meta (through %article-meta-model;)
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+   24. RELATED OBJECT - Added <related-object> everywhere
+       <related-article> was used, including inside 
+       <article-meta> using article-meta-model.
+  
+   23. CONTRIB-GROUP AND CONTRIB MODULE SHIFT - Moved <contrib>
+       and <contrib-group> to common.ent, since they are now used
+       in both article metadata and journal metadata.
+  
+   22. CONTRIBUTOR MODEL - Added "contrib-id.class" to the beginning
+       at the <contrib> model, to hold identifiers for people,
+       such as publishers-specific IDs, ORCIDs, and JST and NII 
+       identifiers.
+  
+   21. COUNTS - Generic <count> element added to the <counts>
+       wrapper. This element is allowed to repeat, to count
+       anything a publisher or archive may wish to count.
+       The @count-type attribute will name what is being counted
+       (such as figures, tables, sections, contributors, images,
+       etc.) The @count attribute will state how many of the 
+       objects are in the document.
+  
+       Although a publisher or archive could choose to label
+       all the counted objects in a document this way, the
+       specific count elements (fig-count, equation-count,
+       word-count, etc.) will be retained for backwards
+       compatibility.
+  
+       New parameter entities: count-atts.
+  
+   20. PUBLICATION DATE ATTRIBUTES - Added to the attributes for
+       <pub-date> (through @pub-date-atts):
+         a) @iso-8601-date - ISO 8601 standard date format
+            of the publication date. Format  YYYY-MM-DDThh:mm:ss 
+         b) @calendar - Name of the calendar used (@calendar) in
+            naming this publication date (such as "Gregorian", 
+            "Japanese" (Emperor years), or "Islamic").
+         c) @date-type to record lifecycle information as to which
+            publication date is involved (such as retracted, corrected,
+            preprint).
+         d) @publication-format to hold what format or media was 
+            published on this date (such as "print" or
+            "electronic").
+         e) @xml:lang (comments below said was this added for 0.4).
+  
+   19. COMPOUND KEYWORD PARTS - Allowed the individual compound 
+       keyword parts (<compound-kwd-part> to be as complex as 
+       ordinary keywords <kwd>), by giving them the same model 
+       as <kwd>.
+  
+   18. NESTED KEYWORDS - Added new keyword type element for nested
+       keywords (<nested-kwd>), to hold hierarchical keywords such
+       as taxonomic structures. New PEs %nested-kwd-model  and
+       %nested-kwd-atts 
+  
+   17. MODULE MOVEMENT (from increased reference content)
+  
+       a) Element <degrees> - Moved <degrees> and its parameter
+          entities from this module from JATS-common.ent.
+  
+       b) Element <supplement> - Moved <supplement> and its parameter
+          entities from this module from JATS-common.ent.
+  
+       c) Element <conf-sponsor> - Moved <conf-sponsor> and its parameter
+          entities from this module from JATS-common.ent.
+  
+       d) Element <on-behalf-of> - Moved <on-behalf-of> and its parameter
+          entities from this module from JATS-common.ent.
+  
+   16. Added name comment to %counts-model;
+  
+   15. Updated the DTD-version attribute to "1.0" and the formal
+       public identifier to the date: "v1.0 20120330//EN".
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+   14. Updated the DTD-version attribute to "0.4" 
+  
+   13. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+             http://jats.nlm.nih.gov/0.4.
+  
+   12. UNSTRUCTURED KEYWORD GROUP ATTRIBUTES - Made
+       %unstructured-kwd-group-atts; into its own PE, as
+       documentation stated had already been done.
+  
+   11. KEYWORD ATTRIBUTES - To make the tag set more consistent,
+       added @content-type to <kwd>, since <compound-kwd> already
+       took this attribute. Through %kwd-atts;
+  
+   10. I18N - At the request of the SBJ Working Group (Japan)
+       made <series-text> repeatable inside <article-categories> using
+       %article-categories-model;
+  
+    9. TITLE ELEMENTS - Removed the dependency which had both
+       <subtitle> and <alt-title> modeled with the same parameter
+       entity %title-elements;. Created new PEs for each element
+       but set them (as the default) to %title-elements so that no
+       customization would break. Models changed:
+         - alt-title    %alt-title-elements; defined in common.ent
+         - subtitle     %subtitle-elements; (moved to this
+             module)
+  
+    8. AFFILIATION ALTERNATIVES - Added the element <aff-alternatives>
+       to <article-meta> through %article meta-model;. This element
+       will hold multiple <aff>s that are a representation of a
+       single affiliation, for example, the name of an institution
+       in two languages or two scripts.
+  
+    7. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+       @xml:lang to the following elements:
+        - alt-title through alt-title-atts (both)
+        - article-id through article-id-atts (@specific-use only)
+        - author-comment through author-comment-atts (both)
+        - author-notes through author-notes-atts (both)
+        - article-id through article-id-atts (@xml:lang)
+        - contrib through contrib-atts (@specific-use only)
+        - contrib-group through contrib-group-atts (@xml:lang)
+        - corresp through corresp-atts (@specific-use)
+        - degrees through degrees-atts (both)
+        - kwd-group through kwd-group-atts (@specific-use only
+               @xml:lang already there)
+        - on-behalf-of through on-behalf-of-atts (both) NEW PE
+        - product through product-atts (both)
+        - pub-date through pub-date-atts (@xml:lang)
+        - self-uri through self-uri-atts (both)
+        - series-text through series-text-atts (both)
+        - series-title through series-title-atts (both)
+        - string-conf through string-conf-atts (both)
+        - subj-group through subj-group-atts (both)
+        - subtitle through subtitle-atts (@specific only
+               @xml:lang already there)
+        - supplement through supplement-atts (both)
+  
+    6. TITLE ELEMENTS - Removed the dependency which had both
+       <subtitle> and <alt-title> modeled with the same parameter
+       entity %title-elements;. Created new PEs for each element
+       but set them (as the default) to %title-elements so that no
+       customization would break.
+  
+    5. COUNT ATTRIBUTES - Removed the dependency which had all of
+       the count elements using a single attribute list (%count-atts;)
+       Created new attributes list PEs for each of them: equation-count,
+       fig-count, page-count, ref-count, table-count, and word-count.
+       *****Customization Alert: New parameter entities could break
+       some customizations. Check the attribute list parameter entity
+       for each of the count elements. *****
+  
+    4. COMPOUND SUBJECT - Created a new element <compound-subject>
+       that acts just like <compound-kwd>, in that it takes one or
+       more <compound-subject-part>s to allow a complex, multi-
+       part subject to be captured. New elements, attribute lists,
+       and parameter entities. (An example of a compound subject
+       is a code with a textual keyword (A11 Permeability).
+       Allowed <compound-subject> as an alternative to <subject>
+       inside a <subj-group>.
+  
+    3. SERIES TEXT ATTRIBUTES - Both <series-title> and
+       <series-text> used to use the PE %series-title-atts;. Added the
+       PE %series-text-atts;, which is the only one <series-text>
+       uses. No documents need change.
+       *****Customization Alert: New parameter entity could break some
+       customizations. Check your <series-text> attributes. *****
+  
+    2. TRANSLATED ABSTRACT ATTRIBUTES - Both <abstract> and
+       <trans-abstract> used to use the PE %abstract-atts;. Added the
+       PE %trans-abstract-atts;, which is the only one <trans-abstract>
+       uses. No documents need change.
+       *****Customization Alert: New parameter entity could break some
+       customizations. Check your <trans-abstract> attributes. *****
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- PARAMETER ENTITIES FOR ATTRIBUTE LISTS -->
+<!-- ============================================================= -->
+<!-- ABSTRACT ATTRIBUTES -->
+<!-- Attributes for the <abstract> element -->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="abstract-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="abstract-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ALTERNATE TITLE ATTRIBUTES -->
+  <!-- Attributes for the <alt-title> element -->
+  <define name="alt-title-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="alt-title-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ARTICLE CATEGORIES ATTRIBUTES -->
+  <!--
+    Attributes for the <article-categories> 
+    element
+  -->
+  <define name="article-categories-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- ARTICLE METADATA ATTRIBUTES -->
+  <!-- Attributes for the <article-meta> element -->
+  <define name="article-meta-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- ARTICLE VERSION ATTRIBUTES -->
+  <!--
+    Attributes for the <article-version> 
+    element
+  -->
+  <define name="article-version-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="article-version-type"/>
+    </optional>
+    <optional>
+      <attribute name="designator"/>
+    </optional>
+    <optional>
+      <attribute name="vocab"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="iso-8601-date"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- ARTICLE VERSION ALTERNATIVE ATTRIBUTES -->
+  <!--
+    Attributes for the 
+    <article-version-alternatives> element
+  -->
+  <define name="article-version-alternatives-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- AUTHOR COMMENT ATTRIBUTES -->
+  <!--                     Attributes for the <author-comment> element -->
+  <define name="author-comment-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- AUTHOR NOTES ATTRIBUTES -->
+  <!-- Attributes for the <author-notes> element -->
+  <define name="author-notes-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="rid">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- ARTICLE IDENTIFIER ATTRIBUTES -->
+  <!-- Attributes for the <article-id> element -->
+  <!-- COMPOUND KEYWORD ATTRIBUTES -->
+  <!-- Attributes for the <compound-kwd> element -->
+  <define name="compound-kwd-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="vocab"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+  </define>
+  <!-- COMPOUND KEYWORD PART ATTRIBUTES -->
+  <!--
+    Attributes for the <compound-kwd-part>
+    element
+  -->
+  <define name="compound-kwd-part-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+  </define>
+  <!-- COMPOUND SUBJECT ATTRIBUTES -->
+  <!-- Attributes for the <compound-subject> element -->
+  <define name="compound-subject-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="vocab"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+  </define>
+  <!-- COMPOUND SUBJECT PART ATTRIBUTES -->
+  <!--
+    Attributes for the <compound-subject-part>
+    element
+  -->
+  <define name="compound-subject-part-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+  </define>
+  <!-- CONFERENCE ACRONYM ATTRIBUTES -->
+  <!-- Attributes for the <conf-acronym> element -->
+  <define name="conf-acronym-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- CONFERENCE NUMBER ATTRIBUTES -->
+  <!-- Attributes for the <conf-num> element -->
+  <define name="conf-num-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- CONFERENCE THEME ATTRIBUTES -->
+  <!-- Attributes for the <conf-theme> element -->
+  <define name="conf-theme-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- CONFERENCE ATTRIBUTES -->
+  <!-- Attributes for the <conference> element -->
+  <define name="conference-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- CORRESPONDING ATTRIBUTES -->
+  <!-- Attributes for the <corresp> element -->
+  <define name="corresp-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- COUNT ATTRIBUTES -->
+  <!-- Attributes for the <count> element -->
+  <define name="count-atts">
+    <ref name="jats-common-atts"/>
+    <attribute name="count-type"/>
+    <attribute name="count">
+      <data type="NMTOKEN"/>
+    </attribute>
+  </define>
+  <!-- COUNTS ATTRIBUTES -->
+  <!-- Attributes for the <counts> element -->
+  <define name="counts-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- DATE NOT AVAILABLE ATTRIBUTES -->
+  <!--
+    Attributes for the <pub-date-not-available> 
+    element
+  -->
+  <define name="pub-date-not-available-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- EQUATION COUNT ATTRIBUTES -->
+  <!--                     Attributes for the <equation-count> element -->
+  <define name="equation-count-atts">
+    <ref name="jats-common-atts"/>
+    <attribute name="count">
+      <data type="NMTOKEN"/>
+    </attribute>
+  </define>
+  <!-- PUBLICATION EVENT ATTRIBUTES -->
+  <!-- Attributes for the <event> element -->
+  <define name="event-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="event-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- EVENT DESCRIPTION ATTRIBUTES -->
+  <!--
+    Attributes used with the <event-desc>
+    element.
+  -->
+  <define name="event-desc-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- FIGURE COUNT ATTRIBUTES -->
+  <!-- Attributes for the <fig-count> element -->
+  <define name="fig-count-atts">
+    <ref name="jats-common-atts"/>
+    <attribute name="count">
+      <data type="NMTOKEN"/>
+    </attribute>
+  </define>
+  <!-- HISTORY ATTRIBUTES -->
+  <!-- Attributes for the <history> element -->
+  <define name="history-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- KEYWORD ATTRIBUTES -->
+  <!-- Attributes for the <kwd> element -->
+  <define name="kwd-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="vocab"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+  </define>
+  <!-- KEYWORD GROUP ATTRIBUTES -->
+  <!-- Attributes for the <kwd-group> element -->
+  <define name="kwd-group-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="kwd-group-type"/>
+    </optional>
+    <optional>
+      <attribute name="vocab"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- NESTED KEYWORD ATTRIBUTES -->
+  <!-- Attributes for the <nested-kwd> element -->
+  <define name="nested-kwd-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="vocab"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+  </define>
+  <!-- PAGE COUNT ATTRIBUTES -->
+  <!-- Attributes for the <page-count> element -->
+  <define name="page-count-atts">
+    <ref name="jats-common-atts"/>
+    <attribute name="count">
+      <data type="NMTOKEN"/>
+    </attribute>
+  </define>
+  <!-- PRODUCT ATTRIBUTES -->
+  <!-- Attributes for the <product> element -->
+  <define name="product-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="product-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- PUBLICATION DATE ATTRIBUTES -->
+  <!-- Attributes for the <pub-date> element -->
+  <define name="pub-date-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="pub-type"/>
+    </optional>
+    <optional>
+      <attribute name="publication-format"/>
+    </optional>
+    <optional>
+      <attribute name="date-type"/>
+    </optional>
+    <optional>
+      <attribute name="iso-8601-date"/>
+    </optional>
+    <optional>
+      <attribute name="calendar"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- PUBLICATION HISTORY ATTRIBUTES -->
+  <!-- Attributes for the <pub-history> element -->
+  <define name="pub-history-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- REFERENCE (CITATION) COUNT ATTRIBUTES -->
+  <!-- Attributes for the <ref-count> element -->
+  <define name="ref-count-atts">
+    <ref name="jats-common-atts"/>
+    <attribute name="count">
+      <data type="NMTOKEN"/>
+    </attribute>
+  </define>
+  <!-- SELF URI ATTRIBUTES -->
+  <!-- Attributes for the <self-uri> element -->
+  <define name="self-uri-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- SERIES TEXT ATTRIBUTES -->
+  <!-- Attributes for the <series-text> element -->
+  <define name="series-text-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- SERIES TITLE ATTRIBUTES -->
+  <!-- Attributes for the <series-title> element -->
+  <define name="series-title-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- STRING CONFERENCE ATTRIBUTES -->
+  <!-- Attributes for the <string-conf> element -->
+  <define name="string-conf-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- SUBJECT GROUP ATTRIBUTES -->
+  <!-- Attributes for the <subj-group> element -->
+  <define name="subj-group-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="subj-group-type"/>
+    </optional>
+    <optional>
+      <attribute name="vocab"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- SUBJECT ATTRIBUTES -->
+  <!-- Attributes for the <subject> element -->
+  <define name="subject-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="vocab"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+  </define>
+  <!-- SUBTITLE ATTRIBUTES -->
+  <!-- Attributes for the <subtitle> element -->
+  <define name="subtitle-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- TABLE COUNT ATTRIBUTES -->
+  <!-- Attributes for the <table-count> element -->
+  <define name="table-count-atts">
+    <ref name="jats-common-atts"/>
+    <attribute name="count">
+      <data type="NMTOKEN"/>
+    </attribute>
+  </define>
+  <!-- TITLE GROUP ATTRIBUTES -->
+  <!-- Attributes for the <title-group> element -->
+  <define name="title-group-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- TRANSLATED ABSTRACT ATTRIBUTES -->
+  <!--                     Attributes for the <trans-abstract> element -->
+  <define name="trans-abstract-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="abstract-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- UNSTRUCTURED KEYWORD GROUP ATTRIBUTES -->
+  <!--
+    Attributes for the <unstructured-kwd-group>
+    element
+  -->
+  <define name="unstructured-kwd-group-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="kwd-group-type"/>
+    </optional>
+    <optional>
+      <attribute name="vocab"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- WORD COUNT ATTRIBUTES -->
+  <!-- Attributes for the <word-count> element -->
+  <define name="word-count-atts">
+    <ref name="jats-common-atts"/>
+    <attribute name="count">
+      <data type="NMTOKEN"/>
+    </attribute>
+  </define>
+  <!-- ============================================================= -->
+  <!-- ARTICLE METADATA -->
+  <!-- ============================================================= -->
+  <!-- ARTICLE METADATA MODEL -->
+  <!--
+    Complete content model for the <article-meta>
+    element, which names the journal article
+    metadata
+  -->
+  <!--
+    ELEM   address links (email | ext-link | uri)
+    Defined in %funding.ent;
+  -->
+  <!-- ELEM   aff          Defined in %common.ent; -->
+  <!--
+    ELEM   copyright-statement
+    Defined in %common.ent;
+  -->
+  <!--
+    ELEM   copyright-year
+    Defined in %common.ent;
+  -->
+  <!--
+    ELEM   custom-meta-group
+    Defined in %common.ent;
+  -->
+  <!-- ELEM   elocation-id Defined in %common.ent; -->
+  <!-- ELEM   ext-link     Defined in %common.ent; -->
+  <!-- ELEM   fpage        Defined in %common.ent; -->
+  <!--
+    ELEM   funding-group
+    Defined in %funding.ent;
+  -->
+  <!-- ELEM   isbn         Defined in %common.ent; -->
+  <!-- ELEM   issue        Defined in %common.ent; -->
+  <!-- ELEM   issue-id     Defined in %common.ent; -->
+  <!-- ELEM   issue-title  Defined in %common.ent; -->
+  <!--
+    ELEM   issue-sponsor
+    Defined in %common.ent;
+  -->
+  <!-- ELEM   license      Defined in %common.ent; -->
+  <!-- ELEM   lpage        Defined in %common.ent; -->
+  <!-- ELEM   page-range   Defined in %common.ent; -->
+  <!-- ELEM   permissions  Defined in %common.ent; -->
+  <!--
+    ELEM   related-article and related-object
+    Defined in %common.ent;
+  -->
+  <!--
+    ELEM   supplementary-material
+    Defined in %display.ent;
+  -->
+  <!-- ELEM   volume       Defined in %common.ent; -->
+  <!-- ELEM   volume-id    Defined in %common.ent; -->
+  <!--
+    ELEM   volume-series
+    Defined in %common.ent;
+  -->
+  <!-- ARTICLE METADATA -->
+  <!--
+    Metadata that identifies this article, for
+    example, bibliographic information such as
+    the title, author, and copyright year.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=article-meta
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=article-meta
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=article-meta
+  -->
+  <define name="article-meta">
+    <element name="article-meta">
+      <ref name="article-meta-attlist"/>
+      <ref name="article-meta-model"/>
+    </element>
+  </define>
+  <define name="article-meta-attlist" combine="interleave">
+    <ref name="article-meta-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- ARTICLE METADATA ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- ARTICLE IDENTIFIER -->
+  <!--
+    Optional element, used to hold one of the
+    "unique identifiers" that have been assigned
+    at various times to an article.  Such
+    identifiers may come from a publisher, a
+    jobber, from PubMed Central, etc.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=article-id
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=article-id
+  -->
+  <define name="article-id">
+    <element name="article-id">
+      <ref name="article-id-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <define name="article-id-attlist" combine="interleave">
+    <ref name="article-id-atts"/>
+  </define>
+  <!-- ARTICLE VERSION -->
+  <!--
+    Optional element, used to hold one of the
+    "version" identifiers (such as version type, 
+    version status, version statement, or version
+    number) that have been assigned to the 
+    current article. 
+    Remarks: A typical version identifier might 
+    use terminology from the NISO Journal Article 
+    Versions Recommendations (such as "preprint"
+    or "copy-of-record", but it might also be a
+    publishers internal versioning number such as
+    "0.9".
+       The element is allowed to repeat inside a
+    <article-version-alternatives> element to hold
+     version numbers from more than one versioning
+     system. A given article should only be a
+     single version in any given system.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=article-version
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=article-version
+  -->
+  <define name="article-version">
+    <element name="article-version">
+      <ref name="article-version-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <define name="article-version-attlist" combine="interleave">
+    <ref name="article-version-atts"/>
+  </define>
+  <!-- ARTICLE VERSION ALTERNATIVES -->
+  <!--
+    Container element to hold multiple
+    <article-version> elements, when the version
+    number/identifier for more than one system
+    needs to be recorded. A given article should
+    only be a single version in any given system.
+    Details at:              
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=article-version-alternatives
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=article-version-alternatives 
+  -->
+  <define name="article-version-alternatives">
+    <element name="article-version-alternatives">
+      <ref name="article-version-alternatives-attlist"/>
+      <oneOrMore>
+        <ref name="article-version"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="article-version-alternatives-attlist" combine="interleave">
+    <ref name="article-version-alternatives-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- ARTICLE GROUPING DATA (ARTICLE METADATA) -->
+  <!-- ============================================================= -->
+  <!-- ARTICLE CATEGORIES MODEL -->
+  <!--
+    Complete content model for the
+    <article-categories> element
+  -->
+  <define name="article-categories-model">
+    <zeroOrMore>
+      <ref name="subj-group"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="series-title"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="series-text"/>
+    </zeroOrMore>
+  </define>
+  <!-- ARTICLE GROUPING DATA -->
+  <!--
+    Container for elements that may be used to
+    group articles into related clusters
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=article-categories
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=article-categories
+  -->
+  <define name="article-categories">
+    <element name="article-categories">
+      <ref name="article-categories-attlist"/>
+      <ref name="article-categories-model"/>
+    </element>
+  </define>
+  <define name="article-categories-attlist" combine="interleave">
+    <ref name="article-categories-atts"/>
+  </define>
+  <!-- SUBJECT GROUP MODEL -->
+  <!--
+    Complete content model for the <subj-group>
+    element
+  -->
+  <define name="subj-group-model">
+    <oneOrMore>
+      <choice>
+        <ref name="subject"/>
+        <ref name="compound-subject"/>
+      </choice>
+    </oneOrMore>
+    <zeroOrMore>
+      <ref name="subj-group"/>
+    </zeroOrMore>
+  </define>
+  <!--
+    GROUPING ARTICLES IN TITLED CATEGORIES
+    Container element that collects multiple
+    subjects and/or hierarchically lower subject
+    groups.
+    Remarks: For some journals, articles are
+    grouped into categories, with the category
+    indicated in the article's display.
+    Sometimes the grouping or category refers
+    to the type of article, such as "Essay",
+    "Commentary", or "Article".  Sometimes the
+    grouping refers to subject areas, such as
+    "Physical Sciences", "Biological Sciences",
+    or "Social Sciences".
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=subj-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=subj-group
+  -->
+  <define name="subj-group">
+    <element name="subj-group">
+      <ref name="subj-group-attlist"/>
+      <ref name="subj-group-model"/>
+    </element>
+  </define>
+  <define name="subj-group-attlist" combine="interleave">
+    <ref name="subj-group-atts"/>
+  </define>
+  <!-- SUBJECT ELEMENTS -->
+  <!--
+    Elements that may be used, along with data
+    characters inside the content model of the
+    <subject> element
+  -->
+  <!-- SUBJECT NAME -->
+  <!--
+    The name of one of the subject groups used
+    to describe an article.  Such groups are
+    used, typically, to provide headings for
+    groups of articles in a printed or online
+    generated Table of Contents.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=subject
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=subject
+  -->
+  <define name="subject">
+    <element name="subject">
+      <ref name="subject-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="subject-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="subject-attlist" combine="interleave">
+    <ref name="subject-atts"/>
+  </define>
+  <!-- COMPOUND SUBJECT MODEL -->
+  <!--
+    Complete content model for the
+    <compound-subject> element
+  -->
+  <define name="compound-subject-model">
+    <oneOrMore>
+      <ref name="compound-subject-part"/>
+    </oneOrMore>
+  </define>
+  <!-- COMPOUND SUBJECT NAME -->
+  <!--
+    Container element to hold all the parts of a
+    multi-part subject, for example, a subject that
+    is comprised of both a term and a code value
+    that represents that term.
+    Related Elements: If a subject is only a word
+    or phrase (Neuroscience, Physical Sciences),
+    the simple <subject> element can be used to
+    capture this information. If a subject is
+    logically both a term and a code
+    (A11 Permeability) but only one of those
+    objects needs to be captured, a <subject>
+    element may also be used. If it is useful to
+    record both the code and the term, they can
+    each be captured as one
+    <compound-subject-part>s inside a
+    <compound-subject>.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=compound-subject
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=compound-subject
+  -->
+  <define name="compound-subject">
+    <element name="compound-subject">
+      <ref name="compound-subject-attlist"/>
+      <ref name="compound-subject-model"/>
+    </element>
+  </define>
+  <define name="compound-subject-attlist" combine="interleave">
+    <ref name="compound-subject-atts"/>
+  </define>
+  <!-- COMPOUND SUBJECT PART ELEMENTS -->
+  <!--
+    Elements that may be used, along with data
+    characters inside the content model of the
+    <compound-subject> element
+  -->
+  <define name="compound-subject-part-elements">
+    <choice>
+      <ref name="emphasis.class"/>
+      <ref name="inline-display.class"/>
+      <ref name="inline-math.class"/>
+      <ref name="phrase-content.class"/>
+      <ref name="subsup.class"/>
+    </choice>
+  </define>
+  <!-- COMPOUND SUBJECT PART NAME -->
+  <!--
+    The name of one of the subject groups used
+    to describe an article, when that article is
+    a multi-part rather than a simple subject.
+    Such groups are used, typically, to provide
+    headings for groups of articles in a printed
+    or online generated Table of Contents. The
+    @content type attribute should be used to
+    indicate the type of part ("text", "code",
+    "sponsor", etc.).
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=compound-subject-part
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=compound-subject-part
+  -->
+  <define name="compound-subject-part">
+    <element name="compound-subject-part">
+      <ref name="compound-subject-part-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="compound-subject-part-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="compound-subject-part-attlist" combine="interleave">
+    <ref name="compound-subject-part-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- SERIES INFORMATION -->
+  <!-- ============================================================= -->
+  <!--
+                        GROUPING ARTICLES IN SERIES
+    Series (as used in the <series-title> and
+    <series-text> elements described below) is
+    used in two different senses. Some issues of
+    journals are part of a series and will have
+    series information just as they have an
+    issue number as part of the article metadata,
+    to describe the issue of the journal in which
+    the article is published.  The second usage
+    is for groupings of articles within one
+    issue of a journal. For example, in some
+    journals, articles are grouped into a
+    series such as "From the Cover" and
+    identified as part of a series.
+    The Series Title element names the series
+    and the Series Text element provides textual
+    description (if any) describing the series.
+  -->
+  <!-- SERIES TITLE ELEMENTS -->
+  <!--
+    Elements that may be used, along with data
+    characters inside the content model of the
+    <series-title> element
+  -->
+  <define name="series-title-elements">
+    <ref name="rendition-plus"/>
+  </define>
+  <!-- SERIES TITLE -->
+  <!--
+    Title of the journal series (bibliographic
+    meaning) or the title of a  series of
+    articles internal to one issue of a journal
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=series-title
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=series-title
+  -->
+  <define name="series-title">
+    <element name="series-title">
+      <ref name="series-title-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="series-title-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="series-title-attlist" combine="interleave">
+    <ref name="series-title-atts"/>
+  </define>
+  <!-- SERIES TEXT ELEMENTS -->
+  <!--
+    Elements that may be used, along with data
+    characters inside the content model of the
+    <series-text> element
+  -->
+  <define name="series-text-elements">
+    <ref name="rendition-plus"/>
+  </define>
+  <!-- SERIES TEXT: HEADER TEXT to DESCRIBE -->
+  <!--
+    Textual description of the series of articles
+    that are named in a <series-title> element
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=series-text
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=series-text
+  -->
+  <define name="series-text">
+    <element name="series-text">
+      <ref name="series-text-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="series-text-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="series-text-attlist" combine="interleave">
+    <ref name="series-text-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- TOP-LEVEL ARTICLE METADATA CONTINUED -->
+  <!-- ============================================================= -->
+  <!-- AUTHOR NOTES MODEL -->
+  <!-- Content model for an <author-notes> element. -->
+  <!-- AUTHOR NOTE GROUP -->
+  <!--
+    Footnotes to authors or notes about authors
+    (and, potentially other contributors) are
+    collected in the Author note group.
+    References to these footnotes are made
+    using the <xref> element.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=author-notes
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=author-notes
+  -->
+  <define name="author-notes">
+    <element name="author-notes">
+      <ref name="author-notes-attlist"/>
+      <ref name="author-notes-model"/>
+    </element>
+  </define>
+  <define name="author-notes-attlist" combine="interleave">
+    <ref name="author-notes-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PRODUCT REVIEW INFORMATION (PRODUCT METADATA) -->
+  <!-- ============================================================= -->
+  <!-- PRODUCT ELEMENTS -->
+  <!--
+    Elements that may be used inside the
+    <product> element
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-text; is an inline
+    mix, the OR bar is already there.
+  -->
+  <!-- PRODUCT INFORMATION -->
+  <!--
+    Used as a wrapper for metadata for a product
+    (such as a book, software package, hardware
+    component, web site, etc.) that is being
+    reviewed.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=product
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=product
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=product
+  -->
+  <define name="product">
+    <element name="product">
+      <ref name="product-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="product-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="product-attlist" combine="interleave">
+    <ref name="product-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- FURTHER METADATA ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- SELF-URI ELEMENTS -->
+  <!--
+    Elements to be mixed with data characters
+    inside the <self-uri> element
+  -->
+  <!-- URI FOR THIS SAME ARTICLE ONLINE -->
+  <!--
+    Sometimes an article is available in several
+    forms, for example there is the version that
+    was published in print and there is the same
+    article (possibly expanded or with different
+    graphics) available online.
+       The URI (such as a URL) may be used as a
+    live link, typically naming a web site or the
+    element content may name the URL, e.g., and
+    use the link attributes to hold the real link:
+       <self-uri xlink:href="...">An expanded
+       version of this article is available
+       online</self-uri>
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=self-uri
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=self-uri
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=self-uri
+  -->
+  <define name="self-uri">
+    <element name="self-uri">
+      <ref name="self-uri-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="self-uri-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="self-uri-attlist" combine="interleave">
+    <ref name="self-uri-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- ABSTRACTS -->
+  <!-- ============================================================= -->
+  <!-- ABSTRACT MODEL -->
+  <!-- Content model for an <abstract> element -->
+  <define name="abstract-model">
+    <zeroOrMore>
+      <ref name="id.class"/>
+    </zeroOrMore>
+    <ref name="sec-opt-title-model"/>
+  </define>
+  <!-- ABSTRACT -->
+  <!--
+    A short summation of the content of an
+    article.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=abstract
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=abstract
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=abstract
+  -->
+  <define name="abstract">
+    <element name="abstract">
+      <ref name="abstract-attlist"/>
+      <ref name="abstract-model"/>
+    </element>
+  </define>
+  <define name="abstract-attlist" combine="interleave">
+    <ref name="abstract-atts"/>
+  </define>
+  <!-- TRANSLATED ABSTRACT MODEL -->
+  <!-- Content model for an <trans-abstract> element. -->
+  <!-- TRANSLATED ABSTRACT -->
+  <!--
+    An abstract that has been translated into
+    another language
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=trans-abstract
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=trans-abstract
+  -->
+  <define name="trans-abstract">
+    <element name="trans-abstract">
+      <ref name="trans-abstract-attlist"/>
+      <ref name="trans-abstract-model"/>
+    </element>
+  </define>
+  <define name="trans-abstract-attlist" combine="interleave">
+    <ref name="trans-abstract-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- KEYWORD ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- KEYWORD GROUP MODEL -->
+  <!-- Content model for a <kwd-group> element -->
+  <!-- KEYWORD GROUP -->
+  <!--
+    Container element for one set of keywords
+    <kwd>s used to describe a document.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=kwd-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=kwd-group
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=kwd-group
+  -->
+  <define name="kwd-group">
+    <element name="kwd-group">
+      <ref name="kwd-group-attlist"/>
+      <ref name="kwd-group-model"/>
+    </element>
+  </define>
+  <define name="kwd-group-attlist" combine="interleave">
+    <ref name="kwd-group-atts"/>
+  </define>
+  <!-- ELEM   title        Defined in %common.ent; -->
+  <!-- KEYWORD CONTENT ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a keyword.
+  -->
+  <!-- KEYWORD -->
+  <!--
+    One subject term, critical expression, key
+    phrase, abbreviation, indexing word, etc.
+    that is associated with the whole document
+    and can be used for identification and
+    indexing purposes.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=kwd
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=kwd
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=kwd
+  -->
+  <define name="kwd">
+    <element name="kwd">
+      <ref name="kwd-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="kwd-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="kwd-attlist" combine="interleave">
+    <ref name="kwd-atts"/>
+  </define>
+  <!-- COMPOUND KEYWORD MODEL -->
+  <!--
+    The content model of the <compound-kwd>
+    element
+  -->
+  <define name="compound-kwd-model">
+    <oneOrMore>
+      <ref name="compound-kwd-part"/>
+    </oneOrMore>
+  </define>
+  <!-- COMPOUND KEYWORD -->
+  <!--
+    Some keywords are simple, a text word or
+    phrase; such keywords can be tagged using the
+    <kwd> element. But other keywords are more
+    complicated:
+     - a code and a term
+     - an abbreviation and its expansion
+     - a hierarchical keyword that carries all
+       the parts of its hierarchy (as index
+       terms do)
+    This element was created to handle these
+    special cases.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=compound-kwd
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=compound-kwd
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=compound-kwd
+  -->
+  <define name="compound-kwd">
+    <element name="compound-kwd">
+      <ref name="compound-kwd-attlist"/>
+      <ref name="compound-kwd-model"/>
+    </element>
+  </define>
+  <define name="compound-kwd-attlist" combine="interleave">
+    <ref name="compound-kwd-atts"/>
+  </define>
+  <!-- COMPOUND KEYWORD PART ELEMENTS -->
+  <!--
+    Elements to be mixed with data characters
+    inside the <compound-kwd-part> element
+  -->
+  <!-- COMPOUND KEYWORD PART -->
+  <!--
+    This element was created to hold one
+    component of a complex keyword, for example
+    one for the code and one for the term.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=compound-kwd-part
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=compound-kwd-part
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=compound-kwd-part
+  -->
+  <define name="compound-kwd-part">
+    <element name="compound-kwd-part">
+      <ref name="compound-kwd-part-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="compound-kwd-part-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="compound-kwd-part-attlist" combine="interleave">
+    <ref name="compound-kwd-part-atts"/>
+  </define>
+  <!-- NESTED KEYWORD MODEL -->
+  <!--
+    The content model of the <nested-kwd>
+    element
+  -->
+  <define name="nested-kwd-model">
+    <oneOrMore>
+      <ref name="nested-kwd.class"/>
+    </oneOrMore>
+    <zeroOrMore>
+      <ref name="nested-kwd"/>
+    </zeroOrMore>
+  </define>
+  <!-- NESTED KEYWORD -->
+  <!--
+    Hierarchical or nested keyword, in which the
+    levels of a taxonomy that describe the
+    article can be described.
+  -->
+  <define name="nested-kwd">
+    <element name="nested-kwd">
+      <ref name="nested-kwd-attlist"/>
+      <ref name="nested-kwd-model"/>
+    </element>
+  </define>
+  <define name="nested-kwd-attlist" combine="interleave">
+    <ref name="nested-kwd-atts"/>
+  </define>
+  <!-- UNSTRUCTURED KEYWORD GROUP ELEMENTS -->
+  <!-- Content model for a <kwd-group> element -->
+  <define name="unstructured-kwd-group-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- UNSTRUCTURED KEYWORD GROUP -->
+  <!--
+    Container element for one set of keywords
+    used to describe a document where the
+    individual keywords are not tagged as
+    separate <kwd>s but instead are all run
+    together in one long text field.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=unstructured-kwd-group
+  -->
+  <define name="unstructured-kwd-group">
+    <element name="unstructured-kwd-group">
+      <ref name="unstructured-kwd-group-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="unstructured-kwd-group-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="unstructured-kwd-group-attlist" combine="interleave">
+    <ref name="unstructured-kwd-group-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- STILL FURTHER ARTICLE METADATA -->
+  <!-- ============================================================= -->
+  <!-- CORRESPONDENCE INFORMATION ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the correspondence information.
+  -->
+  <!-- CORRESPONDENCE INFORMATION -->
+  <!--
+    Optional element, used as a container for
+    information concerning which of the authors
+    (or other contributors) is the corresponding
+    contributor, to whom information requests
+    should be addressed.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=corresp
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=corresp
+  -->
+  <define name="corresp">
+    <element name="corresp">
+      <ref name="corresp-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="corresp-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="corresp-attlist" combine="interleave">
+    <ref name="corresp-atts"/>
+  </define>
+  <!-- PUBLICATION DATE NOT AVAILABLE MODEL -->
+  <!--
+    The content model for the EMPTY element 
+    <pub-date-not-available>.
+  -->
+  <define name="pub-date-not-available-model">
+    <empty/>
+  </define>
+  <!-- DATE NOT AVAILABLE FLAG -->
+  <!--
+    EMPTY element used as a flag to signal that
+    the publication date (<pub-date>) is not
+    available. This flag does not mean, necessarily,
+    that the article is unpublished, just that no
+    <pub-date> is available.
+    Details at:                   
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=pub-date-not-available
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=pub-date-not-available
+  -->
+  <define name="pub-date-not-available">
+    <element name="pub-date-not-available">
+      <ref name="pub-date-not-available-attlist"/>
+      <ref name="pub-date-not-available-model"/>
+    </element>
+  </define>
+  <define name="pub-date-not-available-attlist" combine="interleave">
+    <ref name="pub-date-not-available-atts"/>
+  </define>
+  <!-- PUBLICATION DATE MODEL -->
+  <!-- The content model for the element <pub-date> -->
+  <!-- PUBLICATION DATE -->
+  <!--
+    Date of publication or release of the
+    material in one particular format.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=pub-date
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=pub-date
+  -->
+  <define name="pub-date">
+    <element name="pub-date">
+      <ref name="pub-date-attlist"/>
+      <ref name="pub-date-model"/>
+    </element>
+  </define>
+  <define name="pub-date-attlist" combine="interleave">
+    <ref name="pub-date-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- CONFERENCE INFORMATION ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- CONFERENCE MODEL -->
+  <!-- Content model for the <conference> element -->
+  <!-- CONFERENCE INFORMATION -->
+  <!--
+    The container element for the information
+    about a single conference and its
+    proceedings.
+    Design Note: Conference elements were largely
+    based on Cross-Ref.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=conference
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=conference
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=conference
+  -->
+  <define name="conference">
+    <element name="conference">
+      <ref name="conference-attlist"/>
+      <ref name="conference-model"/>
+    </element>
+  </define>
+  <define name="conference-attlist" combine="interleave">
+    <ref name="conference-atts"/>
+  </define>
+  <!-- ELEM   conf-date     Defined in %common.ent; -->
+  <!-- ELEM   conf-loc      Defined in %common.ent; -->
+  <!-- ELEM   conf-name     Defined in %common.ent; -->
+  <!-- ELEM   conf-sponsor  Defined in %common.ent; -->
+  <!-- CONFERENCE ACRONYM ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the conference acronym.
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-text; is an online
+    mix, the OR bar is already there.
+  -->
+  <define name="conf-acronym-elements">
+    <ref name="simple-text"/>
+  </define>
+  <!-- CONFERENCE ACRONYM -->
+  <!--
+    The short name, popular name, or "jargon
+    name" for a conference, for example,
+    "Extreme" for "Extreme Markup Languages" or
+    "SIGGRAPH" for "Special Interest Group on
+    Computer Graphics".
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=conf-acronym
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=conf-acronym
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=conf-acronym
+  -->
+  <define name="conf-acronym">
+    <element name="conf-acronym">
+      <ref name="conf-acronym-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="conf-acronym-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="conf-acronym-attlist" combine="interleave">
+    <ref name="conf-acronym-atts"/>
+  </define>
+  <!-- CONFERENCE NUMBER ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the conference number.
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-text; is an inline
+    mix, the OR bar is already there.
+  -->
+  <define name="conf-num-elements">
+    <ref name="simple-text"/>
+  </define>
+  <!-- CONFERENCE NUMBER -->
+  <!--
+    The sequential number of the conference.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=conf-num
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=conf-num
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=conf-num
+  -->
+  <define name="conf-num">
+    <element name="conf-num">
+      <ref name="conf-num-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="conf-num-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="conf-num-attlist" combine="interleave">
+    <ref name="conf-num-atts"/>
+  </define>
+  <!-- CONFERENCE THEME ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the conference theme.
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-text; is an online
+    mix, the OR bar is already there.
+  -->
+  <define name="conf-theme-elements">
+    <ref name="simple-text"/>
+  </define>
+  <!-- CONFERENCE THEME -->
+  <!--
+    The theme, slogan, or major subject area of
+    the conference.  For example, the name of an
+    annual conference may be "16th ACH Gathering"
+    but each year has different theme topic,
+    such as "Database Integration" or "Topic
+    Map Subject Access".
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=conf-theme
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=conf-theme
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=conf-theme
+  -->
+  <define name="conf-theme">
+    <element name="conf-theme">
+      <ref name="conf-theme-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="conf-theme-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="conf-theme-attlist" combine="interleave">
+    <ref name="conf-theme-atts"/>
+  </define>
+  <!-- STRING CONFERENCE NAME ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the extended text name of the conference
+    <string-conf>
+    Design Note: %simple-text; begins with an
+    OR bar.
+  -->
+  <define name="string-conf-elements">
+    <choice>
+      <ref name="simple-text"/>
+      <ref name="conference.class"/>
+    </choice>
+  </define>
+  <!-- STRING CONFERENCE NAME -->
+  <!--
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=string-conf
+  -->
+  <define name="string-conf">
+    <element name="string-conf">
+      <ref name="string-conf-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="string-conf-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="string-conf-attlist" combine="interleave">
+    <ref name="string-conf-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- COUNTING INFORMATION (ARTICLE METADATA) -->
+  <!-- ============================================================= -->
+  <!-- COUNTS MODEL -->
+  <!-- Content model for the <counts> element. -->
+  <define name="counts-model">
+    <zeroOrMore>
+      <ref name="count"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="fig-count"/>
+    </optional>
+    <optional>
+      <ref name="table-count"/>
+    </optional>
+    <optional>
+      <ref name="equation-count"/>
+    </optional>
+    <optional>
+      <ref name="ref-count"/>
+    </optional>
+    <optional>
+      <ref name="page-count"/>
+    </optional>
+    <optional>
+      <ref name="word-count"/>
+    </optional>
+  </define>
+  <!-- COUNTS -->
+  <!--
+    Wrapper element to hold all metadata that
+    "counts how many of something appear in the
+    article
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=counts
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=counts
+  -->
+  <define name="counts">
+    <element name="counts">
+      <ref name="counts-attlist"/>
+      <ref name="counts-model"/>
+    </element>
+  </define>
+  <define name="counts-attlist" combine="interleave">
+    <ref name="counts-atts"/>
+  </define>
+  <!-- COUNT -->
+  <!--
+    Generic <count> element to count anything a 
+    publisher or archive may wish to count in a 
+    document. The @count-type attribute will name 
+    what is being counted (such as figures, 
+    tables, sections, contributors, images,
+    etc.) The @count attribute will state how 
+    many of the objects are in the document. 
+    
+    Although a publisher or archive could choose 
+    to label all the counted objects in a document
+    using this element, the specific count 
+    elements (fig-count, equation-count,
+    word-count, etc.) will be retained for 
+    backwards compatibility, and may still be
+    used.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=count
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=count
+  -->
+  <define name="count">
+    <element name="count">
+      <ref name="count-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="count-attlist" combine="interleave">
+    <ref name="count-atts"/>
+  </define>
+  <!-- EQUATION COUNT -->
+  <!--
+    Number of display equations <disp-formula>
+    that appear in the article. Inline-equations
+    <inline-formula> are not counted. No
+    distinction is made between numbered and
+    unnumbered equations, both are counted.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=equation-count
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=equation-count
+  -->
+  <define name="equation-count">
+    <element name="equation-count">
+      <ref name="equation-count-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="equation-count-attlist" combine="interleave">
+    <ref name="equation-count-atts"/>
+  </define>
+  <!-- FIGURE COUNT -->
+  <!--
+    Number of Figures <fig> that appear in the
+    article. Loose <graphic>s that appear
+    outside figures are not counted.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=fig-count
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=fig-count
+  -->
+  <define name="fig-count">
+    <element name="fig-count">
+      <ref name="fig-count-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="fig-count-attlist" combine="interleave">
+    <ref name="fig-count-atts"/>
+  </define>
+  <!-- TABLE COUNT -->
+  <!--
+    Number of tables (Table Wrapper <table-wrap>
+    elements that appear in the article. Arrays
+    are not counted as tables.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=table-count
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=table-count
+  -->
+  <define name="table-count">
+    <element name="table-count">
+      <ref name="table-count-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="table-count-attlist" combine="interleave">
+    <ref name="table-count-atts"/>
+  </define>
+  <!-- REFERENCE COUNT -->
+  <!--
+    Number of reference citations (whether
+    <mixed-citation>s, <element-citation>s, or
+    <nlm-citation>s) that appear in the
+    bibliographic reference list <ref-list>
+    in the article
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=ref-count
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=ref-count
+  -->
+  <define name="ref-count">
+    <element name="ref-count">
+      <ref name="ref-count-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="ref-count-attlist" combine="interleave">
+    <ref name="ref-count-atts"/>
+  </define>
+  <!-- PAGE COUNT -->
+  <!--
+    Number of pages in a print article, counting
+    each page or partial page as one. Electronic
+    articles do not have page counts.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=page-count
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=page-count
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=page-count
+  -->
+  <define name="page-count">
+    <element name="page-count">
+      <ref name="page-count-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="page-count-attlist" combine="interleave">
+    <ref name="page-count-atts"/>
+  </define>
+  <!-- WORD COUNT -->
+  <!--
+    Approximate number of words that appear in
+    the textual portion of an
+    article (not including the words in the
+    metadata or header information)
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=word-count
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=word-count
+  -->
+  <define name="word-count">
+    <element name="word-count">
+      <ref name="word-count-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="word-count-attlist" combine="interleave">
+    <ref name="word-count-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- TITLE GROUP ELEMENTS (BIBLIOGRAPHIC) -->
+  <!-- ============================================================= -->
+  <!-- TITLE GROUP MODEL -->
+  <!--                     Content model for the <title-group> element -->
+  <define name="title-group-model">
+    <ref name="article-title"/>
+    <zeroOrMore>
+      <ref name="subtitle"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="trans-title-group"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="alt-title"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="fn-group"/>
+    </optional>
+  </define>
+  <!-- TITLE GROUP -->
+  <!--
+    Wrapper element to hold the various article
+    titles.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=title-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=title-group
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=title-group
+  -->
+  <define name="title-group">
+    <element name="title-group">
+      <ref name="title-group-attlist"/>
+      <ref name="title-group-model"/>
+    </element>
+  </define>
+  <define name="title-group-attlist" combine="interleave">
+    <ref name="title-group-atts"/>
+  </define>
+  <!--
+    ELEM   article-title
+    Defined in %common.ent;
+  -->
+  <!-- ELEM   trans-title  Defined in %common.ent; -->
+  <!-- SUBTITLE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a paragraph <subtitle>.
+    An earlier version of this tag set used the
+    parameter entity %title-elements; for many
+    title elements including <subtitle>.
+  -->
+  <define name="subtitle-elements">
+    <ref name="title-elements"/>
+  </define>
+  <!-- ARTICLE SUBTITLE -->
+  <!--
+    Secondary title of a journal article
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=subtitle
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=subtitle
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=subtitle
+  -->
+  <define name="subtitle">
+    <element name="subtitle">
+      <ref name="subtitle-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="subtitle-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="subtitle-attlist" combine="interleave">
+    <ref name="subtitle-atts"/>
+  </define>
+  <!-- ALTERNATE TITLE -->
+  <!--
+    A "different" version of an article title,
+    usually created so that it can be processed
+    in a special way, for example a short
+    version of the title for use in a Table of
+    Contents, an ASCII title, a right-running-
+    head title, etc.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=alt-title
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=alt-title
+  -->
+  <define name="alt-title">
+    <element name="alt-title">
+      <ref name="alt-title-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="alt-title-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="alt-title-attlist" combine="interleave">
+    <ref name="alt-title-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- AUTHOR COMMENTS -->
+  <!-- ============================================================= -->
+  <!-- AUTHOR COMMENT MODEL -->
+  <!--
+    Content model for the <author-comment>
+    element
+  -->
+  <define name="author-comment-model">
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <oneOrMore>
+      <ref name="just-para.class"/>
+    </oneOrMore>
+  </define>
+  <!-- AUTHOR COMMENT -->
+  <!--
+    Used for extra textual material associated
+    with a contributor such as an author or
+    editor
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=author-comment
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=author-comment
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=author-comment
+  -->
+  <define name="author-comment">
+    <element name="author-comment">
+      <ref name="author-comment-attlist"/>
+      <ref name="author-comment-model"/>
+    </element>
+  </define>
+  <define name="author-comment-attlist" combine="interleave">
+    <ref name="author-comment-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PUBLICATION HISTORY DATE ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- HISTORY MODEL -->
+  <!-- The content model for the <history> element -->
+  <!-- HISTORY:  DOCUMENT HISTORY -->
+  <!--
+    Used as a container for dates related to the
+    processing history of the document, such as
+    received date and accepted date.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=history
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=history
+  -->
+  <define name="history">
+    <element name="history">
+      <ref name="history-attlist"/>
+      <ref name="history-model"/>
+    </element>
+  </define>
+  <define name="history-attlist" combine="interleave">
+    <ref name="history-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PUBLICATION HISTORY EVENT ELEMENTS -->
+  <!-- More than a date (from BITS) -->
+  <!-- ============================================================= -->
+  <!-- EVENT DESCRIPTION ELEMENTS -->
+  <!--
+    Elements that may be used, along with data
+    characters inside the content model of the
+    <event-desc> element.
+  -->
+  <define name="event-desc-elements">
+    <choice>
+      <ref name="address-link.class"/>
+      <ref name="article-identifier.class"/>
+      <ref name="article-version.class"/>
+      <ref name="date.class"/>
+      <ref name="pub-date.class"/>
+      <ref name="pub-date-not-available"/>
+    </choice>
+  </define>
+  <!-- EVENT DESCRIPTION -->
+  <!--
+    This is a description of an event in the
+    publishing history of a book, for example,
+    reprinting or publication of the revised online
+    edition. This text field may be as
+    simple a few words or as complex as a
+    narrative with embedded markup.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=event-desc
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=event-desc
+  -->
+  <define name="event-desc">
+    <element name="event-desc">
+      <ref name="event-desc-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="event-desc-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="event-desc-attlist" combine="interleave">
+    <ref name="event-desc-atts"/>
+  </define>
+  <!-- EVENT MODEL -->
+  <!-- The content model for the <event> element. -->
+  <define name="event-model">
+    <optional>
+      <ref name="event-desc"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="article-id"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="article-version.class"/>
+    </optional>
+    <choice>
+      <zeroOrMore>
+        <ref name="pub-date.class"/>
+      </zeroOrMore>
+      <optional>
+        <ref name="pub-date-not-available"/>
+      </optional>
+    </choice>
+    <zeroOrMore>
+      <ref name="date.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="issn"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="issn-l"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="isbn"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="permissions"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="notes"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="self-uri"/>
+    </zeroOrMore>
+  </define>
+  <!-- EVENT IN PUBLISHING HISTORY -->
+  <!--
+    This is a description of an event in the
+    publishing history of a book, for example,
+    reprinting or publication of the revised online
+    edition. This text field may be as
+    simple a few words or as complex as a
+    narrative with embedded markup.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=event
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=event
+  -->
+  <define name="event">
+    <element name="event">
+      <ref name="event-attlist"/>
+      <ref name="event-model"/>
+    </element>
+  </define>
+  <define name="event-attlist" combine="interleave">
+    <ref name="event-atts"/>
+  </define>
+  <!-- PUBLICATION HISTORY MODEL -->
+  <!--
+    The content model for the <pub-history>
+    element.
+  -->
+  <define name="pub-history-model">
+    <oneOrMore>
+      <ref name="event.class"/>
+    </oneOrMore>
+  </define>
+  <!-- PUBLICATION HISTORY -->
+  <!--
+    Used as a container for events related to the
+    processing history of the document, such as
+    online publication date or reprint date.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=pub-history 
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=pub-history 
+  -->
+  <define name="pub-history">
+    <element name="pub-history">
+      <ref name="pub-history-attlist"/>
+      <ref name="pub-history-model"/>
+    </element>
+  </define>
+  <define name="pub-history-attlist" combine="interleave">
+    <ref name="pub-history-atts"/>
+  </define>
+</grammar>
+<!-- ================== End Article Metadata Elements  =========== -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-backmatter1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-backmatter1.ent.rng
@@ -1,0 +1,532 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Back Matter Elements -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) JATS DTD Suite Back Matter Elements v1.2 20190208//EN"
+       Delivered as file "JATS-backmatter1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Names elements that are not part of the main -->
+<!-- textual flow of a work, but are considered to be -->
+<!-- ancillary material. -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- December 2002 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- This module is part of the JATS DTD Suite. The -->
+<!-- Suite is a continuation of work done by NCBI, -->
+<!-- Mulberry Technologies, and Inera Inc. on the NLM -->
+<!--              Journal Archiving and Interchange DTD Suite, which -->
+<!-- was originally released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   16. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   15. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   14. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   13. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   12. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+       =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+   11. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   10. JATS became version "1.1d3" and "v1.1d3 20150301"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+     9. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    8. GLOBAL ATTRIBUTES - Added the new parameter entity 
+           %jats-common-atts;
+       to every element in this module. This PE adds (for now) the
+       @id attribute and the @xml:base to every element, whether 
+       metadata or narrative.
+       Since the @id in this parameter entity is optional, a second
+       parameter entity jats-common-atts-id-required was also added.
+       The two are kept in sync with the jats-base-atts parameter 
+       entity.
+  
+    7. ABSTRACTS AND KEYWORDS ON NEW STRUCTURES
+       - Added <abstract> (through %abstract.class;) and <kwd-group> 
+         (through %kwd-group.class;) to the following elements:
+          - app (through %sec-model;)
+          - app-group (through %app-group-model;)
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    6. Updated the DTD-version attribute to "1.0" and the formal
+       public identifier to the date: "v1.0 20120330//EN".
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    4. Updated the DTD-version attribute to "0.4" 
+  
+    3. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+             http://jats.nlm.nih.gov/0.4.
+  
+    2. @XML:LANG - Added @xml:lang to the following elements:
+        - app through app-atts
+        - app-group through app-group-atts
+        - fn-group through fn-group-atts
+        - glossary through glossary-atts
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- BACK MATTER ELEMENTS -->
+<!-- ============================================================= -->
+<!-- ELEM   bio          Defined in %common.ent; -->
+<!-- ELEM   ref-list     Defined in %references.ent; -->
+<!-- ELEM   sec          Defined in %section.ent; -->
+<!-- ELEM   ack          Defined in %common.ent; -->
+<!-- ============================================================= -->
+<!-- PARAMETER ENTITIES FOR ATTRIBUTE LISTS -->
+<!-- ============================================================= -->
+<!-- APPENDIX ATTRIBUTES -->
+<!-- Attributes for the Appendix <app> element -->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="app-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- APPENDIX GROUP ATTRIBUTES -->
+  <!--
+    Attributes for the Appendix Group <app-group>
+    element
+  -->
+  <define name="app-group-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- FOOTNOTE GROUP ATTRIBUTES -->
+  <!--
+    Attributes for the Footnote Group <fn-group>
+    element
+  -->
+  <define name="fn-group-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- GLOSSARY ATTRIBUTES -->
+  <!--
+    Attributes for the Glossary <glossary>
+    element
+  -->
+  <define name="glossary-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ============================================================= -->
+  <!-- APPENDIX ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- APPENDIX GROUP MODEL -->
+  <!-- Content model for the <app-group> element -->
+  <define name="app-group-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="abstract.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="kwd-group.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="para-level"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="app.class"/>
+        <ref name="ref-list.class"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <!-- APPENDIX GROUP -->
+  <!--
+    A container element to hold one or more
+    Appendices.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=app-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=app-group
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=app-group
+  -->
+  <define name="app-group">
+    <element name="app-group">
+      <ref name="app-group-attlist"/>
+      <ref name="app-group-model"/>
+    </element>
+  </define>
+  <define name="app-group-attlist" combine="interleave">
+    <ref name="app-group-atts"/>
+  </define>
+  <!-- APPENDIX MODEL -->
+  <!-- Content model for the <app> element. -->
+  <!-- APPENDIX -->
+  <!--
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=app
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=app
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=app
+  -->
+  <define name="app">
+    <element name="app">
+      <ref name="app-attlist"/>
+      <ref name="app-model"/>
+    </element>
+  </define>
+  <define name="app-attlist" combine="interleave">
+    <ref name="app-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- FOOTNOTE GROUPING ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- FOOTNOTE GROUP MODEL -->
+  <!-- Content model for the <fn-group> element -->
+  <!-- FOOTNOTE GROUP -->
+  <!--
+    Footnotes in a journal article may be
+    scattered throughout the text, at the places
+    they occur, or collected in groups at the
+    end of structural units.  This element is a
+    wrapper tag for such groups of footnotes.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=fn-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=fn-group
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=fn-group
+  -->
+  <define name="fn-group">
+    <element name="fn-group">
+      <ref name="fn-group-attlist"/>
+      <ref name="fn-group-model"/>
+    </element>
+  </define>
+  <define name="fn-group-attlist" combine="interleave">
+    <ref name="fn-group-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- GLOSSARY -->
+  <!-- ============================================================= -->
+  <!-- GLOSSARY MODEL -->
+  <!-- Content model for the <glossary> element -->
+  <define name="glossary-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="para-level"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="glossary"/>
+    </zeroOrMore>
+  </define>
+  <!-- GLOSSARY ELEMENTS -->
+  <!--
+    Glossary or list of definitions.  Typically
+    the content will be one or more <def-list>s.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=glossary
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=glossary
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=glossary
+  -->
+  <define name="glossary">
+    <element name="glossary">
+      <ref name="glossary-attlist"/>
+      <ref name="glossary-model"/>
+    </element>
+  </define>
+  <define name="glossary-attlist" combine="interleave">
+    <ref name="glossary-atts"/>
+  </define>
+</grammar>
+<!-- ================== End Back Matter Module =================== -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-chars1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-chars1.ent.rng
@@ -1,0 +1,662 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Custom Special Characters Module -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) JATS DTD Suite Custom Special Characters Module v1.2 20190208//EN"
+       Delivered as file "JATS-chars1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    XML special character entities -->
+<!---->
+<!-- CONTAINS:   1) Definitions of DTD-specific and custom -->
+<!-- special characters (as general entities -->
+<!-- defined as hexadecimal or decimal character -->
+<!-- entities - Unicode numbers) -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- December 2002 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- This module is part of the JATS DTD Suite. The -->
+<!-- Suite is a continuation of work done by NCBI, -->
+<!-- Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--              Journal Archiving and Interchange DTD Suite, which -->
+<!-- was originally released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   16. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   15. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   14. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   13. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   12. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+       =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+   11. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   10. JATS became version "1.1d3" and "v1.1 20150301//EN"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+     9. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    8. GLOBAL ATTRIBUTES - Added the new parameter entity 
+           %jats-common-atts;
+       to every element in this module. This PE adds (for now) the
+       @id attribute and the @xml:base attribute to every element,
+       whether metadata or narrative.
+       Since the @id in this parameter entity is optional, a second
+       parameter entity jats-common-atts-id-required was also added.
+       The two are kept in sync with the jats-base-atts parameter 
+       entity.
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    7. Updated the DTD-version attribute to "1.0" and the formal
+       public identifier to the date: "v1.0 20120330//EN".
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    6. Updated the DTD-version attribute to "0.4" 
+  
+    5. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+  
+    4. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+       @xml:lang to the following elements:
+         - private-char through private-char-atts (@specific-use)
+  
+    3. PEs FOR CONTENT MODELS - Added parameter entity redefinitions
+       for the model of the <private-char> element.
+  
+    2. PEs FOR ATTLISTS - Added parameter entity redefinitions for the
+       attribute lists of the following elements: (no attributes or
+       values were changed)
+         - glyph-ref         glyph-ref-atts
+         - glyph-data        glyph-data-atts
+         - private-char      private-char-atts
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- DESIGN COMMENT -->
+<!-- ============================================================= -->
+<!--
+  This DTD Suite has been designed with Unicode
+  as the basic representation of all special
+  characters. The use of combining characters
+  is supported and encouraged as is the use
+  of entities defined by the STIX project
+  (http://www.ams.org/STIX/). Unicode values
+  in planes other than Plane 0 may be freely
+  used.
+  
+  Use of private publisher entities and Unicode
+  Private Use Area is discouraged, but supported
+  with the <private-char> element, for which a
+  corresponding bitmap must be submitted.
+  
+  In cases where an entity name has been generally
+  accepted with a corresponding Unicode number
+  and the entity has not been added to
+  the ISO standard entity sets, a named entity
+  may be defined below (e.g. &euro;).
+  
+  Because of the potential for conflicts in
+  assignments by different publishers,
+  the JATS DTD Suite does not support assignment 
+  of values in the Unicode Private Use Area.
+  Publishers who have defined characters in the
+  Private Use Area must remap those characters
+  to existing Unicode values (using combining
+  characters for special accented characters
+  where appropriate), or must submit bitmaps of
+  those characters using one of the two methods
+  supported under the <private-char> element.
+  
+  Those custom publisher entities for which
+  corresponding Unicode values have not been
+  determined must be tagged with the
+  <private-char> element. Publishers must submit
+  bitmaps of those characters using one of the
+  two methods supported in the <private-char>
+  element.
+-->
+<!-- ============================================================= -->
+<!--
+  COMMONLY ACCEPTED ENTITIES FOR UNICODE
+  GLYPHS
+-->
+<!-- ============================================================= -->
+<!--
+  For each of the following entities a name
+  and a Unicode numerical character reference
+  is given. Where a unique Unicode character
+  could be determined, that character was used.
+  For some of the symbols combining characters
+  have been used. Do not use this space to
+  redefine characters already found in standard
+  ISO entity sets. Do not use this space to
+  define any character that cannot be
+  represented with Unicode.
+-->
+<!-- LATIN SMALL LETTER G WITH CARON -->
+<!-- LATIN CAPITAL LETTER H WITH MACRON -->
+<!-- EURO CURRENCY -->
+<!-- FRANC CURRENCY -->
+<!-- ============================================================= -->
+<!-- ATTRIBUTE LISTS FOR PRIVATE CHARACTERS -->
+<!-- ============================================================= -->
+<!-- GLYPH DATA ATTRIBUTES -->
+<!--
+  Attribute list for the <glyph-data>
+  element
+-->
+<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="glyph-data-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="fontchar"/>
+    </optional>
+    <optional>
+      <attribute name="fontname"/>
+    </optional>
+    <optional>
+      <attribute name="format">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="resolution"/>
+    </optional>
+    <optional>
+      <attribute name="xml:space" a:defaultValue="preserve">
+        <value>preserve</value>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="x-size"/>
+    </optional>
+    <optional>
+      <attribute name="y-size"/>
+    </optional>
+  </define>
+  <!-- GLYPH REFERENCE ATTRIBUTES -->
+  <!--
+    Attribute list for the <glyph-ref>
+    element
+  -->
+  <define name="glyph-ref-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="glyph-data">
+        <data type="IDREF"/>
+      </attribute>
+    </optional>
+  </define>
+  <!--
+    PRIVATE USE AREA AND CUSTOM CHARACTERS
+    ATTRIBUTES
+  -->
+  <!--
+    Attribute list for the <private-char>
+    element
+  -->
+  <define name="private-char-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="description"/>
+    </optional>
+    <optional>
+      <attribute name="name"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PRIVATE USE AREA AND CUSTOM CHARACTERS -->
+  <!-- ============================================================= -->
+  <!--
+    Special characters defined by publishers as
+    custom entities or in the Unicode Private Use
+    Area may not be deposited as is. If they
+    cannot be remapped to existing Unicode values,
+    they must be submitted as a bitmap using
+    the <private-char> element. The most
+    repository-friendly technique is <glyph-data>
+    although individual bitmap files may be
+    submitted with inline-graphic.
+    
+    We would like to thank Beacon Publishing and
+    the APS (American Physical Society) for
+    providing us with this technique.
+  -->
+  <!-- PRIVATE CHARACTER MODEL -->
+  <!--
+    The content model for the <private-char>
+    element
+  -->
+  <define name="private-char-model">
+    <choice>
+      <choice>
+        <ref name="glyph-data"/>
+        <ref name="glyph-ref"/>
+      </choice>
+      <zeroOrMore>
+        <ref name="inline-graphic"/>
+      </zeroOrMore>
+    </choice>
+  </define>
+  <!-- PRIVATE CHARACTER (CUSTOM OR UNICODE) -->
+  <!--
+    A custom character entity defined by a
+    publisher or a custom character from the
+    Unicode private-use area for which a bitmap
+    is submitted for the glyph.
+    
+    Since there are no completely standard/public
+    agreements on how such characters are to be
+    named and displayed, this technique is to be
+    used instead of a custom general entity
+    reference, to provide complete information
+    on the intended character.
+    A document should contain a <private-char>
+    element at each location where a private
+    character is used within the document. The
+    corresponding image for the glyph may be
+    given in the <glyph-data> element or as an
+    external bitmap file referenced by an
+    <inline-graphic> element.
+    
+    Implementation Note: <inline-graphic> should
+    only be used outside <private-char> when the
+    graphic is something other than a special
+    character.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=private-char
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=private-char
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=private-char
+  -->
+  <define name="private-char">
+    <element name="private-char">
+      <ref name="private-char-attlist"/>
+      <ref name="private-char-model"/>
+    </element>
+  </define>
+  <!--
+    description
+               A human-readable description of the
+               character, for example, "Arrow, normal
+               weight, single line, two-headed, Northwest
+               to Southeast".
+    name       Unique name for the character in all
+               uppercase ASCII, similar to names found
+               in Unicode standard (e.g., "NORTHWEST
+               SOUTHEAST ARROW"
+  -->
+  <define name="private-char-attlist" combine="interleave">
+    <ref name="private-char-atts"/>
+  </define>
+  <!-- GLYPH DATA FOR A PRIVATE CHARACTER -->
+  <!--
+    This element is used when there is known to
+    be no font available to render the private
+    character. The <glyph-data> element can be
+    used to provide information on the actual
+    glyph that is associated with the private-use
+    character. The element includes an inline
+    bitmap of the glyph encoded in plain
+    PBM (Plain Bit Map) format so that it is
+    human-readable.
+    
+    For example:
+    <private-char name="NORTHWEST SOUTHEAST ARROW"
+    description="Arrow, normal weight, single
+    line, two-headed, Northwest to Southeast">
+    <glyph-data format="PBM" resolution="300"
+    x-size="34" y-size="34">
+    0000000000000000000000000000000000
+    0111111111111100000000000000000000
+    0111111111111100000000000000000000
+    0111110000000000000000000000000000
+    0111110000000000000000000000000000
+    0111111000000000000000000000000000
+    0110111100000000000000000000000000
+    0110011110000000000000000000000000
+    0110001111000000000000000000000000
+    0110000111100000000000000000000000
+    0110000011110000000000000000000000
+    0110000001111000000000000000000000
+    0110000000111100000000000000000000
+    0110000000011110000000000000000000
+    0110000000001111000000000000000000
+    0110000000000111100000000000000000
+    0110000000000011110000000000000000
+    0000000000000001111000000000000000
+    0000000000000000111100000000000110
+    0000000000000000011110000000000110
+    0000000000000000001111000000000110
+    0000000000000000000111100000000110
+    0000000000000000000011110000000110
+    0000000000000000000001111000000110
+    0000000000000000000000111100000110
+    0000000000000000000000011110000110
+    0000000000000000000000001111000110
+    0000000000000000000000000111100110
+    0000000000000000000000000011110110
+    0000000000000000000000000001111110
+    0000000000000000000000000001111110
+    0000000000000000011111111111111110
+    0000000000000000011111111111111110
+    0000000000000000000000000000000000
+    </glyph-data></private-char>
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=glyph-data
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=glyph-data
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=glyph-data
+  -->
+  <define name="glyph-data">
+    <element name="glyph-data">
+      <ref name="glyph-data-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <!--
+    id         Identifier so that the full glyph data need
+               not be repeated every time the character is
+               used. The <glyph-ref> element can be used
+               to point to this ID, to reuse a character
+               in subsequent text.
+    fontchar   The offset of the character into a glyph
+               table, such as a Unicode character.
+    fontname   The name of the character
+    format     Names the image format of the bitmap. Should
+               be "PBM" if the plain bitmap is included
+               inline.
+    resolution Resolution of the bitmap in dots per inch,
+               expressed as a decimal integer (e.g. 72, 300)
+    xml:space  Preserve whitespace within this element.
+    x-size     Number of pixels per row in the bit-mapped
+               glyph
+    y-size     Number of rows of the bit-mapped glyph
+  -->
+  <define name="glyph-data-attlist" combine="interleave">
+    <ref name="glyph-data-atts"/>
+  </define>
+  <!-- GLYPH REFERENCE FOR A PRIVATE CHARACTER -->
+  <!--
+    Once a private character has been declared
+    using a <glyph-data> element, the character
+    can be reused by using this element to
+    point to the full <glyph-data> element.
+    The pointing uses the ID/IDREF mechanism,
+    using the "glyph-data" attribute of this
+    element to point to the "id" attribute of
+    another <glyph-data> element.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=glyph-ref
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=glyph-ref
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=glyph-ref
+  -->
+  <define name="glyph-ref">
+    <element name="glyph-ref">
+      <ref name="glyph-ref-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <!--
+    glyph-data An IDREF-type attribute that points to the
+    "id" attribute of a <glyph-data> character.
+    The idea is to use the full glyph data once,
+    then point to an existing character instead
+    of repeating the entire glyph data again.
+  -->
+  <define name="glyph-ref-attlist" combine="interleave">
+    <ref name="glyph-ref-atts"/>
+  </define>
+</grammar>
+<!-- ================== End Custom XML Special Characters ======== -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-common-atts1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-common-atts1.ent.rng
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Common Attributes (for all elements) -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) JATS DTD Suite Common Attributes (for all elements) v1.2 20190208//EN"
+       Delivered as file "JATS-common-atts1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Defines attributes intended to be used on ALL the -->
+<!-- elements defined in the NISO JATS, including the -->
+<!--              elements for the XHTML-inspired and OASIS-inspired -->
+<!-- table models, excluding only <mml:math> and -->
+<!-- <xi:include>, whose namespaces JATS does not -->
+<!-- control. -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- December 2002 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- This module is part of the JATS DTD Suite. The -->
+<!-- Suite is a continuation of work done by NCBI, -->
+<!-- Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--              Journal Archiving and Interchange DTD Suite, which -->
+<!-- was originally released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   10. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+    9. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+    8. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+    7. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+    6. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+       =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+    5. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    4. JATS became version "1.1d3" and "v1.1d3 20150301"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    3. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    2. XML Base
+       Added the attribute @xml:base to the Global (common)
+       attributes used on all elements.
+  
+       =============================================================
+-->
+<!-- ============================================================= -->
+<!-- NISO JATS COMMON ATTRIBUTES -->
+<!-- ============================================================= -->
+<!-- COMMON ATTRIBUTES -->
+<!--
+  These lists of attributes will be added to 
+  nearly every element, in both the document 
+  metadata and the document body, of the entire 
+  Tag Set:
+    - including table elements for both the 
+        XHTML-inspired and OASIS-inspired
+        table model elements
+    - excluding only <mml:math> and 
+        <xi:include> (whose namespaces JATS
+        does not control).
+     Great care should be taken to use these
+  attributes judiciously, not as a shortcut to
+  thinking through where an attribute should be
+  used. Potential use cases include adding
+  @xml:lang or some RDFa attribute to every 
+  elements.
+-->
+<!-- BASE ATTRIBUTES -->
+<!--
+  Holds all the common attributes except @id.
+  Used to keep the two common attribute lists 
+  in sync. To add a global attribute, modify
+  this list.
+-->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="jats-base-atts">
+    <optional>
+      <attribute name="xml:base"/>
+    </optional>
+  </define>
+  <!-- JATS COMMON ATTRIBUTES -->
+  <!--
+    Holds all the common attributes, as defined in
+    the base attribute parameter entity, plus an
+    optional @id.
+  -->
+  <define name="jats-common-atts">
+    <optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+    </optional>
+    <ref name="jats-base-atts"/>
+  </define>
+  <!-- JATS COMMON ATTRIBUTES (ID REQUIRED) -->
+  <!--
+    Holds all the common attributes, as defined in
+    the base attribute parameter entity, plus a 
+    required @id.
+  -->
+  <define name="jats-common-atts-id-required">
+    <attribute name="id">
+      <data type="ID"/>
+    </attribute>
+    <ref name="jats-base-atts"/>
+  </define>
+</grammar>
+<!-- ================== End JATS Common Attributes Module ======== -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-common1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-common1.ent.rng
@@ -1,0 +1,5741 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Common (Shared) Elements Module -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) JATS DTD Suite Common (Shared) Elements Module v1.2 20190208//EN"
+  Delivered as file "JATS-common1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Defines the common parameter entities, calls the -->
+<!-- shared modules (such as special characters and -->
+<!-- notations) and provides declarations for elements -->
+<!-- that do not properly fit into one class, since -->
+<!--              they can be used at more than one structural level -->
+<!---->
+<!-- MODULES REQUIRED: -->
+<!-- 1) Standard XML Special Characters Module -->
+<!-- (%xmlspecchars.ent;) -->
+<!-- 2) Custom XML Special Characters (%chars.ent;) -->
+<!-- 3) Notation Declarations    (%notat.ent;) -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- December 2002 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- This module is part of the JATS DTD Suite. The -->
+<!-- Suite is a continuation of work done by NCBI, -->
+<!-- Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--              Journal Archiving and Interchange DTD Suite, which -->
+<!-- was originally released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   61. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   60. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   59. PUB-ID-TYPE - @pub-id-type (for all tag sets EXCEPT 
+       Archiving) changed back to a fixed list from CDATA for some
+       elements, reversing the decision of Version 1.2d1. Although 
+       the value list is unchanged, best practice will be documented
+       as using @pub-id-type for type and @assigning-authority
+       for the responsible agency.
+          The following were changed back. Therefore, Archiving must 
+       override the following attribute lists to make @pub-id-type 
+       CDATA:
+           - <article-id> (now value list)
+           - <pub-id>     (now value list)
+       But no change to the following, which were CDATA in version 1.1
+           - <issue-id>
+           - <object-id>
+           - <volume-id>
+  
+   58. ASSIGNING AUTHORITY - Added @assigning-authority to the
+       following elements, so that the type-of-identifier 
+       could be recorded with @pub-id-type and the party-
+       responsible-for-the-identifier could be recorded
+       using @assigning-authority. Previously, these value 
+       types were conflated in @pub-id-type. However, for
+       backward compatibility, @pub-id-type was left as
+       the SAME restricted list, with both types intermingled. 
+           - <contrib-id>
+           - <institution-id>
+           - <issue-id>
+           - <journal-id>
+           - <object-id>
+           - <volume-id>
+           - Note: <ext-link> already took @assigning-authority
+  
+   57. DATA USAGE - Added new CDATA attribute @use-type to both
+       <mixed-citation> and <element-citation>. First use case is to
+       explain cited data usage ("analyzed", "generated", etc.)
+  
+   56. DEGREE OF CONTRIBUTION - Added new CDATA attribute 
+       @degree-contribution to <role> to hold the degree of 
+       contribution. This is an open list, but values are 
+       expected to be "Lead", "Equal", or "Supporting".
+       Numeric values will be discouraged.
+  
+   55. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   54. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   53. VOCABULARY/TAXONOMY ATTRIBUTES - Added 4 new attributes for
+       naming (and possibly linking to) a general or controlled
+       taxonomy, vocabulary, index, database or other source of
+       terms: @vocab, @vocab-identifier, @vocab-term, and
+       @vocab-term-identifier
+        - Added all 4 attributes to:
+          - to <role>, for adding CRediT or other specifically named
+            roles to contributors
+          - Added @vocab amd @vocab-identifier to <institution-id>
+  
+   52. JATS became version "1.2d1" and "v1.2d1 20170631"
+  
+      =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+   51. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   50. ALI (NISO Access and License Indicators)
+       - Added <ali:license_ref> to license-p.class, as 
+         alternatives inside <license>
+       - Use the new class: license.class to hold the new ALI
+         element <ali:free_to_read>, as an alternative to
+         <license> inside <permissions>.
+       - Created new parameter entity 'anyURI' to act as 
+         documentation concerning the content of any element whose
+         content is intended to be a URI.  
+  
+   49. JATS became version "1.1d3" and "v1.1d3 20150301"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+  
+   48. VOLUME ISSUE GROUPING
+     - Added new optional element <volume-issue-group> inside 
+       <article-meta), following all volume and issue elements,
+       to hold volume-issue pairs (or n-tuples) when a second
+       and subsequent <volume> has its own related issue
+       information.
+  
+   47. NEW ATTRIBUTE VALUES FOR @PUB-ID-TYPE
+       Added three new values to @pub-id-types:
+        - accession
+        - arc
+        - handle
+  
+   46. NEW ATTRIBUTE FOR EXT-LINK
+       Added the CDATA attribute @assigning-authority to <ext-link>
+       to the authority (such as CrossRef) responsible for the
+       link
+  
+   45. NEW ATTRIBUTE FOR CONTRIB-ID
+       Added the boolean attribute @authenticated to <contrib-id> to 
+       record whether the agency that assigned the <contrib-id>
+       says the identifier is authenticated. The default value
+       is "false"
+  
+   44. MORE LINKING POSSIBILITIES
+       Added the might-link-atts to:
+        - volume-id
+        - issue-id
+       so that these potentially external identifiers can link,
+       for example to a DOI.
+  
+   43. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+   42. NEW ADDRESS ELEMENTS
+        - Added 3 new elements: <city>, <state>, <postal-code>
+        - Therefore introduced new PEs: city-element, state-elements,
+          and postal-code-elements, all set initially to null strings.
+        - Therefore introduced new PEs: city-atts, state-atts,
+          and postal-code-atts.
+        - Added the elements (in the default classes module) to:
+            - address.class
+            - addrress-line.class
+          which adds then to: address, addr-line, aff, collab, 
+          conf-loc, corresp, publisher-loc
+  
+   41. CHANGES TO <collab>
+       Added @symbol attribute.
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+   40. CHANGES TO <on-behalf-of>
+       Added <institution>, <institution-wrap>, and <xref>
+  
+   39. NEW <contrib> ATTRIBUTE
+       Added @xml:lang as requested with <institution-id>
+  
+   38. NEW <era> ELEMENT
+       Added <era> through date-parts.class to:
+        - <string-date>
+  
+   37. NEW ELEMENT <era>
+       Added to the model of <date>, optional following year,
+       through date-model.
+  
+   36. XML Base
+       Added the attribute @xml:base to the Global (common)
+       attributes used on all elements.
+  
+   35. INSTITUTION WRAP ADDED
+       Added the elements <institution-wrap> to the following elements
+       through the institution-wrap.class:
+        - <copyright-holder>
+        - <on-behalf-of>
+        - <publisher-name>
+        - <std-organization>
+  
+   34. GLOBAL ATTRIBUTES - Added the new parameter entity 
+           %jats-common-atts;
+       to every element in this module. This PE adds (for now) the
+       @id attribute and the @xml:base attribute to every element,
+       whether metadata or narrative.
+       Since the @id in this parameter entity is optional, a second
+       parameter entity jats-common-atts-id-required was also added.
+       The two are kept in sync with the jats-base-atts parameter 
+       entity.
+       This added a new attribute list to:
+        - aff-alternatives
+        - alternatives
+        - citation-alternatives
+        - collab-alternatives
+        - custom-meta-group
+        - institution-wrap
+        - meta-name
+        - meta-value
+        - name-alternatives
+        - permissions                          
+  
+   33. INSTITUTIONAL IDENTIFIERS
+       - Added <institution-id> to hold institutional identifiers
+         whether publisher specific ("AIP") or from an established 
+         authorities ("Ringgold" and "ISNI").
+  
+       - Added <institution-wrap> to hold both the name of an
+         institution <institution> and all of its institutional 
+         identifiers <institution-id>. This element will be allowed
+         everywhere institution is allowed.
+  
+  
+   32. ABSTRACTS AND KEYWORDS ON NEW STRUCTURES
+       - Added <abstract> (through %abstract.class;) and <kwd-group> 
+         (through %kwd-group.class;) to the following elements:
+          - sec-meta (through %sec-meta-model;)
+  
+   31. ATTRIBUTE ALIGNMENT
+       - Added @publication-format and @content-type to <issn>
+         through %issn-atts The idea is to make the attributes
+         for <issn> and <isbn> as similar as possible.
+  
+       - Added @publication-format to <isbn> through %isbn-atts 
+  
+       The idea is to make the attributes for <issn> and <isbn> as 
+       similar as possible. <issn> retains @pub-type for historical
+       reasons. <issn-l> attributes do not change.
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+   30. CONTRIB-GROUP AND CONTRIB MODULE SHIFT - Moved <contrib>
+       and <contrib-group> to common.ent from the module
+       articlemeta.ent, since they are now used
+       in both article metadata and journal metadata.
+  
+   29. CONTRIB ID - Added new element <contrib-id> using new PE 
+       contrib-id.class, contrib-id-atts, contrib-id-model.
+       Element holds one identifier, such as an ORCID, for a
+       person such as a contributor or principal investigator.
+  
+   28. COLLABORATION ALTERNATIVES - Added new element 
+       <collab-alternatives> using new PE %collab-alternatives-model;.
+       Element holds different versions (for example, different
+       language renderings) of a single collaboration.   
+  
+   27. DATE ATTRIBUTES - Added date attributes
+        - to <conf-date> through %conf-date-atts
+        - to <date> through %date-atts
+        - to <string-date> through %string-date-atts
+        - to <year> through %year-atts
+  
+         a) @iso-8601-date - ISO 8601 standard date format
+            of the publication date. Format  YYYY-MM-DDThh:mm:ss 
+  
+         b) @calendar - Name of the calendar used (@calendar) in
+            naming this publication date (such as "Gregorian", 
+            "Japanese" (Emperor years), or "Islamic").
+  
+         c) Added @publication-format, so that both publication
+            dates and history dates can separate the for amt of the
+            publication from the version/lifecycle event. Thus
+            both an "article" and a "manuscript" might be received.
+  
+   27. PUBLICATION IDENTIFIER @pub-id-type
+        - Added "std-designation" as value in predefined  list 
+          for '@pub-id-type' (% pub-id-types).
+        - Added new value "arxiv" as value in predefined  list 
+          for '@pub-id-type' (% pub-id-types).
+       "pub-id-types" are used within citations for 
+       <object-id> and <pub-id>; 
+       used within the article metadata for <article-id>, 
+       <issue-id>, and <volume-id>; 
+       used within many body elements for <object-id>.
+  
+   26. LONG DESCRIPTION - Added the might-link attributes to
+       <long-desc> because of an argument over what <long-desc>
+       should be. The semantic web folks want it to be a URI, the
+       librarians and accessibility (for pronouncing readers) want
+       to find a real description there, not a link. So JATS needs
+       to handle both.
+  
+   25. ISSN Linking - Added new element <issn-l> with the usual
+       %issn-l-elements; and %issn-l-atts;.
+  
+   24. MODULE MOVEMENT (from increased reference content)
+  
+       a) Element <degrees> - Moved <degrees> and its parameter
+          entities into this module from JATS-articlemeta.ent.
+  
+       b) Element <supplement> - Moved <supplement> and its parameter
+          entities into this module from JATS-articlemeta.ent.
+  
+       c) Element <conf-sponsor> - Moved <conf-sponsor> and its parameter
+          entities into this module from JATS-articlemeta.ent.
+  
+       d) Element <on-behalf-of> - Moved <on-behalf-of> and its parameter
+          entities into this module from JATS-articlemeta.ent.
+  
+   23. Element <license-p> - Added @content-type, which can hold
+       values such as "open-access", "CCC-statement",
+       "non-commercial-use".
+  
+   22. Updated the DTD-version attribute to "1.0" and the formal
+       public identifier to the date: "v1.0 20120330//EN".
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+   21. Updated the DTD-version attribute to "0.4" 
+  
+   18. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+             http://jats.nlm.nih.gov/0.4.
+  
+   17. MIXED CITATION ATTS PE - Was defined twice, identically,
+       deleted one of them.
+  
+   16. ACCESSIBILITY - Added @alt to <label> through %label-atts;
+  
+   15. ALTERNATIVES ATTRIBUTES- Created a new parameter entity for
+       attributes for <alternatives>; currently null
+  
+   14. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+       @xml:lang to the following elements:
+         - anonymous through anonymous-atts (both) NEW PE
+         - conf-acronym through conf-acronym-atts (both)
+         - conf-date through conf-date-atts (both)
+         - conf-loc through conf-loc-atts (both)
+         - conf-name through conf-name-atts (both)
+         - conf-num through conf-num-atts (both)
+         - conf-sponsor through conf-sponsor-atts (both)
+         - conf-theme through conf-theme-atts (both)
+         - day through day-atts (@specific-use)
+         - degrees through degrees-atts (both)
+         - element-citation through citation-atts (both)
+         - etal through etal-atts (both) NEW PE
+         - ext-link through ext-link-atts (@xml:lang; @specific-use
+             already)
+         - institution through institution-atts (both)
+         - issue-part through issue-part (both + content-type) NEW PE
+         - isbn through isbn-atts (both) NEW PE
+         - label through label-atts (both) NEW PE
+         - mixed-citation through citation-atts (both)
+         - name through name-atts (@xml:lang; @specific-use already)
+         - notes through notes-atts (both)
+         - prefix through prefix-atts (both)
+         - publisher-loc through publisher-loc-atts (both)
+         - publisher-name through publisher-name-atts (both)
+         - string-name through string-name-atts (both and
+              content-type and name-style) NEW PE
+         - suffix through suffix-atts (both)
+         - textual-form through textual-form-atts (both)
+         - trans-subtitle through trans-subtitle-atts
+            (@xml:lang only) NEW PE
+         - x through x-atts (both)
+  
+   13. AFFILIATION ALTERNATIVES - Created new the element
+       <aff-alternatives> to hold multiple <aff>s that are
+       representations of a single affiliation, for example, the
+       name of an institution in two languages or two scripts.
+       New PE; New attribute PE (currently null)
+  
+   12. RELATED-ARTICLE-ATTS - Removed the dependency that tied
+       %related-article-atts to journal-id-atts and added all
+       the journal-id attributes to related-article-atts explicitly.
+  
+   11. TITLE ELEMENTS - Removed the dependency which had both
+       <subtitle> and <alt-title> modeled with the same parameter
+       entity %title-elements;. Created new PEs for each element
+       but set them (as the default) to %title-elements so that no
+       customization would break. Models changed:
+         - alt-title      %alt-title-elements;
+         - subtitle       %subtitle-elements; (defined in
+                                  article-meta3.ent;)
+         - trans-title    %trans-title-elements;
+         - trans-subtitle %trans-subtitle-elements;
+  
+   10. TEXTUAL FORM MODEL - Changed the textual-form-elements
+       parameter entity to begin with an OR bar, since it names
+       elements to be mixed with #PCDATA.
+       *****Customization Alert: New parameter entity could break some
+       customizations. Check your %textual-form-elements parameter
+       entity. *****
+  
+    9. PUBLISHER - Allowed <publisher-name> and <publisher-loc> to
+       repeat (as an unnamed-parenthetical) inside <publisher>.
+       This will allow co-publishers and publisher names and locations
+       in more than one language. Added to facilitate multiple
+       languages. Also added @specific-use and @xml:lang to
+       both publisher-name and publisher-loc.
+  
+    8. ATTLIST PARAMETER ENTITIES - Changed the attribute lists
+       from using the same parameter entity (%day-atts;) to using:
+         - day    %day-atts;   (no change)
+         - month  %month-atts;
+         - season %season-atts;
+  
+    7. ISBN - Added "isbn" as value in predefined list for
+      '@pub-id-type' (% pub-id-types)
+  
+    6. TEXTUAL FORM - Added the following attributes: (new)
+         - @specific-use
+         - @xml:lang
+  
+    5. NAME ALTERNATIVES - Created a new wrapper element for more
+       than one version of a personal name, for example, the name in
+       Japanese kana characters and a transliterated form of the name
+       in Latin alphabet, or a regular name and a search version
+       that transliterates umlauts to unaccented characters.
+        - new element <name-alternatives>
+        - new PE name-alternatives-model
+        - new PE name-alternatives-atts (currently null)
+  
+    4. STRING NAME - Added the following attributes: (new)
+         - @content-type
+         - @specific-use
+         - @name-style
+         - @xml:lang
+  
+    3. PERSON'S NAME STYLE
+         - Added the value "given-only" to the @name-style on <name>
+  
+    2. PERSON'S NAME - Allowed <given-names> as an alternative
+       to <surname, given-names?) to accommodate the Indian
+       names that are only a given name.
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- PARAMETER ENTITIES FOR ATTRIBUTE VALUES -->
+<!-- ============================================================= -->
+<!-- ARTICLE/PUBLICATION IDENTIFIER TYPES -->
+<!--
+  Values for the @pub-id attribute. Used:
+  1) Within citations with the <pub-id> and 
+  <object-id> elements to name the type of
+  identifier (such as DOI) or the organization 
+  or system that defined the identifier for the 
+  identifier of the journal article or a cited 
+  publication, such as a book or standard.
+  2) Within article metadata with the
+  <article-id>, <issue-id>, and <volume-id>
+  elements to name the type of identifier or 
+  identifying agency.
+  4) Within many body elements to perform a 
+  similar function for the <object-id> element.
+-->
+<grammar xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="pub-id-types">
+    <choice>
+      <value>accession</value>
+      <value>archive</value>
+      <value>ark</value>
+      <value>art-access-id</value>
+      <value>arxiv</value>
+      <value>coden</value>
+      <value>doaj</value>
+      <value>doi</value>
+      <value>handle</value>
+      <value>index</value>
+      <value>isbn</value>
+      <value>manuscript</value>
+      <value>medline</value>
+      <value>mr</value>
+      <value>other</value>
+      <value>pii</value>
+      <value>pmcid</value>
+      <value>pmid</value>
+      <value>publisher-id</value>
+      <value>sici</value>
+      <value>std-designation</value>
+      <value>zbl</value>
+    </choice>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PARAMETER ENTITIES FOR CONTENT MODELS -->
+  <!-- ============================================================= -->
+  <!-- ANY URI SCHEMA TYPE (as documentation) -->
+  <!--
+    Indicates that in an XSD or RNG Schema, this
+    element would be typed as the simple type
+    'anyURI". This has no enforcement power in a 
+    DTD, it is intended for human guidance.
+    but is only for human guidance in a DTD
+  -->
+  <define name="anyURI">
+    <text/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PARAMETER ENTITIES FOR ATTRIBUTE VALUES -->
+  <!-- ============================================================= -->
+  <!-- ARTICLE/PUBLICATION IDENTIFIER TYPES -->
+  <!--
+    Values for the @pub-id attribute. Used:
+    1) Within citations with the <pub-id> and 
+    <object-id> elements to name the type of
+    identifier (such as DOI) or the organization 
+    or system that defined the identifier for the 
+    identifier of the journal article or a cited 
+    publication, such as a book or standard.
+    2) Within article metadata with the
+    <article-id>, <issue-id>, and <volume-id>
+    elements to name the type of identifier or 
+    identifying agency.
+    4) Within many body elements to perform a 
+    similar function for the <object-id> element.
+  -->
+  <!-- ============================================================= -->
+  <!-- PARAMETER ENTITIES FOR FULL CONTENT MODELS -->
+  <!-- ============================================================= -->
+  <!-- DATE ELEMENTS MODEL -->
+  <!--
+    The content models for elements that describe
+    dates, such as Publication Date <pub-date>
+    and History Dates <date>.
+  -->
+  <define name="date-model">
+    <optional>
+      <choice>
+        <group>
+          <optional>
+            <ref name="day"/>
+          </optional>
+          <optional>
+            <ref name="month"/>
+          </optional>
+        </group>
+        <ref name="season"/>
+      </choice>
+    </optional>
+    <optional>
+      <ref name="year"/>
+    </optional>
+    <optional>
+      <ref name="era"/>
+    </optional>
+    <optional>
+      <ref name="string-date"/>
+    </optional>
+  </define>
+  <!-- CONTENT MODEL FOR A STRUCTURAL SECTION -->
+  <!--
+    The model for a section that requires that a
+    section title be present, used for elements
+    such as Section and Appendix.
+  -->
+  <!-- CONTENT MODEL FOR A SECTION METADATA -->
+  <!--
+    In some works, each section has a different
+    author or some sections are authored by
+    different contributors from the enclosing
+    article. This wrapper element for
+    section-level metadata is used to capture
+    information such as those contributors.
+  -->
+  <define name="sec-meta-model">
+    <zeroOrMore>
+      <ref name="contrib-group.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="abstract.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="kwd-group.class"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="permissions"/>
+    </optional>
+  </define>
+  <!-- CONTENT MODEL FOR AN UNTITLED SECTION -->
+  <!--
+    The model for a section-like structure that
+    may or may not have an initial title
+  -->
+  <!-- ============================================================= -->
+  <!-- PARAMETER ENTITIES FOR MIXED CONTENT -->
+  <!-- ============================================================= -->
+  <!-- LINK ELEMENTS -->
+  <!--
+    Elements for use in the linking elements
+    such as <xref>, <target>, and <ext-link>
+  -->
+  <!-- PARAGRAPH ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a paragraph <p>.
+    Design Note: There is a major overlap between
+    this parameter entity and the mix for elements
+    that are at the same level as a paragraph.
+    Inline elements appear only inside a
+    paragraph, but block elements such as quotes
+    and lists may appear either within a
+    paragraph or at the same level as a
+    paragraph. This serves a requirement in a
+    repository DTD, since some incoming material
+    will have restricted such elements to only
+    inside a paragraph, some incoming material
+    will have restricted them to only outside a
+    paragraph and some may allow them in both
+    places. Thus the DTD must allow for them to
+    be in either or both.
+    Design Note: Inline mixes begin with an
+    OR bar
+  -->
+  <!-- ============================================================= -->
+  <!-- PARAMETER ENTITIES FOR TITLES -->
+  <!-- ============================================================= -->
+  <!-- TITLE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a paragraph <title>.
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-phrase; is an
+    inline mix, the OR bar is already there.
+  -->
+  <!-- ALTERNATE TITLE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a paragraph <alt-title>.
+    An earlier version of this tag set used the
+    parameter entity %title-elements; for many
+    title elements including <alt-title>.
+  -->
+  <define name="alt-title-elements">
+    <ref name="title-elements"/>
+  </define>
+  <!-- TRANSLATED TITLE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a paragraph <trans-title>.
+    An earlier version of this tag set used the
+    parameter entity %title-elements; for many
+    title elements including <trans-title>.
+  -->
+  <define name="trans-title-elements">
+    <ref name="title-elements"/>
+  </define>
+  <!-- TRANSLATED SUBTITLE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a paragraph <subtitle>.
+    An earlier version of this tag set used the
+    parameter entity %title-elements; for many
+    title elements including <trans-subtitle>.
+  -->
+  <define name="trans-subtitle-elements">
+    <ref name="title-elements"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PARAMETER ENTITIES FOR LINKING ATTRIBUTES -->
+  <!-- THE FOLLOWING FEW ARE SHARED ATTRIBUTES -->
+  <!-- ============================================================= -->
+  <!-- COMMON ATTRIBUTES -->
+  <!--
+    These lists of attributes will be added to 
+    nearly every element, in both the document 
+    metadata and the document body, of the entire 
+    Tag Set:
+      - including table elements for both the 
+          XHTML-inspired and OASIS-inspired
+          table model elements
+      - excluding only <mml:math> and 
+          <xi:include> (whose namespaces JATS
+          does not control).
+       Great care should be taken to use these
+    attributes judiciously, not as a shortcut to
+    thinking through where an attribute should be
+    used. Potential use cases include adding
+    @xml:lang or some RDFa attribute to every 
+    elements.
+  -->
+  <!-- BASE ATTRIBUTES -->
+  <!--
+    Holds all the common attributes except @id.
+    Used to keep the two common attribute lists 
+    in sync. To add a global attribute, modify
+    this list.
+  -->
+  <!-- JATS COMMON ATTRIBUTES -->
+  <!--
+    Holds all the common attributes, as defined in
+    the base attribute parameter entity, plus an
+    optional @id.
+  -->
+  <!-- JATS COMMON ATTRIBUTES (ID REQUIRED) -->
+  <!--
+    Holds all the common attributes, as defined in
+    the base attribute parameter entity, plus a 
+    required @id.
+  -->
+  <!-- XLINK LINK ATTRIBUTES -->
+  <!--
+    Used for elements that are a link by
+    definition, such as the <xref> element.
+  -->
+  <define name="link-atts">
+    <optional>
+      <attribute name="xlink:type">
+        <choice>
+          <value>simple</value>
+        </choice>
+      </attribute>
+    </optional>
+    <attribute name="xlink:href"/>
+    <optional>
+      <attribute name="xlink:role"/>
+    </optional>
+    <optional>
+      <attribute name="xlink:title"/>
+    </optional>
+    <optional>
+      <attribute name="xlink:show">
+        <choice>
+          <value>embed</value>
+          <value>new</value>
+          <value>none</value>
+          <value>other</value>
+          <value>replace</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xlink:actuate">
+        <choice>
+          <value>none</value>
+          <value>onLoad</value>
+          <value>onRequest</value>
+          <value>other</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!-- MIGHT LINK XLINK ATTRIBUTES -->
+  <!--
+    Used for elements which may need to link to
+    external sources or other objects within
+    the document, but may not necessarily act
+    as a link at all.  The attribute
+    "xlink:href" identifies the object to which
+    the link points.
+  -->
+  <!-- CITATION ATTRIBUTES -->
+  <!--
+    Attributes for all two kinds of citations:
+    <element-citation> and <mixed-citation>
+  -->
+  <define name="citation-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="publication-type"/>
+    </optional>
+    <optional>
+      <attribute name="publisher-type"/>
+    </optional>
+    <optional>
+      <attribute name="publication-format"/>
+    </optional>
+    <optional>
+      <attribute name="use-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PARAMETER ENTITIES FOR ATTRIBUTES LISTS -->
+  <!-- (ALPHABETICAL ORDER) -->
+  <!-- ============================================================= -->
+  <!-- AFFILIATION ATTRIBUTES -->
+  <!-- Attributes for the <ack> element -->
+  <define name="ack-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ADDRESS ATTRIBUTES -->
+  <!-- Attributes for the <address> element -->
+  <define name="address-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ADDRESS LINE ATTRIBUTES -->
+  <!-- Attributes for the <addr-line> element -->
+  <define name="addr-line-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- AFFILIATION ATTRIBUTES -->
+  <!--
+    Attributes for the Affiliation <aff>
+    element
+  -->
+  <define name="aff-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="rid">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- AFFILIATION ALTERNATIVES ATTRIBUTES -->
+  <!--
+    Attributes for the <aff-alternatives>
+    element
+  -->
+  <define name="aff-alternatives-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- ALTERNATE TEXT ATTRIBUTES -->
+  <!-- Attributes for the <alt-text> element -->
+  <define name="alt-text-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ANONYMOUS ATTRIBUTES -->
+  <!-- Attributes for the <anonymous> element -->
+  <define name="anonymous-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ALTERNATIVES ATTRIBUTES -->
+  <!-- Attributes for the <alternatives> element -->
+  <define name="alternatives-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- ARTICLE TITLE ATTRIBUTES -->
+  <!-- Attributes for the <article-title> element -->
+  <define name="article-title-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ATTRIBUTION ATTRIBUTES -->
+  <!-- Attributes for the <attrib> element -->
+  <define name="attrib-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- BIOGRAPHY ATTRIBUTES -->
+  <!-- Attributes for <bio> element -->
+  <define name="bio-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="rid">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- CITATION ALTERNATIVES ATTRIBUTES -->
+  <!--
+    Attributes for the <citation-alternatives>
+    element
+  -->
+  <define name="citation-alternatives-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- CITY ATTRIBUTES -->
+  <!-- Attributes for the <city> element -->
+  <define name="city-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- COLLABORATION ATTRIBUTES -->
+  <!-- Attributes for <collab> -->
+  <define name="collab-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="collab-type"/>
+    </optional>
+    <optional>
+      <attribute name="symbol"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- COLLABORATION ALTERNATIVES ATTRIBUTES -->
+  <!--
+    Attributes for the <collab-alternatives>
+    element
+  -->
+  <define name="collab-alternatives-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- CONFERENCE DATE ATTRIBUTES -->
+  <!-- Attributes for the <conf-date> element -->
+  <define name="conf-date-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="iso-8601-date"/>
+    </optional>
+    <optional>
+      <attribute name="calendar"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- CONFERENCE LOCATION ATTRIBUTES -->
+  <!-- Attributes for the <conf-loc> element -->
+  <define name="conf-loc-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- CONFERENCE NAME ATTRIBUTES -->
+  <!-- Attributes for the <conf-name> element. -->
+  <define name="conf-name-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- CONFERENCE SPONSOR ATTRIBUTES -->
+  <!-- Attributes for the <conf-sponsor> element. -->
+  <define name="conf-sponsor-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- CONTRIBUTOR ATTRIBUTES -->
+  <!-- Attributes for the <contrib> element -->
+  <define name="contrib-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="contrib-type"/>
+    </optional>
+    <optional>
+      <attribute name="corresp">
+        <choice>
+          <value>no</value>
+          <value>yes</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="equal-contrib">
+        <choice>
+          <value>no</value>
+          <value>yes</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="deceased">
+        <choice>
+          <value>no</value>
+          <value>yes</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rid">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- CONTRIBUTOR GROUP ATTRIBUTES -->
+  <!-- Attributes for the <contrib-group> element -->
+  <define name="contrib-group-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- CONTRIBUTOR IDENTIFIER ATTRIBUTES -->
+  <!--
+    Attributes for the <contrib-id> 
+    element.
+  -->
+  <define name="contrib-id-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="contrib-id-type"/>
+    </optional>
+    <optional>
+      <attribute name="assigning-authority"/>
+    </optional>
+    <optional>
+      <attribute name="authenticated" a:defaultValue="false">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- COPYRIGHT HOLDER ATTRIBUTES -->
+  <!--
+    Attributes for the <copyright-holder>
+    element.
+  -->
+  <define name="copyright-holder-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- COPYRIGHT STATEMENT ATTRIBUTES -->
+  <!--
+    Attributes for the <copyright-statement>
+    element.
+  -->
+  <define name="copyright-statement-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- COPYRIGHT YEAR ATTRIBUTES -->
+  <!--
+    Attributes for the <copyright-year>
+    element
+  -->
+  <define name="copyright-year-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- COUNTRY ATTRIBUTES -->
+  <!-- Attributes for the <country> element -->
+  <define name="country-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="country"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- CUSTOM METADATA ATTRIBUTES -->
+  <!-- Attributes for the <custom-meta> element -->
+  <define name="custom-meta-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- CUSTOM METADATA GROUP ATTRIBUTES -->
+  <!--
+    Attributes for the <custom-meta-group>
+    element
+  -->
+  <define name="custom-meta-group-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- DATE (HISTORICAL) ATTRIBUTES -->
+  <!-- Attributes for the <date> element -->
+  <!-- DAY ATTRIBUTES -->
+  <!-- Attributes for the <day> element -->
+  <define name="day-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- DEFINITION LIST: DEFINITION ATTRIBUTES -->
+  <!-- Attribute list for the <def> element -->
+  <define name="def-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="rid">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- DEGREES ATTRIBUTES -->
+  <!-- Attributes for the <degrees> element -->
+  <define name="degrees-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ELEMENT CITATION ATTRIBUTES -->
+  <!-- Attributes for <element-citation> -->
+  <define name="element-citation-atts">
+    <ref name="citation-atts"/>
+  </define>
+  <!--
+    ELECTRONIC LOCATION IDENTIFIER ATTRIBUTES
+    Attribute list for the <elocation-id>
+    element
+  -->
+  <define name="elocation-id-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="seq"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- EMAIL ATTRIBUTES -->
+  <!-- Attribute list for the <email> element -->
+  <define name="email-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- ERA ATTRIBUTES -->
+  <!-- Attributes for the <era> element -->
+  <define name="era-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ET AL. ATTRIBUTES -->
+  <!-- Attribute list for the <etal> element -->
+  <define name="etal-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- EXTERNAL LINK ATTRIBUTES -->
+  <!--
+    Attribute list for external links, such as
+    <ext-link>
+  -->
+  <define name="ext-link-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="ext-link-type"/>
+    </optional>
+    <optional>
+      <attribute name="assigning-authority"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- FAX ATTRIBUTES -->
+  <!-- Attribute list for the <fax> element -->
+  <define name="fax-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- FIRST PAGE ATTRIBUTES -->
+  <!-- Attribute list for the <fpage> element -->
+  <define name="fpage-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="seq"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- FREE TO READ ATTRIBUTES -->
+  <!--
+    Attributes for the ALI namespaced
+    <ali:free_to_read> element
+  -->
+  <define name="free-to-read-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="end_date"/>
+    </optional>
+    <optional>
+      <attribute name="start_date"/>
+    </optional>
+    <ref name="ali.xmlns.attrib"/>
+  </define>
+  <!-- GIVEN NAMES ATTRIBUTES -->
+  <!-- Attribute list for the <given-names> element -->
+  <define name="given-names-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="initials"/>
+    </optional>
+  </define>
+  <!-- INSTITUTION ATTRIBUTES -->
+  <!-- Attribute list for <institution> -->
+  <define name="institution-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- INSTITUTION IDENTIFIER ATTRIBUTES -->
+  <!-- Attribute list for <institution-id> -->
+  <define name="institution-id-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="institution-id-type"/>
+    </optional>
+    <optional>
+      <attribute name="assigning-authority"/>
+    </optional>
+    <optional>
+      <attribute name="vocab"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- INSTITUTION WRAPPER ATTRIBUTES -->
+  <!--
+    Attributes for the <institution-wrap>
+    element
+  -->
+  <define name="institution-wrap-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- ISBN ATTRIBUTES -->
+  <!-- Attributes for the <isbn> element -->
+  <define name="isbn-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="publication-format"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- ISSN ATTRIBUTES -->
+  <!-- Attribute list for the <issn> element -->
+  <define name="issn-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="pub-type"/>
+    </optional>
+    <optional>
+      <attribute name="publication-format"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- ISSN-L (INKING ISSN) ATTRIBUTES -->
+  <!-- Attribute list for the <issn-l> element -->
+  <define name="issn-l-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- ISSUE ATTRIBUTES -->
+  <!-- Attribute list for the <issue> element -->
+  <define name="issue-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="seq"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ISSUE IDENTIFIER ATTRIBUTES -->
+  <!-- Attributes for the <issue-id> element -->
+  <define name="issue-id-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="pub-id-type"/>
+    </optional>
+    <optional>
+      <attribute name="assigning-authority"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- ISSUE PART ATTRIBUTES -->
+  <!-- Attribute list for <issue-part> element -->
+  <define name="issue-part-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ISSUE SPONSOR ATTRIBUTES -->
+  <!-- Attribute list for <issue-sponsor> element -->
+  <define name="issue-sponsor-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ISSUE TITLE ATTRIBUTES -->
+  <!-- Attribute list for <issue-title> element -->
+  <define name="issue-title-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- JOURNAL IDENTIFIER ATTRIBUTES -->
+  <!--
+    Attribute list for journal identifier
+    <journal-id> element
+  -->
+  <define name="journal-id-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="journal-id-type"/>
+    </optional>
+    <optional>
+      <attribute name="assigning-authority"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- LABEL ATTRIBUTES -->
+  <!-- Attributes for the <label> element -->
+  <define name="label-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="alt"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- LICENSE ATTRIBUTES -->
+  <!-- Attributes for the <license> element -->
+  <define name="license-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="license-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- LICENSE PARAGRAPH ATTRIBUTES -->
+  <!-- Attributes for the <license> element -->
+  <define name="license-p-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- LICENSE REFERENCE ATTRIBUTES -->
+  <!--
+    Attributes for the ALI namespaced
+    <ali:license_ref> element
+  -->
+  <define name="license-ref-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="start_date"/>
+    </optional>
+    <ref name="ali.xmlns.attrib"/>
+  </define>
+  <!-- LONG DESCRIPTION ATTRIBUTES -->
+  <!-- Attributes for the <long-desc> element -->
+  <define name="long-desc-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- LPAGE ATTRIBUTES -->
+  <!-- Attributes for the <lpage> element -->
+  <define name="lpage-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- METADATA NAME (CUSTOM) ATTRIBUTES -->
+  <!-- Attributes for <meta-name> element -->
+  <define name="meta-name-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- METADATA VALUE (CUSTOM) ATTRIBUTES -->
+  <!-- Attributes for <meta-value> element -->
+  <define name="meta-value-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- MIXED CITATION ATTRIBUTES -->
+  <!-- Attributes for <mixed-citation> element -->
+  <define name="mixed-citation-atts">
+    <ref name="citation-atts"/>
+  </define>
+  <!-- MONTH ATTRIBUTES -->
+  <!-- Attributes for the <month> element -->
+  <define name="month-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- NAME ATTRIBUTES -->
+  <!-- Attribute list for the <name> element -->
+  <define name="name-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="name-style" a:defaultValue="western">
+        <choice>
+          <value>western</value>
+          <value>eastern</value>
+          <value>islensk</value>
+          <value>given-only</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- NAME ALTERNATIVES ATTRIBUTES -->
+  <!--
+    Attributes for the <name-alternatives>
+    element
+  -->
+  <define name="name-alternatives-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- NOTES ATTRIBUTES -->
+  <!-- Attribute list for the <note> element -->
+  <define name="notes-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="notes-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- OBJECT IDENTIFIER ATTRIBUTES -->
+  <!-- Attributes for the <object-id> element -->
+  <define name="object-id-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="pub-id-type"/>
+    </optional>
+    <optional>
+      <attribute name="assigning-authority"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- ON BEHALF OF ATTRIBUTES -->
+  <!-- Attributes for the <on-behalf-of> element -->
+  <define name="on-behalf-of-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- PAGE RANGE ATTRIBUTES -->
+  <!-- Attributes for the <page-range> element -->
+  <define name="page-range-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- PERMISSIONS ATTRIBUTES -->
+  <!-- Attributes for the <permission> element -->
+  <define name="permissions-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- PHONE ATTRIBUTES -->
+  <!-- Attributes for the <phone> element -->
+  <define name="phone-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- POSTAL CODE ATTRIBUTES -->
+  <!-- Attributes for the <postal-code> element -->
+  <define name="postal-code-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- PREFIX ATTRIBUTES -->
+  <!-- Attributes for the <prefix> element -->
+  <define name="prefix-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- PRICE ATTRIBUTES -->
+  <!-- Attributes for the <price> element -->
+  <define name="price-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="currency"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- PUBLISHER ATTRIBUTES -->
+  <!-- Attributes for the <publisher> element -->
+  <define name="publisher-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+  </define>
+  <!-- PUBLISHER LOCATION ATTRIBUTES -->
+  <!-- Attributes for the <publisher-loc> element -->
+  <define name="publisher-loc-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- PUBLISHER NAME ATTRIBUTES -->
+  <!--                     Attributes for the <publisher-name> element -->
+  <define name="publisher-name-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- RELATED ARTICLE ATTRIBUTES -->
+  <!-- Attributes for <related-article> -->
+  <define name="related-article-atts">
+    <ref name="jats-common-atts"/>
+    <attribute name="related-article-type"/>
+    <optional>
+      <attribute name="ext-link-type"/>
+    </optional>
+    <optional>
+      <attribute name="vol"/>
+    </optional>
+    <optional>
+      <attribute name="page"/>
+    </optional>
+    <optional>
+      <attribute name="issue"/>
+    </optional>
+    <optional>
+      <attribute name="elocation-id"/>
+    </optional>
+    <optional>
+      <attribute name="journal-id"/>
+    </optional>
+    <optional>
+      <attribute name="journal-id-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- ROLE ATTRIBUTES -->
+  <!-- Attributes for the <role> element -->
+  <define name="role-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="degree-contribution"/>
+    </optional>
+    <optional>
+      <attribute name="vocab"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- SEASON ATTRIBUTES -->
+  <!-- Attributes for the <season> element -->
+  <define name="season-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- SIGNATURE ATTRIBUTES -->
+  <!-- Attributes for the <sig> element -->
+  <define name="sig-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="rid">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- SIGNATURE BLOCK ATTRIBUTES -->
+  <!-- Attributes for the <sig-block> element -->
+  <define name="sig-block-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="rid">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- SIZE ATTRIBUTES -->
+  <!-- Attribute list for the <size> element -->
+  <define name="size-atts">
+    <ref name="jats-common-atts"/>
+    <attribute name="units"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- STATE ATTRIBUTES -->
+  <!-- Attributes for the <state> element -->
+  <define name="state-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- STRING DATE ATTRIBUTES -->
+  <!-- Attributes for the <string-date> element -->
+  <define name="string-date-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="iso-8601-date"/>
+    </optional>
+    <optional>
+      <attribute name="calendar"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- STRING NAME ATTRIBUTES -->
+  <!-- Attribute list for the <string-name> element -->
+  <define name="string-name-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="name-style" a:defaultValue="western">
+        <choice>
+          <value>western</value>
+          <value>eastern</value>
+          <value>islensk</value>
+          <value>given-only</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- SUFFIX ATTRIBUTES -->
+  <!-- Attributes for the <suffix> element -->
+  <define name="suffix-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- SUPPLEMENT ATTRIBUTES -->
+  <!-- Attributes for the <supplement> element -->
+  <define name="supplement-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="supplement-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- SURNAME ATTRIBUTES -->
+  <!-- Attribute list for the <surname> element -->
+  <define name="surname-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="initials"/>
+    </optional>
+  </define>
+  <!-- TEXTUAL FORM ATTRIBUTES -->
+  <!-- Attributes for the <textual-form> element -->
+  <define name="textual-form-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- TITLE ATTRIBUTES -->
+  <!-- Attributes for the <title> element -->
+  <define name="title-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- TRANSLATED SUBTITLE ATTRIBUTES -->
+  <!--
+    Attributes for the <trans-subtitle>
+    element
+  -->
+  <define name="trans-subtitle-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- TRANSLATED TITLE ATTRIBUTES -->
+  <!-- Attribute list for the <trans-title> -->
+  <define name="trans-title-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- TRANSLATED TITLE GROUP ATTRIBUTES -->
+  <!-- Attribute list for the <trans-title-group> -->
+  <!-- URI ATTRIBUTES -->
+  <!-- Attributes for the <uri> element -->
+  <define name="uri-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- VOLUME NUMBER ATTRIBUTES -->
+  <!-- Attribute list for the <volume> element -->
+  <define name="volume-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="seq"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- VOLUME IDENTIFIER ATTRIBUTES -->
+  <!-- Attributes for the <volume-id> element -->
+  <define name="volume-id-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="pub-id-type"/>
+    </optional>
+    <optional>
+      <attribute name="assigning-authority"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- VOLUME ISSUE GROUPING ATTRIBUTES -->
+  <!--
+    Attribute list for the <volume-issue-group>
+    element
+  -->
+  <define name="volume-issue-group-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- VOLUME SERIES ATTRIBUTES -->
+  <!--
+    Attribute list for the <volume-series>
+    element
+  -->
+  <define name="volume-series-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- YEAR ATTRIBUTES -->
+  <!-- Attributes for the <year> element -->
+  <define name="year-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="iso-8601-date"/>
+    </optional>
+    <optional>
+      <attribute name="calendar"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ============================================================= -->
+  <!-- METADATA USED BY MORE THAN ONE CLASS -->
+  <!-- ============================================================= -->
+  <!-- ============================================================= -->
+  <!-- NISO ACCESS AND INDICATOR ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- FREE TO READ (NISO ALI) MODEL -->
+  <!--
+    Content model for the ALI namespaced  
+    <ali:free_to_read> element.
+  -->
+  <define name="free-to-read-model">
+    <empty/>
+  </define>
+  <!-- FREE TO READ (NISO ALI) -->
+  <!--
+    An EMPTY element whose presence indicates 
+    that a document or portion of a document 
+    is free to be read. 
+    Remarks: Defined in "NISO Access License and 
+    Indicators (ALI) NISO RP-22-2015".    
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=ali:free_to_read
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=ali:free_to_read
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=ali:free_to_read
+  -->
+  <define name="ali.free_to_read">
+    <element name="ali:free_to_read">
+      <ref name="ali.free_to_read-attlist"/>
+      <ref name="free-to-read-model"/>
+    </element>
+  </define>
+  <define name="ali.free_to_read-attlist" combine="interleave">
+    <ref name="free-to-read-atts"/>
+  </define>
+  <!-- LICENSE REFERENCE (NISO ALI) MODEL -->
+  <!--
+    Content model for the ALI namespaced  
+    <ali:license_ref> element.
+  -->
+  <define name="license-ref-model">
+    <ref name="anyURI"/>
+  </define>
+  <!-- LICENSE REFERENCE (NISO ALI) -->
+  <!--
+    A URI that is a pointer to a public license
+    or waiver. If the element has content, it 
+    must be a URI.
+    Remarks: Defined in "NISO Access License and 
+    Indicators (ALI) NISO RP-22-2015".    
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=ali:license_ref
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=ali:license_ref
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=ali:license_ref
+  -->
+  <define name="ali.license_ref">
+    <element name="ali:license_ref">
+      <ref name="ali.license_ref-attlist"/>
+      <ref name="license-ref-model"/>
+    </element>
+  </define>
+  <define name="ali.license_ref-attlist" combine="interleave">
+    <ref name="license-ref-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- CONTRIBUTOR GROUP (AUTHOR/EDITOR) ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- CONTRIBUTOR GROUP MODEL -->
+  <!--
+    Content model for the <contrib-group>
+    element
+  -->
+  <!-- CONTRIBUTOR GROUP -->
+  <!--
+    Wrapper element for information concerning
+    a grouping of contributors, such as the
+    primary authors
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=contrib-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=contrib-group
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=contrib-group
+  -->
+  <define name="contrib-group">
+    <element name="contrib-group">
+      <ref name="contrib-group-attlist"/>
+      <ref name="contrib-group-model"/>
+    </element>
+  </define>
+  <define name="contrib-group-attlist" combine="interleave">
+    <ref name="contrib-group-atts"/>
+  </define>
+  <!-- CONTRIBUTOR MODEL -->
+  <!-- Content model for the <contrib> element -->
+  <!-- CONTRIBUTOR -->
+  <!--
+    Wrapper element to contain the information
+    about a single contributor, for example an
+    author or editor.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=contrib
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=contrib
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=contrib
+  -->
+  <define name="contrib">
+    <element name="contrib">
+      <ref name="contrib-attlist"/>
+      <ref name="contrib-model"/>
+    </element>
+  </define>
+  <define name="contrib-attlist" combine="interleave">
+    <ref name="contrib-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- COMMON COPYRIGHT/PERMISSION ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- COPYRIGHT HOLDER ELEMENTS -->
+  <!--
+    Elements to be mixed with data characters
+    inside the content model for the
+    <copyright-holder> element.
+  -->
+  <!-- COPYRIGHT HOLDER -->
+  <!--
+    Name of the organizational or personal
+    entity that holds the copyright.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=copyright-holder
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=copyright-holder
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=copyright-holder
+  -->
+  <define name="copyright-holder">
+    <element name="copyright-holder">
+      <ref name="copyright-holder-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="copyright-holder-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="copyright-holder-attlist" combine="interleave">
+    <ref name="copyright-holder-atts"/>
+  </define>
+  <!-- COPYRIGHT STATEMENT ELEMENTS -->
+  <!-- Content model for <copyright-statement> -->
+  <!-- COPYRIGHT STATEMENT -->
+  <!--
+    Copyright notice or statement, suitable for
+    printing or display. Within the statement the
+    copyright year should be identified, if
+    expected to be displayed.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=copyright-statement
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=copyright-statement
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=copyright-statement
+  -->
+  <define name="copyright-statement">
+    <element name="copyright-statement">
+      <ref name="copyright-statement-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="copyright-statement-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="copyright-statement-attlist" combine="interleave">
+    <ref name="copyright-statement-atts"/>
+  </define>
+  <!-- COPYRIGHT YEAR -->
+  <!--
+    Year of the copyright. Need not be used, if,
+    for example, having the year as part of the
+    copyright statement is sufficient.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=copyright-year
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=copyright-year
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=copyright-year
+  -->
+  <define name="copyright-year">
+    <element name="copyright-year">
+      <ref name="copyright-year-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <define name="copyright-year-attlist" combine="interleave">
+    <ref name="copyright-year-atts"/>
+  </define>
+  <!-- LICENSE MODEL -->
+  <!-- Content model for an <license> element -->
+  <define name="license-model">
+    <oneOrMore>
+      <ref name="license-p.class"/>
+    </oneOrMore>
+  </define>
+  <!-- LICENSE INFORMATION -->
+  <!--
+    The set of conditions under which people are
+    allowed to use this article or other
+    license-related information or restrictions.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=license
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=license
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=license
+  -->
+  <define name="license">
+    <element name="license">
+      <ref name="license-attlist"/>
+      <ref name="license-model"/>
+    </element>
+  </define>
+  <define name="license-attlist" combine="interleave">
+    <ref name="license-atts"/>
+  </define>
+  <!-- LICENSE PARAGRAPH ELEMENTS -->
+  <!--
+    Elements that can be included with the text
+    inside a <license-p> element.
+    Design Note: All inline mixes begin with an
+    OR bar, but since %p-elements; is an
+    inline mix, the OR bar is already there.
+  -->
+  <define name="license-p-elements">
+    <choice>
+      <ref name="p-elements"/>
+      <ref name="price.class"/>
+    </choice>
+  </define>
+  <!-- LICENSE PARAGRAPH -->
+  <!--
+    Paragraphs of text within the description of
+    a <license>. Not defined as an ordinary
+    paragraph, so that it can have special
+    content.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=license-p
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=license-p
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=license-p
+  -->
+  <define name="license-p">
+    <element name="license-p">
+      <ref name="license-p-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="license-p-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="license-p-attlist" combine="interleave">
+    <ref name="license-p-atts"/>
+  </define>
+  <!-- PERMISSIONS MODEL -->
+  <!-- Model for <permissions> wrapper element -->
+  <define name="permissions-model">
+    <zeroOrMore>
+      <ref name="copyright-statement"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="copyright-year"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="copyright-holder"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="license.class"/>
+    </zeroOrMore>
+  </define>
+  <!-- PERMISSIONS -->
+  <!--
+    Wrapper element to hold the copyright
+    information, license material, and any
+    future similar metadata.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=permissions
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=permissions
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=permissions
+  -->
+  <define name="permissions">
+    <element name="permissions">
+      <ref name="permissions-attlist"/>
+      <ref name="permissions-model"/>
+    </element>
+  </define>
+  <define name="permissions-attlist" combine="interleave">
+    <ref name="permissions-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- COMMON METADATA/BIBLIOGRAPHIC ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- ARTICLE TITLE ELEMENTS -->
+  <!--
+    Elements that can be included with the text
+    inside an <article-title> element.
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-phrase; is an
+    inline mix, the OR bar is already there.
+  -->
+  <!-- ARTICLE TITLE -->
+  <!--
+    The title of the article in the language
+    in which the article was originally
+    published
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=article-title
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=article-title
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=article-title
+  -->
+  <define name="article-title">
+    <element name="article-title">
+      <ref name="article-title-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="article-title-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="article-title-attlist" combine="interleave">
+    <ref name="article-title-atts"/>
+  </define>
+  <!-- AFFILIATION ELEMENTS -->
+  <!-- Elements for use in the <aff> element -->
+  <!-- AFFILIATION -->
+  <!--
+    Name of a institution or organization such as
+    a university or corporation.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=aff
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=aff
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=aff
+  -->
+  <define name="aff">
+    <element name="aff">
+      <ref name="aff-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="aff-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="aff-attlist" combine="interleave">
+    <ref name="aff-atts"/>
+  </define>
+  <!-- AFFILIATION ALTERNATIVES MODEL -->
+  <!--
+    Content model for the element
+    <aff-alternatives>
+  -->
+  <define name="aff-alternatives-model">
+    <oneOrMore>
+      <ref name="aff"/>
+    </oneOrMore>
+  </define>
+  <!-- AFFILIATION ALTERNATIVES -->
+  <!--
+    Container element to hold one or more
+    representations of a single affiliation, for
+    example the name of an institution in two
+    languages or two scripts.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=aff-alternatives
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=aff-alternatives
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=aff-alternatives
+  -->
+  <define name="aff-alternatives">
+    <element name="aff-alternatives">
+      <ref name="aff-alternatives-attlist"/>
+      <ref name="aff-alternatives-model"/>
+    </element>
+  </define>
+  <define name="aff-alternatives-attlist" combine="interleave">
+    <ref name="aff-alternatives-atts"/>
+  </define>
+  <!-- CONFERENCE DATE ELEMENTS -->
+  <!--                     Elements for use in the <conf-date> element -->
+  <!-- CONFERENCE DATE -->
+  <!--
+    The date(s) on which the conference was held.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=conf-date
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=conf-date
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=conf-date
+  -->
+  <define name="conf-date">
+    <element name="conf-date">
+      <ref name="conf-date-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="conf-date-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="conf-date-attlist" combine="interleave">
+    <ref name="conf-date-atts"/>
+  </define>
+  <!-- CONFERENCE LOCATION ELEMENTS -->
+  <!--
+    Elements for use in the <conf-loc> element
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-text; is an inline
+    mix, the OR bar is already there.
+  -->
+  <define name="conf-loc-elements">
+    <choice>
+      <ref name="simple-text"/>
+      <ref name="address.class"/>
+    </choice>
+  </define>
+  <!-- CONFERENCE LOCATION -->
+  <!--
+    The physical location(s) of the conference.
+    This may include a city, a country, or a
+    campus or organization location if that is
+    the only location available.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=conf-loc
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=conf-loc
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=conf-loc
+  -->
+  <define name="conf-loc">
+    <element name="conf-loc">
+      <ref name="conf-loc-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="conf-loc-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="conf-loc-attlist" combine="interleave">
+    <ref name="conf-loc-atts"/>
+  </define>
+  <!-- CONFERENCE NAME ELEMENTS -->
+  <!--
+    Elements for use in the <conf-name> element.
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-text; is an inline
+    mix, the OR bar is already there.
+  -->
+  <define name="conf-name-elements">
+    <ref name="simple-text"/>
+  </define>
+  <!-- CONFERENCE NAME -->
+  <!--
+    The full name of the conference, including any
+    qualifiers such as "43rd Annual".
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=conf-name
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=conf-name
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=conf-name
+  -->
+  <define name="conf-name">
+    <element name="conf-name">
+      <ref name="conf-name-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="conf-name-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="conf-name-attlist" combine="interleave">
+    <ref name="conf-name-atts"/>
+  </define>
+  <!-- CONFERENCE SPONSOR  ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the conference sponsor.
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-text; is an inline
+    mix, the OR bar is already there.
+  -->
+  <define name="conf-sponsor-elements">
+    <choice>
+      <ref name="simple-text"/>
+      <ref name="institution-wrap.class"/>
+    </choice>
+  </define>
+  <!-- CONFERENCE SPONSOR -->
+  <!--
+    One organization that sponsored the
+    conference. If more than one organization
+    sponsored the conference, multiple
+    <conf-sponsor> elements should be used.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=conf-sponsor
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=conf-sponsor
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=conf-sponsor
+  -->
+  <define name="conf-sponsor">
+    <element name="conf-sponsor">
+      <ref name="conf-sponsor-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="conf-sponsor-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="conf-sponsor-attlist" combine="interleave">
+    <ref name="conf-sponsor-atts"/>
+  </define>
+  <!-- OBJECT IDENTIFIER -->
+  <!--
+    Used to record an identifier such as a DOI
+    for an interior element such as an <abstract>
+    or <figure>.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=object-id
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=object-id
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=object-id
+  -->
+  <define name="object-id">
+    <element name="object-id">
+      <ref name="object-id-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <define name="object-id-attlist" combine="interleave">
+    <ref name="object-id-atts"/>
+  </define>
+  <!-- ISBN ELEMENTS -->
+  <!--
+    Elements for use with data characters inside
+    the model for the <isbn> element
+  -->
+  <!-- ISBN -->
+  <!--
+    International Standard Book Number
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=isbn
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=isbn
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=isbn
+  -->
+  <define name="isbn">
+    <element name="isbn">
+      <ref name="isbn-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="isbn-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="isbn-attlist" combine="interleave">
+    <ref name="isbn-atts"/>
+  </define>
+  <!-- ISSN ELEMENTS -->
+  <!--
+    Elements for use with data characters inside
+    the model for the <issue> element
+  -->
+  <!-- ISSN -->
+  <!--
+    International Standard Serial Number
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=issn
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=issn
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=issn
+  -->
+  <define name="issn">
+    <element name="issn">
+      <ref name="issn-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="issn-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="issn-attlist" combine="interleave">
+    <ref name="issn-atts"/>
+  </define>
+  <!-- ISSN-L ELEMENTS -->
+  <!--
+    Elements for use with data characters inside
+    the model for the <issn-l> element
+  -->
+  <!-- ISSN LINKING -->
+  <!--
+    International Standard Linking Serial Number
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=issn-l
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=issn-l
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=issn-l
+  -->
+  <define name="issn-l">
+    <element name="issn-l">
+      <ref name="issn-l-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="issn-l-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="issn-l-attlist" combine="interleave">
+    <ref name="issn-l-atts"/>
+  </define>
+  <!-- ISSUE ELEMENTS -->
+  <!--
+    Elements for use with data characters inside
+    the model for the <issue> element
+  -->
+  <define name="issue-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- ISSUE NUMBER -->
+  <!--
+    The issue number, issue name, or other
+    identifier of an issue of a journal that
+    is displayed or printed with the issue.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=issue
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=issue
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=issue
+  -->
+  <define name="issue">
+    <element name="issue">
+      <ref name="issue-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="issue-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="issue-attlist" combine="interleave">
+    <ref name="issue-atts"/>
+  </define>
+  <!-- ISSUE IDENTIFIER -->
+  <!--
+    Used to record an identifier such as a DOI
+    that describes an entire issue of a
+    journal
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=issue-id
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=issue-id
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=issue-id
+  -->
+  <define name="issue-id">
+    <element name="issue-id">
+      <ref name="issue-id-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <define name="issue-id-attlist" combine="interleave">
+    <ref name="issue-id-atts"/>
+  </define>
+  <!-- ISSUE PART ELEMENTS -->
+  <!--
+    Elements that can be added to the text
+    within the element <issue-part>
+  -->
+  <define name="issue-part-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- ISSUE PART -->
+  <!--
+    A publisher may split an issue into two or
+    more separately bound or separately issued
+    parts. This element holds the identifiers
+    (titles, part numbers, etc.) for those
+    publishing components.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=issue-part
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=issue-part
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=issue-part
+  -->
+  <define name="issue-part">
+    <element name="issue-part">
+      <ref name="issue-part-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="issue-part-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="issue-part-attlist" combine="interleave">
+    <ref name="issue-part-atts"/>
+  </define>
+  <!-- ISSUE SPONSOR ELEMENTS -->
+  <!--
+    Elements for use in the <issue-sponsor>
+    element
+  -->
+  <define name="issue-sponsor-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- ISSUE TITLE -->
+  <!--
+    Used to record the sponsor for an issue of
+    the journal
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=issue-sponsor
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=issue-sponsor
+  -->
+  <define name="issue-sponsor">
+    <element name="issue-sponsor">
+      <ref name="issue-sponsor-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="issue-sponsor-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="issue-sponsor-attlist" combine="interleave">
+    <ref name="issue-sponsor-atts"/>
+  </define>
+  <!-- ISSUE TITLE ELEMENTS -->
+  <!-- Elements for use in the <issue-title> element -->
+  <!-- ISSUE TITLE -->
+  <!--
+    Used to record the theme or special issue
+    title for an issue of the journal
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=issue-title
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=issue-title
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=issue-title
+  -->
+  <define name="issue-title">
+    <element name="issue-title">
+      <ref name="issue-title-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="issue-title-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="issue-title-attlist" combine="interleave">
+    <ref name="issue-title-atts"/>
+  </define>
+  <!-- JOURNAL IDENTIFIER -->
+  <!--
+    Short code that represents the journal; used
+    as an alternative to or short form of the
+    journal title; used for identification of
+    the journal domain.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=journal-id
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=journal-id
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=journal-id
+  -->
+  <define name="journal-id">
+    <element name="journal-id">
+      <ref name="journal-id-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <define name="journal-id-attlist" combine="interleave">
+    <ref name="journal-id-atts"/>
+  </define>
+  <!-- ROLE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <role>
+    Design Note: All inline mixes begin with an
+    OR bar; since %rendition-plus; is an
+    inline mix, the OR bar is already there.
+  -->
+  <!-- ROLE OR FUNCTION TITLE OF CONTRIBUTOR -->
+  <!--
+    A title or the role of a contributor
+    (such as an author) in this work. For example,
+    Editor-in-Chief, Contributor, Chief
+    Scientist, Photographer, Research Associate,
+    etc.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=role
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=role
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=role
+  -->
+  <define name="role">
+    <element name="role">
+      <ref name="role-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="role-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="role-attlist" combine="interleave">
+    <ref name="role-atts"/>
+  </define>
+  <!-- TRANSLATED TITLE GROUP MODEL -->
+  <!--
+    Content model for the element
+    <trans-title-group>
+  -->
+  <define name="trans-title-group-model">
+    <ref name="trans-title"/>
+    <zeroOrMore>
+      <ref name="trans-subtitle"/>
+    </zeroOrMore>
+  </define>
+  <!-- TRANSLATED TITLE GROUP -->
+  <!--
+    Container element for all translated, and
+    transliterated journal titles.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=trans-title-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=trans-title-group
+  -->
+  <define name="trans-title-group">
+    <element name="trans-title-group">
+      <ref name="trans-title-group-attlist"/>
+      <ref name="trans-title-group-model"/>
+    </element>
+  </define>
+  <define name="trans-title-group-attlist" combine="interleave">
+    <ref name="trans-title-group-atts"/>
+  </define>
+  <!-- TRANSLATED SUBTITLE -->
+  <!--
+    An alternate version of an article subtitle
+    that has been translated out of the original
+    language of the article subtitle <subtitle>
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=trans-subtitle
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=trans-subtitle
+  -->
+  <define name="trans-subtitle">
+    <element name="trans-subtitle">
+      <ref name="trans-subtitle-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="trans-subtitle-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="trans-subtitle-attlist" combine="interleave">
+    <ref name="trans-subtitle-atts"/>
+  </define>
+  <!-- TRANSLATED TITLE -->
+  <!--
+    An alternate version of the title that has
+    been translated into a language other than
+    that of the original article title
+    <article-title>
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=trans-title
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=trans-title
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=trans-title
+  -->
+  <define name="trans-title">
+    <element name="trans-title">
+      <ref name="trans-title-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="trans-title-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="trans-title-attlist" combine="interleave">
+    <ref name="trans-title-atts"/>
+  </define>
+  <!-- VOLUME NUMBER ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <volume>
+  -->
+  <define name="volume-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- VOLUME NUMBER -->
+  <!--
+    NEW DEFINITION FOR RELEASE 2.0:
+    The volume number, volume name, or other
+    identifier of an volume of a journal that
+    is displayed or printed with the volume.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=volume
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=volume
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=volume
+  -->
+  <define name="volume">
+    <element name="volume">
+      <ref name="volume-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="volume-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="volume-attlist" combine="interleave">
+    <ref name="volume-atts"/>
+  </define>
+  <!-- VOLUME IDENTIFIER ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <volume-id>
+  -->
+  <define name="volume-id-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- VOLUME IDENTIFIER -->
+  <!--
+    Used to record an identifier such as a DOI
+    that describes an entire volume of a
+    journal.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=volume-id
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=volume-id
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=volume-id
+  -->
+  <define name="volume-id">
+    <element name="volume-id">
+      <ref name="volume-id-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="volume-id-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="volume-id-attlist" combine="interleave">
+    <ref name="volume-id-atts"/>
+  </define>
+  <!-- VOLUME SERIES ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <volume>
+  -->
+  <define name="volume-series-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- VOLUME SERIES -->
+  <!--
+    This is a rare metadata element, intended to
+    hold the series number, in those odd cases
+    where, for example, a Publisher has reissued
+    a journal, restarting the volume numbers
+    with "1", so duplicate volume numbers
+    would exist and need to be differentiated.
+    Such a publisher typically adds a series
+    number to their volume numbers, and
+    this element has been created to hold such
+    a series number.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=volume-series
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=volume-series
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=volume-series
+  -->
+  <define name="volume-series">
+    <element name="volume-series">
+      <ref name="volume-series-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="volume-series-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="volume-series-attlist" combine="interleave">
+    <ref name="volume-series-atts"/>
+  </define>
+  <!-- VOLUME ISSUE GROUP -->
+  <!--
+    Content model for the element
+    <volume-issue-group>.
+  -->
+  <define name="volume-issue-group-model">
+    <zeroOrMore>
+      <ref name="volume"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="volume-id"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="volume-series"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="issue"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="issue-id"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="issue-title"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="issue-sponsor"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="issue-part"/>
+    </optional>
+  </define>
+  <!-- TRANSLATED TITLE GROUP -->
+  <!--
+    Container element to hold together related
+    volume and issue elements.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=volume-issue-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=volume-issue-group
+  -->
+  <define name="volume-issue-group">
+    <element name="volume-issue-group">
+      <ref name="volume-issue-group-attlist"/>
+      <ref name="volume-issue-group-model"/>
+    </element>
+  </define>
+  <define name="volume-issue-group-attlist" combine="interleave">
+    <ref name="volume-issue-group-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- COMMON ARTICLE METADATA/BIBLIOGRAPHIC -->
+  <!-- CONTRIBUTOR IDENTIFICATION ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- ANONYMOUS ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    an <anonymous> element
+  -->
+  <!-- ANONYMOUS CONTENT MODEL -->
+  <!--
+    The content model for the <anonymous> 
+    element
+  -->
+  <define name="anonymous-model">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="anonymous-elements"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <!-- ANONYMOUS -->
+  <!--
+    Place holder for the name of a contributor
+    whose name is unknown or not disclosed.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=anonymous
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=anonymous
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=anonymous
+  -->
+  <define name="anonymous">
+    <element name="anonymous">
+      <ref name="anonymous-attlist"/>
+      <ref name="anonymous-model"/>
+    </element>
+  </define>
+  <define name="anonymous-attlist" combine="interleave">
+    <ref name="anonymous-atts"/>
+  </define>
+  <!-- ET AL ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    an <etal> element
+  -->
+  <!-- ET AL CONTENT MODEL -->
+  <!-- The content model for the <etal> element -->
+  <define name="etal-model">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="etal-elements"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <!-- ET AL -->
+  <!--
+    Most journals model this as an EMPTY element,
+    typically used to generate the text "et al."
+    from a stylesheet. However, a few journal
+    DTDs (Blackwell's, for example) expect
+    content for this element, with such text as
+    "Associates, coworkers, and colleagues".
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=etal
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=etal
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=etal
+  -->
+  <define name="etal">
+    <element name="etal">
+      <ref name="etal-attlist"/>
+      <ref name="etal-model"/>
+    </element>
+  </define>
+  <define name="etal-attlist" combine="interleave">
+    <ref name="etal-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- COMMON ARTICLE METADATA/BIBLIOGRAPHIC -->
+  <!-- PUBLISHER IDENTIFICATION ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- ON BEHALF OF CONTENT ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    <on-behalf-of>
+    Design Note: -%rendition-plus; begins with
+    an OR bar, so this inline mix beguines with
+    an OR bar.
+  -->
+  <define name="on-behalf-of-elements">
+    <choice>
+      <ref name="rendition-plus"/>
+      <ref name="institution-wrap.class"/>
+    </choice>
+  </define>
+  <!-- ON BEHALF OF -->
+  <!--
+    When a contributor has written or edited
+    a work  "on-behalf-of" an organization or
+    group the contributor is acting as a
+    representative of the organization, which
+    may or may not be his/her usual affiliation.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=on-behalf-of
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=on-behalf-of
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=on-behalf-of
+  -->
+  <define name="on-behalf-of">
+    <element name="on-behalf-of">
+      <ref name="on-behalf-of-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="on-behalf-of-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="on-behalf-of-attlist" combine="interleave">
+    <ref name="on-behalf-of-atts"/>
+  </define>
+  <!-- PUBLISHER CONTENT MODEL -->
+  <!--
+    The content model for the <publisher>
+    element
+  -->
+  <define name="publisher-model">
+    <oneOrMore>
+      <ref name="publisher-name"/>
+      <optional>
+        <ref name="publisher-loc"/>
+      </optional>
+    </oneOrMore>
+  </define>
+  <!-- PUBLISHER -->
+  <!--
+    Who published the work
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=publisher
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=publisher
+  -->
+  <define name="publisher">
+    <element name="publisher">
+      <ref name="publisher-attlist"/>
+      <ref name="publisher-model"/>
+    </element>
+  </define>
+  <define name="publisher-attlist" combine="interleave">
+    <ref name="publisher-atts"/>
+  </define>
+  <!-- PUBLISHER'S NAME ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <publisher-name>
+    Design Note: All inline mixes begin with an
+    OR bar; since %just-rendition; is an
+    inline mix, the OR bar is already there
+  -->
+  <define name="publisher-name-elements">
+    <choice>
+      <ref name="just-rendition"/>
+      <ref name="institution-wrap.class"/>
+    </choice>
+  </define>
+  <!-- PUBLISHER'S NAME -->
+  <!--
+    Name of the publisher of the work
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=publisher-name
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=publisher-name
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=publisher-name
+  -->
+  <define name="publisher-name">
+    <element name="publisher-name">
+      <ref name="publisher-name-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="publisher-name-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="publisher-name-attlist" combine="interleave">
+    <ref name="publisher-name-atts"/>
+  </define>
+  <!-- PUBLISHER'S LOCATION ELEMENTS -->
+  <!--
+    Elements for use in the Publisher Location
+    <publisher-loc> element
+  -->
+  <!-- PUBLISHER'S LOCATION -->
+  <!--
+    Place of publication, usually a city such
+    as New York or London
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=publisher-loc
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=publisher-loc
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=publisher-loc
+  -->
+  <define name="publisher-loc">
+    <element name="publisher-loc">
+      <ref name="publisher-loc-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="publisher-loc-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="publisher-loc-attlist" combine="interleave">
+    <ref name="publisher-loc-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- COMMON METADATA ELEMENTS CONTINUED -->
+  <!-- PAGE NUMBERING (SIZE) ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- FIRST PAGE -->
+  <!--
+    The page number on which the article starts,
+    for print journals that have page numbers
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=fpage
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=fpage
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=fpage
+  -->
+  <define name="fpage">
+    <element name="fpage">
+      <ref name="fpage-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <define name="fpage-attlist" combine="interleave">
+    <ref name="fpage-atts"/>
+  </define>
+  <!-- LAST PAGE -->
+  <!--
+    The page number on which the article ends,
+    for print journals that have page numbers
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=lpage
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=lpage
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=lpage
+  -->
+  <define name="lpage">
+    <element name="lpage">
+      <ref name="lpage-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <define name="lpage-attlist" combine="interleave">
+    <ref name="lpage-atts"/>
+  </define>
+  <!-- PAGE RANGES -->
+  <!--
+    A container element for additional page
+    information (TO BE USED TO SUPPLEMENT AND
+    NOT TO REPLACE <fpage> and <lpage>) to record
+    discontinuous pages ranges such as
+        "8-11, 14-19, 40"
+    meaning that the article begins on page
+    8, runs 8 through 11, skips to pages 14
+    through 19, and concludes on page 40.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=page-range
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=page-range
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=page-range
+  -->
+  <define name="page-range">
+    <element name="page-range">
+      <ref name="page-range-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <define name="page-range-attlist" combine="interleave">
+    <ref name="page-range-atts"/>
+  </define>
+  <!-- SIZE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the size element.
+  -->
+  <!-- SIZE -->
+  <!--
+    The size (such as running time, page count,
+    or physical measurements) of the object being
+    described, usually by a <product> element.
+    The "units" attribute must be used to name
+    the unit of measure (pages, minutes, hours,
+    linear feet, etc.).
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=size
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=size
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=size
+  -->
+  <define name="size">
+    <element name="size">
+      <ref name="size-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="size-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="size-attlist" combine="interleave">
+    <ref name="size-atts"/>
+  </define>
+  <!-- ELECTRONIC LOCATION IDENTIFIER -->
+  <!--
+    Used to identify an article that
+    does not have traditional page numbers.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=elocation-id
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=elocation-id
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=elocation-id
+  -->
+  <define name="elocation-id">
+    <element name="elocation-id">
+      <ref name="elocation-id-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <define name="elocation-id-attlist" combine="interleave">
+    <ref name="elocation-id-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- CITATIONS (BIBLIOGRAPHIC REFERENCE) -->
+  <!-- ============================================================= -->
+  <!-- CITATION ALTERNATIVES MODEL -->
+  <!--
+    Model for the <citation-alternatives>
+    element.
+  -->
+  <define name="citation-alternatives-model">
+    <oneOrMore>
+      <ref name="citation-minus-alt.class"/>
+    </oneOrMore>
+  </define>
+  <!-- CITATION ALTERNATIVES -->
+  <!--
+    This element will hold alternative versions of 
+    one citation, for example, a single citation 
+    in multiple languages or a single citation 
+    tagged as both a <mixed-citation> complete 
+    with punctuation and spacing and as an
+    <element-citation> with punctuation and 
+    spacing removed.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=citation-alternativesv
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=citation-alternatives
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=citation-alternatives
+  -->
+  <define name="citation-alternatives">
+    <element name="citation-alternatives">
+      <ref name="citation-alternatives-attlist"/>
+      <ref name="citation-alternatives-model"/>
+    </element>
+  </define>
+  <define name="citation-alternatives-attlist" combine="interleave">
+    <ref name="citation-alternatives-atts"/>
+  </define>
+  <!-- CITATION ELEMENTS -->
+  <!--
+    Content for both types of citation. These
+    elements may be mixed with #PCDATA in the
+    <mixed-citation> element (in which all
+    punctuation and spacing are left intact), and
+    they also constitute the choices that can be
+    used to form the all-element-content of the
+    <element-citation> element (in which
+    punctuation and spacing are removed).
+    Design Note: All inline mixes begin with an
+    OR bar.
+  -->
+  <!-- MIXED CITATION -->
+  <!--
+    A citation is a description of a work, such
+    as a journal article, book, or personal
+    communication, that is cited in the text of
+    the article. This citation element is
+    completely loose, with text, punctuation,
+    spacing, and any of the citation elements
+    in any order.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=mixed-citation
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=mixed-citation
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=mixed-citation
+  -->
+  <define name="mixed-citation">
+    <element name="mixed-citation">
+      <ref name="mixed-citation-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="citation-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mixed-citation-attlist" combine="interleave">
+    <ref name="mixed-citation-atts"/>
+  </define>
+  <!-- ELEMENT CITATION -->
+  <!--
+    A citation is a description of a work, such
+    as a journal article, book, or personal
+    communication, that is cited in the text of
+    the article. This citation model contains
+    element-only content, with elements in
+    any order as many times as needed. This
+    citation is intended for use in capturing
+    a publisher's specific element order.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=element-citation
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=element-citation
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=element-citation
+  -->
+  <define name="element-citation">
+    <element name="element-citation">
+      <ref name="element-citation-attlist"/>
+      <oneOrMore>
+        <ref name="citation-elements"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="element-citation-attlist" combine="interleave">
+    <ref name="element-citation-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- ADDRESS ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- ADDRESS MODEL -->
+  <!-- Content model for the <address> element -->
+  <!-- ADDRESS/CONTACT INFORMATION -->
+  <!--
+    Wrapper element for contact information such
+    as address, phone, fax, email, url, country,
+    etc.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=address
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=address
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=address
+  -->
+  <define name="address">
+    <element name="address">
+      <ref name="address-attlist"/>
+      <ref name="address-model"/>
+    </element>
+  </define>
+  <define name="address-attlist" combine="interleave">
+    <ref name="address-atts"/>
+  </define>
+  <!-- ADDRESS LINE ELEMENTS -->
+  <!--                     Elements for use in the <addr-line> element -->
+  <define name="addr-line-elements">
+    <choice>
+      <ref name="simple-text"/>
+      <ref name="address-line.class"/>
+    </choice>
+  </define>
+  <!-- ADDRESS LINE -->
+  <!-- One line in an address -->
+  <!--
+    Conversion Note: If the address is
+    undifferentiated data characters, the entire
+    address may be inside one of these elements.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=addr-line
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=addr-line
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=addr-line
+  -->
+  <define name="addr-line">
+    <element name="addr-line">
+      <ref name="addr-line-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="addr-line-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="addr-line-attlist" combine="interleave">
+    <ref name="addr-line-atts"/>
+  </define>
+  <!-- CITY ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the city element.
+  -->
+  <define name="city-elements">
+    <notAllowed/>
+  </define>
+  <!-- CITY: IN AN ADDRESS -->
+  <!--
+    The name of a city.                   
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=city
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=city
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=city
+  -->
+  <define name="city">
+    <element name="city">
+      <ref name="city-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="city-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="city-attlist" combine="interleave">
+    <ref name="city-atts"/>
+  </define>
+  <!-- COUNTRY ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the country element.
+  -->
+  <!-- COUNTRY: IN AN ADDRESS -->
+  <!--
+    The name of a country.                    
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=country
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=country
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=country
+  -->
+  <define name="country">
+    <element name="country">
+      <ref name="country-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="country-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="country-attlist" combine="interleave">
+    <ref name="country-atts"/>
+  </define>
+  <!-- EMAIL ADDRESS ELEMENTS -->
+  <!--
+    Elements to be mixed with #PCDATA inside the
+    <email> element
+  -->
+  <!-- EMAIL ADDRESS -->
+  <!--
+    The email address of a person or institution.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=email
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=email
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=email
+  -->
+  <define name="email">
+    <element name="email">
+      <ref name="email-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="email-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="email-attlist" combine="interleave">
+    <ref name="email-atts"/>
+  </define>
+  <!-- FAX NUMBER ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <fax>
+  -->
+  <define name="fax-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- FAX NUMBER: IN AN ADDRESS -->
+  <!--
+    The number used to send faxes.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=fax
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=fax
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=fax
+  -->
+  <define name="fax">
+    <element name="fax">
+      <ref name="fax-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="fax-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="fax-attlist" combine="interleave">
+    <ref name="fax-atts"/>
+  </define>
+  <!-- INSTITUTION NAME ELEMENTS -->
+  <!--
+    Elements for use in the <institution>
+    element
+  -->
+  <!-- INSTITUTION NAME: IN AN ADDRESS -->
+  <!--
+    Name of a institution or organization such as
+    a university or corporation used in an
+    address or within a citation (such as a
+    <mixed-citation> or an <element-citation>)
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=institution
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=institution
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=institution
+  -->
+  <define name="institution">
+    <element name="institution">
+      <ref name="institution-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="institution-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="institution-attlist" combine="interleave">
+    <ref name="institution-atts"/>
+  </define>
+  <!-- INSTITUTION IDENTIFIER MODEL -->
+  <!--
+    Content model for the <institution-id>
+    element
+  -->
+  <define name="institution-id-model">
+    <text/>
+  </define>
+  <!-- INSTITUTION IDENTIFIER -->
+  <!--
+    Contains an institutional identifier,
+    whether publisher-specific (for example,  
+    "AIP") or from an established identifying
+    authority (for example,"Ringgold" or "ISNI").
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=institution-id
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=institution-id
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=institution-id
+  -->
+  <define name="institution-id">
+    <element name="institution-id">
+      <ref name="institution-id-attlist"/>
+      <ref name="institution-id-model"/>
+    </element>
+  </define>
+  <define name="institution-id-attlist" combine="interleave">
+    <ref name="institution-id-atts"/>
+  </define>
+  <!-- INSTITUTION WRAPPER MODEL -->
+  <!--
+    Content model for the <institution-wrap>
+    element
+  -->
+  <define name="institution-wrap-model">
+    <zeroOrMore>
+      <ref name="institution.class"/>
+    </zeroOrMore>
+  </define>
+  <!-- INSTITUTION WRAPPER -->
+  <!--
+    A container element to hold the name of an
+    institution <institution> and any formal
+    identifiers for that institution 
+    <institution-id>), for example, a INSI or
+    Ringgold ID.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=institution-wrap
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=institution-wrap
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=institution-wrap
+  -->
+  <define name="institution-wrap">
+    <element name="institution-wrap">
+      <ref name="institution-wrap-attlist"/>
+      <ref name="institution-wrap-model"/>
+    </element>
+  </define>
+  <define name="institution-wrap-attlist" combine="interleave">
+    <ref name="institution-wrap-atts"/>
+  </define>
+  <!-- PHONE NUMBER ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <phone number>
+    Design Note: All inline mixes begin with an
+    OR bar, but since %just-rendition; is an
+    inline mix, the OR bar is already there.
+  -->
+  <define name="phone-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- PHONE NUMBER: IN AN ADDRESS -->
+  <!--
+    A callable phone number in some telephone or
+    wireless system somewhere in the world.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=phone
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=phone
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=phone
+  -->
+  <define name="phone">
+    <element name="phone">
+      <ref name="phone-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="phone-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="phone-attlist" combine="interleave">
+    <ref name="phone-atts"/>
+  </define>
+  <!-- POSTAL CODE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the postal-code element.
+  -->
+  <define name="postal-code-elements">
+    <notAllowed/>
+  </define>
+  <!-- POSTAL CODE: IN AN ADDRESS -->
+  <!--
+    A postal number such as a zip-code or postal
+    code used to address physical mail.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=postal-code
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=postal-code
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=postal-code
+  -->
+  <define name="postal-code">
+    <element name="postal-code">
+      <ref name="postal-code-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="postal-code-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="postal-code-attlist" combine="interleave">
+    <ref name="postal-code-atts"/>
+  </define>
+  <!-- STATE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the state element.
+  -->
+  <define name="state-elements">
+    <notAllowed/>
+  </define>
+  <!-- STATE or PROVINCE: IN AN ADDRESS -->
+  <!--
+    The name of a state, province, territory or
+    other political unit used in an address. This
+    is a lower level subdivision than a country,
+    but higher than a city, county, or parish. 
+    The names for such a unit vary geopolitically.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=state
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=state
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=state
+  -->
+  <define name="state">
+    <element name="state">
+      <ref name="state-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="state-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="state-attlist" combine="interleave">
+    <ref name="state-atts"/>
+  </define>
+  <!-- URI ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <uri>
+    Design Note: This PE begins with an OR
+    bar because %just-rendition; begins with an
+    OR bar.
+  -->
+  <define name="uri-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- URI -->
+  <!--
+    URI such as a URL that may be used as a
+    live link, typically naming a web site, such
+    as:
+       <url>http://www.mulberrytech.com</url>
+    Alternatively the element content may name
+    the URL, e.g., "Mulberry's Website" and the
+    "xlink:href" attribute may hold the real
+    URL.
+       <url xlink:href="http://www.mulberrytech.
+       com">Mulberry's Website</url>
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=uri
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=uri
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=uri
+  -->
+  <define name="uri">
+    <element name="uri">
+      <ref name="uri-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="uri-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="uri-attlist" combine="interleave">
+    <ref name="uri-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- SUPPLEMENT ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- SUPPLEMENT ELEMENTS -->
+  <!--
+    Elements for use in the <supplement> element
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-text; is an inline
+    mix, the OR bar is already there.
+  -->
+  <define name="supplement-elements">
+    <choice>
+      <ref name="simple-text"/>
+      <ref name="contrib-group.class"/>
+      <ref name="title.class"/>
+    </choice>
+  </define>
+  <!-- SUPPLEMENT -->
+  <!--
+    For a journal published as a supplement, this
+    is a container element for all the provided
+    supplement information, such as additional
+    identification numbers, titles, authors, and
+    supplement series information.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=supplement
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=supplement
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=supplement
+  -->
+  <define name="supplement">
+    <element name="supplement">
+      <ref name="supplement-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="supplement-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="supplement-attlist" combine="interleave">
+    <ref name="supplement-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- DATE ELEMENTS (PUBLICATION HISTORY) -->
+  <!-- ============================================================= -->
+  <!-- DATE -->
+  <!--
+    The elements <day>, <month>, and <year> should
+    ALWAYS be numeric values. The date may be
+    represented as a string in <string-date>, but
+    the numeric values should be present whenever
+    possible.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=date
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=date
+  -->
+  <define name="date">
+    <element name="date">
+      <ref name="date-attlist"/>
+      <ref name="date-model"/>
+    </element>
+  </define>
+  <define name="date-attlist" combine="interleave">
+    <ref name="date-atts"/>
+  </define>
+  <!-- DAY -->
+  <!--
+    The numeric value of a day of the month, used
+    in both article metadata and inside a citation,
+    in two digits as it would be stated in the "DD"
+    in an international date format YYYY-MM-DD, for
+    example "03", "25".
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=day
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=day
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=day
+  -->
+  <define name="day">
+    <element name="day">
+      <ref name="day-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <define name="day-attlist" combine="interleave">
+    <ref name="day-atts"/>
+  </define>
+  <!-- MONTH -->
+  <!--
+    Names one of the months of the year. Used in
+    both article metadata and inside a citation,
+    this element may contain a full month
+    "December", an abbreviation "Dec", or,
+    preferably, a numeric month such as "12".
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=month
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=month
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=month
+  -->
+  <define name="month">
+    <element name="month">
+      <ref name="month-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <define name="month-attlist" combine="interleave">
+    <ref name="month-atts"/>
+  </define>
+  <!-- SEASON -->
+  <!--
+    Season of publication, such as "Spring".
+    Used in both article metadata and inside a
+    citation (such as a <mixed-citation> or an
+    <element-citation>)
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=season
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=season
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=season
+  -->
+  <define name="season">
+    <element name="season">
+      <ref name="season-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <define name="season-attlist" combine="interleave">
+    <ref name="season-atts"/>
+  </define>
+  <!-- ERA -->
+  <!--
+    Era of publication. Used in certain Japanese
+    and Korean dates.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=era
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=era
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=era
+  -->
+  <define name="era">
+    <element name="era">
+      <ref name="era-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <define name="era-attlist" combine="interleave">
+    <ref name="era-atts"/>
+  </define>
+  <!-- YEAR -->
+  <!--
+    Year of publication, which should be expressed
+    as a 4-digit number: "1776" or "1924"
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=year
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=year
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=year
+  -->
+  <define name="year">
+    <element name="year">
+      <ref name="year-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <define name="year-attlist" combine="interleave">
+    <ref name="year-atts"/>
+  </define>
+  <!-- STRING DATE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <string-date> element
+  -->
+  <!-- DATE AS A STRING -->
+  <!--
+    This is a representation of the date as a
+    string; usually used for dates for which
+    months and years are not given, but may be
+    used for any date as a string (i.e., "January,
+    2001" "Fall 2001" "March 11, 2001").
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=string-date
+  -->
+  <define name="string-date">
+    <element name="string-date">
+      <ref name="string-date-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="string-date-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="string-date-attlist" combine="interleave">
+    <ref name="string-date-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- GROUP OR CORPORATE AUTHOR ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- COLLABORATION ALTERNATIVES ELEMENTS -->
+  <!--
+    Content model for the <collab-alternatives>
+    element.
+  -->
+  <define name="collab-alternatives-model">
+    <oneOrMore>
+      <ref name="collab.class"/>
+    </oneOrMore>
+  </define>
+  <!-- COLLABORATION ALTERNATIVES -->
+  <!--
+    Wrapper element for more than one version of
+    a collaboration, for example, the name of a
+    laboratory in more than one language such as
+    the lab name in Japanese kana characters and 
+    a transliterated form of the lab name in Latin 
+    alphabet.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=collab-alternatives
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=collab-alternatives
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=collab-alternatives
+  -->
+  <define name="collab-alternatives">
+    <element name="collab-alternatives">
+      <ref name="collab-alternatives-attlist"/>
+      <ref name="collab-alternatives-model"/>
+    </element>
+  </define>
+  <define name="collab-alternatives-attlist" combine="interleave">
+    <ref name="collab-alternatives-atts"/>
+  </define>
+  <!-- COLLABORATIVE (GROUP) AUTHOR ELEMENTS -->
+  <!--
+    Elements for use in the <collab> element
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-text; is an inline
+    mix, the OR bar is already there.
+  -->
+  <!-- COLLABORATIVE (GROUP) AUTHOR -->
+  <!--
+    Used for groups of authors credited under
+    one name, either as a collaboration in the
+    strictest sense, or when an organization,
+    institution, or corporation is the group.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=collab
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=collab
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=collab
+  -->
+  <define name="collab">
+    <element name="collab">
+      <ref name="collab-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="collab-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="collab-attlist" combine="interleave">
+    <ref name="collab-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PERSON'S NAME ELEMENTS (BIBLIOGRAPHIC) -->
+  <!-- ============================================================= -->
+  <!-- CONTRIBUTOR IDENTIFIER MODEL -->
+  <!-- Content model for the <contrib-id> element -->
+  <define name="contrib-id-model">
+    <text/>
+  </define>
+  <!-- CONTRIBUTOR IDENTIFIER -->
+  <!--
+    One identifier for a person such as a
+    contributor or principal investigator. This
+    element will hold an ORCID, a trusted
+    publisher's identifier, or a JST or NII 
+    identifier.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=contrib-id
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=contrib-id
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=contrib-id
+  -->
+  <define name="contrib-id">
+    <element name="contrib-id">
+      <ref name="contrib-id-attlist"/>
+      <ref name="contrib-id-model"/>
+    </element>
+  </define>
+  <define name="contrib-id-attlist" combine="interleave">
+    <ref name="contrib-id-atts"/>
+  </define>
+  <!-- NAME ALTERNATIVES MODEL -->
+  <!--
+    Content model for the <name-alternatives>
+    element
+  -->
+  <define name="name-alternatives-model">
+    <oneOrMore>
+      <ref name="name-alternatives.class"/>
+    </oneOrMore>
+  </define>
+  <!-- NAME ALTERNATIVES -->
+  <!--
+    Wrapper element for more than one version of
+    a personal name, for example, the name in
+    Japanese kana characters and a transliterated
+    form of the name in Latin alphabet.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=name-alternatives
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=name-alternatives
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=name-alternatives
+  -->
+  <define name="name-alternatives">
+    <element name="name-alternatives">
+      <ref name="name-alternatives-attlist"/>
+      <ref name="name-alternatives-model"/>
+    </element>
+  </define>
+  <define name="name-alternatives-attlist" combine="interleave">
+    <ref name="name-alternatives-atts"/>
+  </define>
+  <!-- NAME OF PERSON (STRUCTURED) -->
+  <!--
+    Wrapper element for personal names.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=name
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=name
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=name
+  -->
+  <define name="name">
+    <element name="name">
+      <ref name="name-attlist"/>
+      <choice>
+        <group>
+          <ref name="surname"/>
+          <optional>
+            <ref name="given-names"/>
+          </optional>
+        </group>
+        <ref name="given-names"/>
+      </choice>
+      <optional>
+        <ref name="prefix"/>
+      </optional>
+      <optional>
+        <ref name="suffix"/>
+      </optional>
+    </element>
+  </define>
+  <define name="name-attlist" combine="interleave">
+    <ref name="name-atts"/>
+  </define>
+  <!-- STRING NAME ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <string-name> element
+  -->
+  <!-- NAME OF PERSON (UNSTRUCTURED) -->
+  <!--
+    Wrapper element for personal names where the
+    stricter format of the <name> element cannot
+    be followed. This is a very loose element,
+    allowing data characters, generated text,
+    and any or all of the naming elements.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=string-name
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=string-name
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=string-name
+  -->
+  <define name="string-name">
+    <element name="string-name">
+      <ref name="string-name-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="string-name-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="string-name-attlist" combine="interleave">
+    <ref name="string-name-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PARTS OF A PERSON'S NAME ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- DEGREE(S) ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    <degrees>
+    Design Note: -%just-rendition; begins with
+    an OR bar, so this inline mix begins with
+    an OR bar.
+  -->
+  <define name="degrees-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- DEGREE(S) -->
+  <!--
+    Academic degrees or professional
+    certifications
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=degrees
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=degrees
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=degrees
+  -->
+  <define name="degrees">
+    <element name="degrees">
+      <ref name="degrees-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="degrees-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="degrees-attlist" combine="interleave">
+    <ref name="degrees-atts"/>
+  </define>
+  <!-- GIVEN (FIRST) NAMES ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <given-names>
+  -->
+  <define name="given-names-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- GIVEN (FIRST) NAMES -->
+  <!--
+    Includes all given names for a person, such
+    as the first name, middle names, maiden
+    name if used as part of the married name,
+    etc.)
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=given-names
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=given-names
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=given-names
+  -->
+  <define name="given-names">
+    <element name="given-names">
+      <ref name="given-names-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="given-names-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="given-names-attlist" combine="interleave">
+    <ref name="given-names-atts"/>
+  </define>
+  <!-- SURNAME ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <surname>
+    Design Note: This PE begins with an OR
+    bar because %just-rendition; begins with an
+    OR bar.
+  -->
+  <define name="surname-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- SURNAME -->
+  <!--
+    The surname (family name) of an individual.
+    or the single name if there is only one
+    name, for example, "Cher" or "Pele".
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=surname
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=surname
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=surname
+  -->
+  <define name="surname">
+    <element name="surname">
+      <ref name="surname-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="surname-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="surname-attlist" combine="interleave">
+    <ref name="surname-atts"/>
+  </define>
+  <!-- PREFIX ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <prefix>
+    Design Note: This PE begins with an OR
+    bar because %just-rendition; begins with an
+    OR bar.
+  -->
+  <define name="prefix-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- PREFIX -->
+  <!--
+    Honorifics or other qualifiers that usually
+    precede the surname, for example,  Professor,
+    Rev., President, Senator, Dr., Sir, The
+    Honorable, et al.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=prefix
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=prefix
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=prefix
+  -->
+  <define name="prefix">
+    <element name="prefix">
+      <ref name="prefix-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="prefix-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="prefix-attlist" combine="interleave">
+    <ref name="prefix-atts"/>
+  </define>
+  <!-- SUFFIX ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <suffix>
+    Design Note: This PE begins with an OR bar,
+    it is inside %just-rendition;
+  -->
+  <define name="suffix-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- SUFFIX -->
+  <!--
+    Text used as a suffix to a person's name, for
+    example: Sr., Jr., III, 3rd
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=suffix
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=suffix
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=suffix
+  -->
+  <define name="suffix">
+    <element name="suffix">
+      <ref name="suffix-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="suffix-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="suffix-attlist" combine="interleave">
+    <ref name="suffix-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- EXTERNAL LINK ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- EXTERNAL LINK ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    an <ext-link>
+    Design Note: All inline mixes begin with an
+    OR bar, but since %link-elements; is an inline
+    mix, the OR bar is already there.
+  -->
+  <!-- EXTERNAL LINK -->
+  <!--
+    Link to an external file, such as Medline,
+    Genbank, etc.  Linking may be accomplished
+    using the XLink linking attributes.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=ext-link
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=ext-link
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=ext-link
+  -->
+  <define name="ext-link">
+    <element name="ext-link">
+      <ref name="ext-link-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="ext-link-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="ext-link-attlist" combine="interleave">
+    <ref name="ext-link-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- SHARED STRUCTURAL ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- ATTRIBUTION ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    an attribution
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-phrase; is an
+    inline mix, the OR bar is already there.
+  -->
+  <define name="attrib-elements">
+    <ref name="emphasized-text"/>
+  </define>
+  <!-- ATTRIBUTION -->
+  <!--
+    Source, author, formal thanks, or other
+    information (other than copyright material)
+    concerning the origins of an extract, a poem
+    <verse-group> or similar element.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=attrib
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=attrib
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=attrib
+  -->
+  <define name="attrib">
+    <element name="attrib">
+      <ref name="attrib-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="attrib-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="attrib-attlist" combine="interleave">
+    <ref name="attrib-atts"/>
+  </define>
+  <!-- DEFINITION LIST: DEFINITION MODEL -->
+  <!--
+    Content model for the <def> element, which
+    is used in contexts outside of <def-list>s
+  -->
+  <define name="def-model">
+    <oneOrMore>
+      <ref name="just-para.class"/>
+    </oneOrMore>
+  </define>
+  <!-- DEFINITION LIST: DEFINITION -->
+  <!--
+    Used in two senses:
+    1) The definition, description, or other
+    explanation of the word, phrase, or picture
+    of a 2-part or definition list
+    2) The definition or expansion of an
+    abbreviation or acronym <abbrev>
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=def
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=def
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=def
+  -->
+  <define name="def">
+    <element name="def">
+      <ref name="def-attlist"/>
+      <ref name="def-model"/>
+    </element>
+  </define>
+  <define name="def-attlist" combine="interleave">
+    <ref name="def-atts"/>
+  </define>
+  <!-- LABEL ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <label> element
+  -->
+  <!-- LABEL OF A FIGURE, REFERENCE, ETC. -->
+  <!--
+    The number and any prefix word that comes
+    before, for example, the caption of a Figure,
+    such as "Figure 3." or "Exhibit 2.".
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=label
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=label
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=label
+  -->
+  <define name="label">
+    <element name="label">
+      <ref name="label-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="label-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="label-attlist" combine="interleave">
+    <ref name="label-atts"/>
+  </define>
+  <!-- PRICE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <price> element
+  -->
+  <define name="price-elements">
+    <ref name="emphasis.class"/>
+  </define>
+  <!-- PRICE -->
+  <!--
+    Sale price of a work, typically a book or
+    software package that is being reviewed
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=price
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=price
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=price
+  -->
+  <define name="price">
+    <element name="price">
+      <ref name="price-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="price-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="price-attlist" combine="interleave">
+    <ref name="price-atts"/>
+  </define>
+  <!-- STRUCTURAL TITLE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <title> element
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-phrase; is an
+    inline mix, the OR bar is already there.
+  -->
+  <!-- TITLE -->
+  <!--
+    Heading or title for a structural element
+    such as a Section, Figure, Boxed Text, etc.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=title
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=title
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=title
+  -->
+  <define name="title">
+    <element name="title">
+      <ref name="title-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="struct-title-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="title-attlist" combine="interleave">
+    <ref name="title-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- RELATED ARTICLE ELEMENTS -->
+  <!-- (METADATA AND STRUCTURAL) -->
+  <!-- ============================================================= -->
+  <!-- RELATED ARTICLE ELEMENTS -->
+  <!-- Elements allowed inside <related-article> -->
+  <!-- RELATED ARTICLE INFORMATION -->
+  <!--
+    Wrapper element, used as a container for
+    text links to a related article, possibly
+    accompanied by a very brief description
+    such as "errata (correction)".
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=related-article
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=related-article
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=related-article
+  -->
+  <define name="related-article">
+    <element name="related-article">
+      <ref name="related-article-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="related-article-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="related-article-attlist" combine="interleave">
+    <ref name="related-article-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- SIGNATURE BLOCK ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- SIGNATURE BLOCK ELEMENTS -->
+  <!--
+    Elements to be mixed with data characters
+    inside the content model for the
+    <sig-block> element.
+  -->
+  <!-- SIGNATURE BLOCK -->
+  <!--
+    An area of text and graphic material placed
+    at the end of an article or section to hold
+    the graphical signature or other description
+    of the person responsible for or attesting
+    to the content.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=sig-block
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=sig-block
+  -->
+  <define name="sig-block">
+    <element name="sig-block">
+      <ref name="sig-block-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="sig-block-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="sig-block-attlist" combine="interleave">
+    <ref name="sig-block-atts"/>
+  </define>
+  <!-- SIGNATURE ELEMENTS -->
+  <!--
+    Elements to be mixed with data characters
+    inside the content model for the
+    <sig> element.
+  -->
+  <!-- SIGNATURE -->
+  <!--
+    One contributor signature and associated
+    material (such as a text restatement of the
+    affiliation) inside a signature block.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=sig
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=sig
+  -->
+  <define name="sig">
+    <element name="sig">
+      <ref name="sig-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="sig-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="sig-attlist" combine="interleave">
+    <ref name="sig-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- FRONT MATTER/BACK MATTER ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- ACKNOWLEDGMENTS MODEL -->
+  <!-- Content model for the <ack> element -->
+  <define name="ack-model">
+    <ref name="sec-opt-title-model"/>
+  </define>
+  <!-- ACKNOWLEDGMENTS -->
+  <!--
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=ack
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=ack
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=ack
+  -->
+  <define name="ack">
+    <element name="ack">
+      <ref name="ack-attlist"/>
+      <ref name="ack-model"/>
+    </element>
+  </define>
+  <define name="ack-attlist" combine="interleave">
+    <ref name="ack-atts"/>
+  </define>
+  <!-- BIOGRAPHY MODEL -->
+  <!-- Content model for the <bio> element -->
+  <define name="bio-model">
+    <ref name="sec-opt-title-model"/>
+  </define>
+  <!-- BIOGRAPHY -->
+  <!--
+    Short biography of a person, usually the
+    author
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=bio
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=bio
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=bio
+  -->
+  <define name="bio">
+    <element name="bio">
+      <ref name="bio-attlist"/>
+      <ref name="bio-model"/>
+    </element>
+  </define>
+  <define name="bio-attlist" combine="interleave">
+    <ref name="bio-atts"/>
+  </define>
+  <!-- NOTES MODEL -->
+  <!-- Content model for the <notes> element -->
+  <define name="notes-model">
+    <ref name="sec-opt-title-model"/>
+  </define>
+  <!-- NOTES -->
+  <!--
+    A container element for the notes that may
+    appear at the end of an Article or at the
+    end of a Table, for example, a typical
+    end-of-article note is a "Note in Proof".
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=notes
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=notes
+  -->
+  <define name="notes">
+    <element name="notes">
+      <ref name="notes-attlist"/>
+      <ref name="notes-model"/>
+    </element>
+  </define>
+  <define name="notes-attlist" combine="interleave">
+    <ref name="notes-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- ACCESSIBILITY ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- ALTERNATE TITLE TEXT FOR A FIGURE, ETC. -->
+  <!--
+    Short phrase used to display or pronounce
+    as an alternative to providing the full
+    graphic for accessibility display or
+    graphic-limited web sites or devices. For
+    example, <alt-text> may be used to display
+    "behind" a figure or graphic.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=alt-text
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=alt-text
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=alt-text
+  -->
+  <define name="alt-text">
+    <element name="alt-text">
+      <ref name="alt-text-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <define name="alt-text-attlist" combine="interleave">
+    <ref name="alt-text-atts"/>
+  </define>
+  <!-- LONG DESCRIPTION ELEMENTS -->
+  <!--
+    Elements to be mixed with data characters
+    inside the <long-desc> element
+  -->
+  <!-- LONG DESCRIPTION -->
+  <!--
+    Description or summary of the content of a
+    graphical object, table, or textual object
+    such as a text box, used by some systems to
+    make the object accessible, even to people
+    or systems that cannot read/see/display the
+    object.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=long-desc
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=long-desc
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=long-desc
+  -->
+  <define name="long-desc">
+    <element name="long-desc">
+      <ref name="long-desc-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="long-desc-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="long-desc-attlist" combine="interleave">
+    <ref name="long-desc-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- CUSTOM METADATA ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- CUSTOM METADATA GROUP MODEL -->
+  <!--
+    Content model for the <custom-meta-group>
+    element
+  -->
+  <define name="custom-meta-group-model">
+    <oneOrMore>
+      <ref name="custom-meta"/>
+    </oneOrMore>
+  </define>
+  <!-- CUSTOM METADATA GROUP -->
+  <!--
+    Some DTDs and schemas allow for metadata
+    above and beyond that which can be specified
+    by this DTD. This element is a grouping
+    element used to contain all these additional
+    metadata elements.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=custom-meta-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=custom-meta-group
+  -->
+  <define name="custom-meta-group">
+    <element name="custom-meta-group">
+      <ref name="custom-meta-group-attlist"/>
+      <ref name="custom-meta-group-model"/>
+    </element>
+  </define>
+  <define name="custom-meta-group-attlist" combine="interleave">
+    <ref name="custom-meta-group-atts"/>
+  </define>
+  <!-- CUSTOM METADATA MODEL -->
+  <!--                     Content model for the <custom-meta> element -->
+  <define name="custom-meta-model">
+    <ref name="meta-name"/>
+    <ref name="meta-value"/>
+  </define>
+  <!-- CUSTOM METADATA -->
+  <!--
+    Some DTDs and schemas allow for metadata
+    above and beyond that which can be specified
+    by this DTD. This element is used to capture
+    metadata elements that have not been defined
+    explicitly in the models for this DTD, so
+    that the intellectual content will not be lost.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=custom-meta
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=custom-meta
+  -->
+  <define name="custom-meta">
+    <element name="custom-meta">
+      <ref name="custom-meta-attlist"/>
+      <ref name="custom-meta-model"/>
+    </element>
+  </define>
+  <define name="custom-meta-attlist" combine="interleave">
+    <ref name="custom-meta-atts"/>
+  </define>
+  <!-- METADATA DATA NAME ELEMENTS -->
+  <!--
+    Elements that may be used, along with data
+    characters, inside the <meta-name> element
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-phrase; is an
+    inline mix, the OR bar is already there.
+  -->
+  <!-- METADATA DATA NAME FOR CUSTOM METADATA -->
+  <!--
+    The <custom-meta> element
+    allows for an infinite number of name/value
+    pairs, with few constraints on the length or
+    content of the value. This element contains
+    the name of the metadata field.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=meta-name
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=meta-name
+  -->
+  <define name="meta-name">
+    <element name="meta-name">
+      <ref name="meta-name-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="meta-name-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="meta-name-attlist" combine="interleave">
+    <ref name="meta-name-atts"/>
+  </define>
+  <!-- METADATA DATA VALUE ELEMENTS -->
+  <!--
+    Elements that may be used, along with data
+    characters, inside the <meta-value> element
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-phrase; is an
+    inline mix, the OR bar is already there.
+  -->
+  <!-- METADATA DATA VALUE FOR CUSTOM METADATA -->
+  <!--
+    The <custom-meta> element
+    allows for an infinite number of name/value
+    pairs, with few constraints on the length or
+    content of the value. This element contains
+    the value of the metadata field that is named
+    by the <meta-name> element.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=meta-value
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=meta-value
+  -->
+  <define name="meta-value">
+    <element name="meta-value">
+      <ref name="meta-value-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="meta-value-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="meta-value-attlist" combine="interleave">
+    <ref name="meta-value-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PROCESSING ALTERNATIVES ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- ALTERNATIVES MODEL -->
+  <!--
+    Model for the <alternatives> processing
+    alternatives element
+  -->
+  <define name="alternatives-model">
+    <oneOrMore>
+      <choice>
+        <ref name="alternatives-display.class"/>
+        <ref name="math.class"/>
+      </choice>
+    </oneOrMore>
+  </define>
+  <!-- ALTERNATIVES FOR PROCESSING -->
+  <!--
+    Container element used to hold a group of
+    processing alternatives, for example, a
+    single logical <graphic> that ships in
+    different formats (tif, gif, jpeg) or
+    different resolutions. This element is a
+    physical grouping to contain multiple
+    logically equivalent (substitutable) versions
+    of the same information object.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=alternatives
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=alternatives
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=alternatives
+  -->
+  <define name="alternatives">
+    <element name="alternatives">
+      <ref name="alternatives-attlist"/>
+      <ref name="alternatives-model"/>
+    </element>
+  </define>
+  <define name="alternatives-attlist" combine="interleave">
+    <ref name="alternatives-atts"/>
+  </define>
+  <!-- TEXTUAL FORM ELEMENTS -->
+  <!-- Model for the <textual-form> element -->
+  <!-- TEXTUAL FORM -->
+  <!--
+    Container element (for use only inside
+    <alternatives>) that will hold text and
+    mixed content objects that act as alternatives
+    to, for example, graphics.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=textual-form
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=textual-form
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=textual-form
+  -->
+  <define name="textual-form">
+    <element name="textual-form">
+      <ref name="textual-form-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="textual-form-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="textual-form-attlist" combine="interleave">
+    <ref name="textual-form-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- GENERATED TEXT OR PUNCTUATION -->
+  <!-- ============================================================= -->
+  <!-- X TEXT ATTRIBUTES -->
+  <!-- Attributes for the element <x> -->
+  <define name="x-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="xml:space" a:defaultValue="preserve">
+        <value>preserve</value>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- X ELEMENTS -->
+  <!-- Elements for use inside the <x> element -->
+  <!-- X - GENERATED TEXT AND PUNCTUATION -->
+  <!--
+    A container element to hold punctuation or
+    other generated text, typically when 1) an
+    archive decides not to have any text
+    generated and thus to pre-generate such
+    things as commas or semicolons between
+    keywords or 2) when an archive receives text
+    with <x> tags embedded and wishes to retain
+    them.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=x
+  -->
+  <define name="x">
+    <element name="x">
+      <ref name="x-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="x-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="x-attlist" combine="interleave">
+    <ref name="x-atts"/>
+  </define>
+</grammar>
+<!-- ================== End NISO JATS Common (Shared) Elements === -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-default-classes1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-default-classes1.ent.rng
@@ -1,0 +1,1743 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Default Element Classes Module -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) Default Element Classes Module v1.2 20190208//EN"
+  Delivered as file "JATS-default-classes1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    To declare the Parameter Entities (PEs) used to -->
+<!-- define the default element classes. Classes are -->
+<!-- OR-groups of elements that are defined together -->
+<!-- to be used in mixes and in Element Declarations. -->
+<!---->
+<!-- Note: Since PEs must be declared before they -->
+<!-- are used, this module must be called before all -->
+<!-- content modules that declare elements, and after -->
+<!-- the class customization module (if any). -->
+<!---->
+<!-- CONTAINS:   PEs that define the element classes to be used -->
+<!-- in the JATS DTD Suite modules. -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- August 2004 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- This module is part of the JATS DTD Suite. The -->
+<!-- Suite is a continuation of work done by NCBI, -->
+<!-- Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--              Journal Archiving and Interchange DTD Suite, which -->
+<!-- was originally released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   24. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   23. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   38. INLINE-INDEX - Added the elements <index-term> and
+       <index-term-range-end> to phrase class to add the ability
+       to tag inline (embedded) index terms.
+  
+   38. INLINE-MEDIA - <inline-media> added to all the classes that 
+       contained <inline-graphic>
+  
+   37. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   36. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   35. NEW CLASS FOR TITLES/SOURCES - Made the element <abbrev>
+       into its own class, so it can be added to title elements 
+       without adding milestones.
+  
+   34. INSIDE A TABLE: Added <disp-formula> as a sibling to
+       <graphic>, <list>, etc. as the content of a <table-wrap>
+       that does not contain a <table>. Added <disp-formula> to 
+       simple-intable-display.class.
+  
+   33. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+       =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+   32. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   32. ALI (NISO Access and License Indicators)
+       - Added <ali:license_ref> to license-p.class, as 
+         alternatives inside <license>
+       - Created a new class: license.class to hold the new ALI
+         element <ali:free_to_read>, as an alternative to
+         <license> inside <permissions>. 
+  
+   31. JATS became version "1.1d3" and "v1.1d3 20150301"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   30. ADDED TO REFERENCES - Added the following elements to 
+       %references.class so that it would be allowed inside all 
+       citation types, product, et al.
+        - conf-acronym
+        - data-title (for citing datasets and parts of datasets)
+        - version (for data and software, similar to edition)
+  
+   29. STATEMENT - Added new statement.class, so that statements
+       can be recursive.
+  
+   28. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+   27. ADDRESS ELEMENTS IN NEW CLASSES
+        - Added 3 new elements: <city>, <state>, <postal-code>
+            - address.class
+            - address-line.class
+          which adds then to: address, addr-line, add, collab, 
+          conf-loc, corresp, publisher-loc      
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+   26. NEW <era> ELEMENT
+       Added <era> to date-parts.class
+  
+   25. NEW CLASSES
+       - def-item.class
+       - def-list.class
+       - list-item.class
+       - ref.class for use in <ref-list>
+       - unstructured-kwd-group.class for use in Green
+  
+   24. NEW CODE ELEMENT- Added <code> to
+        - alternatives-display.class
+        - block-display.class
+        - block-display-noalt.class
+        - floats-display.class
+        - inside-chem-struct-wrap.class      
+        - simple-display.class
+        - simple-display-noalt.class
+        - simple-intable-display.class
+  
+   23. INSTITUTION-WRAP ADDED
+       Added the element <institution-wrap> to the following classes:
+        - address.class
+        - address-line.class
+        - recipient-name.class
+        - references.class
+  
+   18. RUBY
+       - Added <ruby> to emphasis class
+       - Added a face-markup class (all the emphasis class except 
+           <ruby>) for use inside <ruby>
+  
+   17. ADDED NEW CLASSES (for new locations for the elements)
+       - abstract.class
+       - kwd-group.class
+       - institution.class
+       - institution-wrap.class
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+   16. CITATION ALTERNATIVES - Added a new element 
+       <citation-alternatives> to the citation.class. The element
+       will hold, for example, a single citation in multiple
+       languages or a single citation tagged as a <mixed-citation>
+       complete with punctuation and spacing and also as an
+       <element-citation> with all punctuation and spacing removed.
+  
+   15. CONTRIBUTOR ID CLASS - Created a new class "contrib-id.class"
+       to hold identifiers for people such as contributors such
+       as <contrib> and <principal-investigator>s. This will hold
+       publishers-specific IDs, ORCIDs, and JST and NII identifiers.
+  
+   14. NESTED KEYWORD CLASS - Created a new class "nested-kwd.class"
+       to hold the kinds of keywords that can be used inside
+       a nested keyword structure.
+  
+   13. COLLAB CLASS - Created a new class "collab.class" to hold 
+       only the element <collab>, for use in the element
+       <collab-alternatives>.
+  
+   12. COLLABORATION ALTERNATIVES - Added <collab-alternatives> to
+       the name.class and -references.class to allow the
+       <collab-alternatives> element to occur anywhere <collab> 
+       was already used.
+  
+   11. STANDARDS CLASS - Created a new class "std.class" to hold all
+       the elements inside the <std> element within citations.
+  
+   10. REFERENCES CLASS - Added <issn-l> to the class.
+  
+    9. NOTHING BUT PARA CLASS - Added a new %nothing-but-para.class;
+       to get rid of PE clashes when the entity %just-para.class; needed
+       to be expanded to include other elements. The nothing-but
+       parameter entity contains <p> and only <p> and should never
+       be changed in a customization. The infelicitously-named PE
+       %just-para.class; can be modified for a customization to include
+       other elements as well.
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    8. Updated the DTD-version attribute to "0.4" 
+  
+    7. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+             http://jats.nlm.nih.gov/0.4.
+  
+    6. NEW CLASS FOR just <alt-text> %small-access.class;
+       Since not everything needs a <long-desc>
+  
+    5. ALTERNATIVES - Added <private-char> so that the alternatives
+       wrapper may be used to hold alternative characters, some as
+       <private-char>, some as <textual-form>, some as <graphic>,
+       etc.
+  
+    4. AFFILIATION ALTERNATIVES - Added the element <aff-alternatives>
+       to hold multiple <aff>s that are representations of a single
+       affiliation, for example, the name of an institution in two
+       languages or two scripts.
+        -  contrib-info.class
+        -  person-group-info.class
+        -  Made a new class %aff-alternatives.class to hold just
+           <aff> and <aff-alternatives> NEW PE
+  
+    3. NAME ALTERNATIVES - Added a new container element to hold
+       alternate versions of a person's name, for example:
+         -  a Roman alphabet transliteration, the Japanese characters,
+            and the Japanese with Ruby annotations or
+         -  the full peerage title of a person as well as a name
+            that is just surname and given names
+         -  a name and a sort version of the name that transliterates
+            the diacritics (such as cedillas and umlauts) to the same
+            character with no diacritic.
+       a. This structure was added to name.class PE
+       b. This structure was added to %investigator-name.class;
+       c. This structure was added to %recipient-name.class;
+       d. This structure was added to %references.class;
+  
+    2. ROLE - Added <role> to %person-group-info.class; thereby
+       adding it to: <person-group> and <sig-block>
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- CLASSES FOR COMMON ELEMENTS (%common.ent;) -->
+<!-- ============================================================= -->
+<!-- ADDRESS CLASS ELEMENTS -->
+<!--
+  Potential element components of an address;
+  not a proper class
+-->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <define name="address.class">
+    <choice>
+      <ref name="addr-line"/>
+      <ref name="city"/>
+      <ref name="country"/>
+      <ref name="fax"/>
+      <ref name="institution"/>
+      <ref name="institution-wrap"/>
+      <ref name="phone"/>
+      <ref name="postal-code"/>
+      <ref name="state"/>
+    </choice>
+  </define>
+  <!-- ADDRESS LINE CLASS ELEMENTS -->
+  <!--
+    Potential element components of an address;
+    line not a proper class
+  -->
+  <define name="address-line.class">
+    <choice>
+      <ref name="city"/>
+      <ref name="country"/>
+      <ref name="fax"/>
+      <ref name="institution"/>
+      <ref name="institution-wrap"/>
+      <ref name="phone"/>
+      <ref name="postal-code"/>
+      <ref name="state"/>
+    </choice>
+  </define>
+  <!-- CITATION CLASS ELEMENTS -->
+  <!--
+    Reference to an external document, as used
+    within, for example, the text of a
+    paragraph
+  -->
+  <!-- CITATION MINUS ALTERNATIVES CLASS ELEMENTS -->
+  <!--
+    All the citation elements except the
+    <citation-alternatives> element.
+  -->
+  <!-- DEFINITION CLASS ELEMENTS -->
+  <!--
+    Definitions and other elements to match
+    with terms and abbreviations
+  -->
+  <define name="def.class">
+    <ref name="def"/>
+  </define>
+  <!-- DEGREE CLASS -->
+  <!--
+    The academic or professional degrees that
+    accompany a person's name
+  -->
+  <define name="degree.class">
+    <ref name="degrees"/>
+  </define>
+  <!-- IDENTIFIER CLASS ELEMENTS -->
+  <!--
+    DOIs and other identifiers are used by
+    publishers at many levels, for example for
+    an <abstract> or a <fig>.
+  -->
+  <define name="id.class">
+    <ref name="object-id"/>
+  </define>
+  <!-- LABEL CLASS -->
+  <!--
+    The label element, used to hold the number
+    or character of a labeled object such as a
+    table or footnote
+  -->
+  <define name="label.class">
+    <ref name="label"/>
+  </define>
+  <!-- NOTE CLASS ELEMENTS -->
+  <!--
+    A note may appear at the end of an Article
+    or at the end of a Table.  For example, a
+    typical end-of-article note is a
+    "Note in Proof".
+  -->
+  <define name="note.class">
+    <ref name="note"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PERSON NAMING ELEMENTS (%common.ent;) -->
+  <!-- ============================================================= -->
+  <!-- COLLAB CLASS -->
+  <!--
+    A class to hold the <collab> element, so that
+    more than on collaboration can be named 
+    inside <collab-alternatives>.
+  -->
+  <define name="collab.class">
+    <ref name="collab"/>
+  </define>
+  <!-- INVESTIGATOR NAMES CLASS -->
+  <!--
+    The elements used to name the personal names
+    for principal investigators.
+  -->
+  <define name="investigator-name.class">
+    <choice>
+      <ref name="name"/>
+      <ref name="name-alternatives"/>
+      <ref name="string-name"/>
+    </choice>
+  </define>
+  <!-- NAMES ALTERNATIVES CLASS -->
+  <!--
+    Elements that may contain the name of a
+    person. These elements act as alternatives
+    inside the <name-alternatives> wrapper, to
+    allow multiple versions of one person's name
+    to be included. These variants are
+    differentiated by attributes: @xml:lang for
+    language, region, language variant, etc. and
+    @specific-use for indexing names,
+    search names, etc.
+  -->
+  <define name="name-alternatives.class">
+    <choice>
+      <ref name="name"/>
+      <ref name="string-name"/>
+    </choice>
+  </define>
+  <!-- NAMES CLASS -->
+  <!--
+    The elements used to name the personal names
+    for individuals and the collaboration names
+    for groups.
+  -->
+  <define name="name.class">
+    <choice>
+      <ref name="anonymous"/>
+      <ref name="collab"/>
+      <ref name="collab-alternatives"/>
+      <ref name="name"/>
+      <ref name="name-alternatives"/>
+      <ref name="string-name"/>
+    </choice>
+  </define>
+  <!-- PERSONAL NAMES CLASS -->
+  <!--
+    The element components of a person's name,
+    for the name of a contributor
+  -->
+  <define name="person-name.class">
+    <choice>
+      <ref name="degrees"/>
+      <ref name="given-names"/>
+      <ref name="prefix"/>
+      <ref name="surname"/>
+      <ref name="suffix"/>
+    </choice>
+  </define>
+  <!-- STRING NAME CLASS -->
+  <!--
+    The element <string-name> is most useful
+    inside citations, but some tag sets restrict
+    its use in metadata. A one-element class.
+  -->
+  <!-- RECIPIENT NAMES CLASS -->
+  <!--
+    The elements used to name the personal names
+    or corporate names (such as Labs) for
+    funded award recipients
+  -->
+  <define name="recipient-name.class">
+    <choice>
+      <ref name="name"/>
+      <ref name="name-alternatives"/>
+      <ref name="institution"/>
+      <ref name="institution-wrap"/>
+      <ref name="string-name"/>
+    </choice>
+  </define>
+  <!-- ============================================================= -->
+  <!-- ARTICLE METADATA CONTRIBUTOR CLASSES; -->
+  <!-- ============================================================= -->
+  <!-- CONTRIBUTOR CLASS -->
+  <!--
+    Sometimes only the <contrib> element needs to
+    be added to a model. Used mostly in the
+    model for <contrib-group>.
+  -->
+  <define name="contrib.class">
+    <ref name="contrib"/>
+  </define>
+  <!-- CONTRIBUTOR GROUP CLASS -->
+  <!--
+    Sometimes only the <contrib-group> element
+    needs to be added to a model.
+  -->
+  <define name="contrib-group.class">
+    <ref name="contrib-group"/>
+  </define>
+  <!-- CONTRIBUTOR IDENTIFIER CLASS -->
+  <!--
+    Names the class to hold unique
+    person identifiers, such as an ORCID or
+    a trusted publisher identifier.
+  -->
+  <define name="contrib-id.class">
+    <ref name="contrib-id"/>
+  </define>
+  <!-- CONTRIBUTOR INFORMATION CLASS -->
+  <!-- Metadata about a contributor -->
+  <!-- CONTRIBUTOR INFORMATION FOR REFERENCES -->
+  <!--
+    The additions and alternatives to a person's
+    name that may be used inside the element
+    <person-group>
+  -->
+  <define name="person-group-info.class">
+    <choice>
+      <ref name="aff"/>
+      <ref name="aff-alternatives"/>
+      <ref name="etal"/>
+      <ref name="role"/>
+    </choice>
+  </define>
+  <!-- ============================================================= -->
+  <!-- ARTICLE METADATA CLASSES %articlemeta.ent; -->
+  <!-- ============================================================= -->
+  <!-- ARTICLE IDENTIFIER CLASS ELEMENTS -->
+  <!--
+    Collected article identifiers for use in
+    various models.
+  -->
+  <define name="article-identifier.class">
+    <choice>
+      <ref name="article-id"/>
+      <ref name="issn"/>
+      <ref name="issn-l"/>
+      <ref name="isbn"/>
+    </choice>
+  </define>
+  <!-- ARTICLE VERSION CLASS ELEMENTS -->
+  <!--
+    Making sure that wherever <article-version>
+    is allowed, <article-version-alternatives>
+    is also allowed.
+  -->
+  <define name="article-version.class">
+    <choice>
+      <ref name="article-version"/>
+      <ref name="article-version-alternatives"/>
+    </choice>
+  </define>
+  <!-- ABSTRACT CLASS ELEMENTS -->
+  <!--
+    Potential element components of an address;
+    not a proper class
+  -->
+  <define name="abstract.class">
+    <ref name="abstract"/>
+  </define>
+  <!-- AFFILIATIONS ALTERNATIVES CLASS -->
+  <!-- The <aff> and <aff-alternatives> elements only -->
+  <define name="aff-alternatives.class">
+    <choice>
+      <ref name="aff"/>
+      <ref name="aff-alternatives"/>
+    </choice>
+  </define>
+  <!-- CONFERENCE CLASS -->
+  <!--
+    The element components of the description
+    of a conference; not a proper class
+  -->
+  <define name="conference.class">
+    <choice>
+      <ref name="conf-date"/>
+      <ref name="conf-name"/>
+      <ref name="conf-num"/>
+      <ref name="conf-loc"/>
+      <ref name="conf-sponsor"/>
+      <ref name="conf-theme"/>
+      <ref name="conf-acronym"/>
+      <ref name="string-conf"/>
+    </choice>
+  </define>
+  <!-- CORRESPONDING AUTHOR CLASS -->
+  <!--
+    Elements associated with the corresponding
+    author
+  -->
+  <define name="corresp.class">
+    <ref name="corresp"/>
+  </define>
+  <!-- DATE CLASS ELEMENTS -->
+  <!-- Dates and other matters of history -->
+  <define name="date.class">
+    <choice>
+      <ref name="date"/>
+      <ref name="string-date"/>
+    </choice>
+  </define>
+  <!-- DATE PARTS CLASS ELEMENTS -->
+  <!-- Components of date-style elements -->
+  <define name="date-parts.class">
+    <choice>
+      <ref name="day"/>
+      <ref name="era"/>
+      <ref name="month"/>
+      <ref name="season"/>
+      <ref name="year"/>
+    </choice>
+  </define>
+  <!-- EVENT CLASS ELEMENTS -->
+  <!-- Dates and other matters of history -->
+  <define name="event.class">
+    <ref name="event"/>
+  </define>
+  <!-- INSTITUTION CLASS ELEMENTS -->
+  <!--
+    To hold an <institution> and its
+    identifiers, so you always can use both
+    together.
+  -->
+  <define name="institution.class">
+    <choice>
+      <ref name="institution"/>
+      <ref name="institution-id"/>
+    </choice>
+  </define>
+  <!-- INSTITUTION CLASS ELEMENTS -->
+  <!--
+    To allow both of the institution elements to 
+    be used anywhere one of them might be needed.
+  -->
+  <define name="institution-wrap.class">
+    <choice>
+      <ref name="institution"/>
+      <ref name="institution-wrap"/>
+    </choice>
+  </define>
+  <!-- JOURNAL IDENTIFIER CLASS ELEMENTS -->
+  <!--
+    The <journal-id> element and any synonyms.
+    Created for use inside <related-article>.
+  -->
+  <define name="journal-id.class">
+    <ref name="journal-id"/>
+  </define>
+  <!-- KEYWORD CLASS ELEMENTS -->
+  <!-- Keywords and any keyword-synonyms -->
+  <define name="kwd.class">
+    <choice>
+      <ref name="kwd"/>
+      <ref name="compound-kwd"/>
+      <ref name="nested-kwd"/>
+    </choice>
+  </define>
+  <!-- KEYWORD GROUP CLASS ELEMENTS -->
+  <!-- The element <kwd-group> for use in models. -->
+  <define name="kwd-group.class">
+    <ref name="kwd-group"/>
+  </define>
+  <!-- LICENSE CLASS ELEMENTS -->
+  <!--
+    The alternatives to <license> that may live
+    inside <permissions>.
+  -->
+  <define name="license.class">
+    <choice>
+      <ref name="ali.free_to_read"/>
+      <ref name="license"/>
+    </choice>
+  </define>
+  <!-- LICENSE PARAGRAPH CLASS ELEMENTS -->
+  <!--
+    To hold the paragraphs and license
+    references that may be inside the element
+    <license>.
+  -->
+  <define name="license-p.class">
+    <choice>
+      <ref name="ali.license_ref"/>
+      <ref name="license-p"/>
+    </choice>
+  </define>
+  <!-- NESTED KEYWORD CLASS ELEMENTS -->
+  <!--
+    The kinds of keywords that can be used inside
+    a nested keyword structure.
+  -->
+  <define name="nested-kwd.class">
+    <choice>
+      <ref name="kwd"/>
+      <ref name="compound-kwd"/>
+    </choice>
+  </define>
+  <!-- PUBLICATION DATE CLASS ELEMENTS -->
+  <!--
+    New element <pub-date-not-available> added to
+    <book-meta> as an alternative to <pub-date>. 
+    The meaning is that a publication date was 
+    (for whatever reason) not available. Presence 
+    of the element says nothing about
+    publication status. The element
+    <pub-date-not-available> was NOT added to 
+    this class, since the new element may
+    occur only once.
+  -->
+  <define name="pub-date.class">
+    <ref name="pub-date"/>
+  </define>
+  <!-- TITLE CLASS -->
+  <!--
+    Title metadata element that can be used
+    to provide article-like metadata about
+    other objects, for example a <supplement>
+  -->
+  <define name="title.class">
+    <ref name="title"/>
+  </define>
+  <!-- UNSTRUCTURED KEYWORD GROUP CLASS -->
+  <!--
+    The <unstructured-kwd-group> element for use 
+    by itself.
+  -->
+  <define name="unstructured-kwd-group.class">
+    <ref name="unstructured-kwd-group"/>
+  </define>
+  <!-- STRING DATE CLASS -->
+  <!-- The <string-date> element for use by itself. -->
+  <define name="string-date.class">
+    <ref name="string-date"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- BACK MATTER CLASSES (%backmatter.ent;) -->
+  <!-- ============================================================= -->
+  <!-- JUST APPENDIX CLASS -->
+  <!-- The appendix and only the appendix -->
+  <define name="app.class">
+    <ref name="app"/>
+  </define>
+  <!-- BACK MATTER CLASS -->
+  <!--
+    Ancillary elements, typically used in the
+    back matter of an article, section, etc.
+  -->
+  <define name="back.class">
+    <choice>
+      <ref name="ack"/>
+      <ref name="app-group"/>
+      <ref name="bio"/>
+      <ref name="fn-group"/>
+      <ref name="glossary"/>
+      <ref name="ref-list"/>
+    </choice>
+  </define>
+  <!-- FRONT MATTER CLASS -->
+  <!--
+    Ancillary elements, typically used in the
+    front matter of an article, book, etc.  .
+  -->
+  <define name="front.class">
+    <choice>
+      <ref name="ack"/>
+      <ref name="bio"/>
+      <ref name="fn-group"/>
+      <ref name="glossary"/>
+    </choice>
+  </define>
+  <!-- FRONT AND BACK CLASS -->
+  <!--
+    Ancillary elements, typically used in the
+    front or back matter of an article
+  -->
+  <define name="front-back.class">
+    <ref name="notes"/>
+  </define>
+  <!-- SECTION BACK MATTER CLASS -->
+  <!--
+    Ancillary elements, typically used in the
+    back matter of a section, etc.
+  -->
+  <define name="sec-back.class">
+    <choice>
+      <ref name="fn-group"/>
+      <ref name="glossary"/>
+      <ref name="ref-list"/>
+    </choice>
+  </define>
+  <!-- JUST SIGNATURE CLASS -->
+  <!--
+    The signature and only the signature <sig>
+    for use inside <sig-block>s
+  -->
+  <define name="sig.class">
+    <ref name="sig"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- CLASSES USED IN DISPLAY ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- ACCESSIBILITY CLASS ELEMENTS -->
+  <!--
+    Elements added to make it easier to process
+    journal articles in ways that are more
+    accessible to people and devices with special
+    needs, for example the visually handicapped.
+      <alt-text> is a short phrase description of
+    an objects, <long-desc> is a more complete
+    description of the content or intent of an
+    object.
+  -->
+  <define name="access.class">
+    <choice>
+      <ref name="alt-text"/>
+      <ref name="long-desc"/>
+    </choice>
+  </define>
+  <!-- SMALL ACCESSIBILITY CLASS ELEMENTS -->
+  <!--
+    Elements added to make it easier to process
+    journal articles in ways that are more
+    accessible to people and devices with special
+    needs, for example the visually handicapped.
+      <alt-text> is a short phrase description of
+    an objects. This class is for use when
+    <long-desc> is just too much.
+  -->
+  <!-- CAPTION DISPLAY ELEMENTS -->
+  <!-- Basic figure display elements -->
+  <define name="caption.class">
+    <ref name="caption"/>
+  </define>
+  <!-- DISPLAY ELEMENT BACK MATTER ELEMENTS -->
+  <!--
+    Miscellaneous stuff (such as photo credits or
+    copyright statement) at the end of a display
+    element such as a figure or a boxed text
+    element such as a sidebar.
+  -->
+  <define name="display-back-matter.class">
+    <choice>
+      <ref name="attrib"/>
+      <ref name="permissions"/>
+    </choice>
+  </define>
+  <!-- ============================================================= -->
+  <!-- DISPLAY ELEMENTS CLASSES -->
+  <!-- ============================================================= -->
+  <!-- DISPLAY CLASS ELEMENTS -->
+  <!--
+    Graphical or other image-related elements.
+    The display elements may occur within
+    the text of a table cell or paragraph
+    although they are typically at the same
+    hierarchical level as a paragraph.
+  -->
+  <define name="block-display.class">
+    <choice>
+      <ref name="address"/>
+      <ref name="alternatives"/>
+      <ref name="array"/>
+      <ref name="boxed-text"/>
+      <ref name="chem-struct-wrap"/>
+      <ref name="code"/>
+      <ref name="fig"/>
+      <ref name="fig-group"/>
+      <ref name="graphic"/>
+      <ref name="media"/>
+      <ref name="preformat"/>
+      <ref name="supplementary-material"/>
+      <ref name="table-wrap"/>
+      <ref name="table-wrap-group"/>
+    </choice>
+  </define>
+  <define name="block-display-noalt.class">
+    <choice>
+      <ref name="address"/>
+      <ref name="array"/>
+      <ref name="boxed-text"/>
+      <ref name="chem-struct-wrap"/>
+      <ref name="code"/>
+      <ref name="fig"/>
+      <ref name="fig-group"/>
+      <ref name="graphic"/>
+      <ref name="media"/>
+      <ref name="preformat"/>
+      <ref name="supplementary-material"/>
+      <ref name="table-wrap"/>
+      <ref name="table-wrap-group"/>
+    </choice>
+  </define>
+  <!-- FLOATING DISPLAY CLASS ELEMENTS -->
+  <!--
+    Block display elements that can take the
+    position attribute, and thus may be floating
+    as opposed to fixed in narrative position in
+    an article. Created for use as the content
+    of <floats-group>.
+  -->
+  <define name="floats-display.class">
+    <choice>
+      <ref name="alternatives"/>
+      <ref name="boxed-text"/>
+      <ref name="chem-struct-wrap"/>
+      <ref name="code"/>
+      <ref name="fig"/>
+      <ref name="fig-group"/>
+      <ref name="graphic"/>
+      <ref name="media"/>
+      <ref name="preformat"/>
+      <ref name="supplementary-material"/>
+      <ref name="table-wrap"/>
+      <ref name="table-wrap-group"/>
+    </choice>
+  </define>
+  <!-- FIGURE DISPLAY ELEMENTS -->
+  <!-- Basic figure display elements -->
+  <define name="fig-display.class">
+    <ref name="fig"/>
+  </define>
+  <!-- INLINE DISPLAY CLASS ELEMENTS -->
+  <!--
+    Non-block display elements that set or
+    display inline with the text
+  -->
+  <define name="inline-display.class">
+    <choice>
+      <ref name="alternatives"/>
+      <ref name="inline-graphic"/>
+      <ref name="inline-media"/>
+      <ref name="private-char"/>
+    </choice>
+  </define>
+  <define name="inline-display-noalt.class">
+    <choice>
+      <ref name="inline-graphic"/>
+      <ref name="inline-media"/>
+      <ref name="private-char"/>
+    </choice>
+  </define>
+  <!-- MOST BASIC DISPLAY ELEMENTS -->
+  <!--
+    Just the few display elements that are
+    simple display objects: a picture, a movie,
+    a sound file.
+  -->
+  <define name="just-base-display.class">
+    <choice>
+      <ref name="alternatives"/>
+      <ref name="graphic"/>
+      <ref name="media"/>
+    </choice>
+  </define>
+  <define name="just-base-display-noalt.class">
+    <choice>
+      <ref name="graphic"/>
+      <ref name="media"/>
+    </choice>
+  </define>
+  <!-- SIMPLE DISPLAY ELEMENTS -->
+  <!--
+    The simplest and most basic of the Display
+    Class elements, which may be allowed in many
+    places, for example, inside other Display
+    Class elements or inside the cell of a
+    Table
+  -->
+  <define name="simple-display.class">
+    <choice>
+      <ref name="alternatives"/>
+      <ref name="array"/>
+      <ref name="code"/>
+      <ref name="graphic"/>
+      <ref name="media"/>
+      <ref name="preformat"/>
+    </choice>
+  </define>
+  <define name="simple-display-noalt.class">
+    <choice>
+      <ref name="array"/>
+      <ref name="code"/>
+      <ref name="graphic"/>
+      <ref name="media"/>
+      <ref name="preformat"/>
+    </choice>
+  </define>
+  <!-- SIMPLE TABLE DISPLAY ELEMENTS -->
+  <!--
+    Very similar to the simple-display.class, but
+    Table Wrappers <table-wrap> should contain
+    <table>s, <oasis:table>s, etc., not
+    arrays.
+  -->
+  <define name="simple-intable-display.class">
+    <choice>
+      <ref name="alternatives"/>
+      <ref name="chem-struct-wrap"/>
+      <ref name="code"/>
+      <ref name="disp-formula"/>
+      <ref name="graphic"/>
+      <ref name="media"/>
+      <ref name="preformat"/>
+    </choice>
+  </define>
+  <!-- INSIDE CHEMICAL STRUCTURE ELEMENTS -->
+  <!--
+    Very similar to the simple-display.class, but
+    for use inside <chem-struct-wrap>, so it
+    can contain both <chem-struct> and
+    <textual-form>
+  -->
+  <define name="inside-chem-struct-wrap.class">
+    <choice>
+      <ref name="alternatives"/>
+      <ref name="chem-struct"/>
+      <ref name="code"/>
+      <ref name="graphic"/>
+      <ref name="media"/>
+      <ref name="preformat"/>
+      <ref name="textual-form"/>
+    </choice>
+  </define>
+  <!-- ALTERNATIVES DISPLAY CLASS ELEMENTS -->
+  <!--
+    Display elements that can be alternatives to
+    each  other inside an alternatives element.
+  -->
+  <define name="alternatives-display.class">
+    <choice>
+      <ref name="array"/>
+      <ref name="chem-struct"/>
+      <ref name="code"/>
+      <ref name="graphic"/>
+      <ref name="inline-graphic"/>
+      <ref name="inline-media"/>
+      <ref name="inline-supplementary-material"/>
+      <ref name="media"/>
+      <ref name="preformat"/>
+      <ref name="private-char"/>
+      <ref name="supplementary-material"/>
+      <ref name="table"/>
+      <ref name="textual-form"/>
+    </choice>
+  </define>
+  <!-- ============================================================= -->
+  <!-- MATH CLASSES (%math.ent;) -->
+  <!-- ============================================================= -->
+  <!--
+    MATHEMATICAL EXPRESSIONS AND FORMULAE
+    CLASS ELEMENTS
+  -->
+  <define name="block-math.class">
+    <choice>
+      <ref name="disp-formula"/>
+      <ref name="disp-formula-group"/>
+    </choice>
+  </define>
+  <!-- CHEMICAL STRUCTURE WRAPPER CLASS -->
+  <define name="chem-struct-wrap.class">
+    <ref name="chem-struct-wrap"/>
+  </define>
+  <!--
+    INLINE MATHEMATICAL EXPRESSIONS MIX CLASS
+    ELEMENTS
+  -->
+  <define name="inline-math.class">
+    <choice>
+      <ref name="chem-struct"/>
+      <ref name="inline-formula"/>
+    </choice>
+  </define>
+  <!-- MATHEMATICAL EXPRESSIONS CLASS ELEMENTS -->
+  <define name="math.class">
+    <choice>
+      <ref name="tex-math"/>
+      <ref name="mml.math"/>
+    </choice>
+  </define>
+  <!-- SIMPLE MATHML CLASS -->
+  <!-- ============================================================= -->
+  <!-- FORMAT CLASSES (%format.ent;) -->
+  <!-- ============================================================= -->
+  <!-- APPEARANCE CLASS ELEMENTS -->
+  <!--
+                        Names those elements (inherited from the
+    XHTML table DTD that are only concerned with
+    appearance, not with structure or content.
+    Use of these elements is to be discouraged.
+  -->
+  <define name="appearance.class">
+    <ref name="hr"/>
+  </define>
+  <!-- FORCED BREAK FORMATTING CLASS ELEMENTS -->
+  <!--
+    Element to force a formatting break such as
+    a line break
+  -->
+  <define name="break.class">
+    <ref name="break"/>
+  </define>
+  <!-- EMPHASIS/RENDITION ELEMENTS -->
+  <!--
+    Elements concerning with marking the location
+    of typographical emphasis (highlighting)
+    DTD Design Note: There are no emphasis
+    elements for <fractur>, <openface> (black
+    board), <script>, etc. because this DTD
+    recommends the use of the STIX extensions
+    to accomplish this, as soon as they are
+    available.
+  -->
+  <define name="emphasis.class">
+    <choice>
+      <ref name="bold"/>
+      <ref name="fixed-case"/>
+      <ref name="italic"/>
+      <ref name="monospace"/>
+      <ref name="overline"/>
+      <ref name="overline-start"/>
+      <ref name="overline-end"/>
+      <ref name="roman"/>
+      <ref name="sans-serif"/>
+      <ref name="sc"/>
+      <ref name="strike"/>
+      <ref name="underline"/>
+      <ref name="underline-start"/>
+      <ref name="underline-end"/>
+      <ref name="ruby"/>
+    </choice>
+  </define>
+  <!-- FACE MARKUP ELEMENTS -->
+  <!--
+    All of the emphasis/rendition elements
+    except <ruby>, for use (initially) inside
+    <ruby> itself.
+  -->
+  <define name="face-markup.class">
+    <choice>
+      <ref name="bold"/>
+      <ref name="fixed-case"/>
+      <ref name="italic"/>
+      <ref name="monospace"/>
+      <ref name="overline"/>
+      <ref name="overline-start"/>
+      <ref name="overline-end"/>
+      <ref name="roman"/>
+      <ref name="sans-serif"/>
+      <ref name="sc"/>
+      <ref name="strike"/>
+      <ref name="underline"/>
+      <ref name="underline-start"/>
+      <ref name="underline-end"/>
+    </choice>
+  </define>
+  <!-- UP/DOWN RENDITION ELEMENTS -->
+  <define name="subsup.class">
+    <choice>
+      <ref name="sub"/>
+      <ref name="sup"/>
+    </choice>
+  </define>
+  <!-- ============================================================= -->
+  <!-- LINK CLASSES (%link.ent;) -->
+  <!-- ============================================================= -->
+  <!-- ADDRESS LINK CLASS ELEMENTS -->
+  <!--
+    Link elements that can be used inside
+    addresses. This is essentially the three
+    generic external links.
+    (Note: in earlier releases, this Parameter
+    Entity was named %address-elements;,
+    although it functioned as a class.)
+  -->
+  <define name="address-link.class">
+    <choice>
+      <ref name="email"/>
+      <ref name="ext-link"/>
+      <ref name="uri"/>
+    </choice>
+  </define>
+  <!-- SIMPLE LINKS/CROSS-REFERENCES CLASS -->
+  <!--
+    The smaller and simpler linking elements
+    that might be inside, for example, a
+    Keyword <kwd>
+  -->
+  <define name="simple-link.class">
+    <choice>
+      <ref name="fn"/>
+      <ref name="target"/>
+      <ref name="xref"/>
+    </choice>
+  </define>
+  <!-- CROSS-REFERENCES CLASS -->
+  <!-- A class just to hold <xref>. -->
+  <!-- ============================================================= -->
+  <!-- FOOTNOTE CLASSES (%link.ent;) -->
+  <!-- ============================================================= -->
+  <!-- FOOTNOTE LINKS CLASS -->
+  <!-- Only the most basic, internal links -->
+  <define name="fn-link.class">
+    <ref name="fn"/>
+  </define>
+  <!-- FOOTNOTE GROUP CLASS -->
+  <!-- Collections of footnotes -->
+  <define name="fn-group.class">
+    <ref name="fn-group"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- RELATED-OBJECT CLASSES -->
+  <!-- ============================================================= -->
+  <!-- JOURNAL ARTICLE LINK CLASS ELEMENTS -->
+  <!--
+    Links used inside journal articles, to point
+    to related material
+  -->
+  <define name="article-link.class">
+    <choice>
+      <ref name="inline-supplementary-material"/>
+      <ref name="related-article"/>
+      <ref name="related-object"/>
+    </choice>
+  </define>
+  <!-- RELATED ARTICLE LINKS CLASS -->
+  <!--
+    For using <related-article> at the paragraph
+    level
+  -->
+  <define name="related-article.class">
+    <choice>
+      <ref name="related-article"/>
+      <ref name="related-object"/>
+    </choice>
+  </define>
+  <!-- ============================================================= -->
+  <!-- LIST CLASSES (%list.ent;) -->
+  <!-- ============================================================= -->
+  <!-- DEFINITION LIST CLASS ELEMENT -->
+  <!--
+    Class for the <list-item>, so it may be used
+    in OR groups.
+  -->
+  <define name="def-list.class">
+    <ref name="def-list"/>
+  </define>
+  <!-- DEFINITION LIST ITEM CLASS ELEMENT -->
+  <!--
+    Class for the <list-item>, so it may be used
+    in OR groups.
+  -->
+  <define name="def-item.class">
+    <ref name="def-item"/>
+  </define>
+  <!-- LIST CLASS ELEMENTS -->
+  <!--
+    All the types of lists that may occur
+    as part of the text, therefore excluding
+    Bibliographic Reference Lists <ref-list>
+  -->
+  <define name="list.class">
+    <choice>
+      <ref name="def-list"/>
+      <ref name="list"/>
+    </choice>
+  </define>
+  <!-- LIST ITEM CLASS ELEMENT -->
+  <!--
+    Class for the <list-item>, so it may be used
+    in OR groups.
+  -->
+  <define name="list-item.class">
+    <ref name="list-item"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PARAGRAPH CLASSES (%para.ent;) -->
+  <!-- ============================================================= -->
+  <!-- REST OF PARAGRAPH CLASS -->
+  <!--
+    Information for the reader that is at the
+    same structural level as a Paragraph.
+    Contains all paragraph-level objects that are
+    not also used inside tables and excepting
+    also the paragraph element itself
+  -->
+  <!-- IN TABLE PARAGRAPH CLASS -->
+  <!--
+    The simpler of the paragraph-level elements
+    that might be found inside a table cell
+  -->
+  <define name="intable-para.class">
+    <choice>
+      <ref name="disp-quote"/>
+      <ref name="speech"/>
+      <ref name="statement"/>
+      <ref name="verse-group"/>
+    </choice>
+  </define>
+  <!-- JUST PARAGRAPH CLASS -->
+  <!--
+    Set by default to hold the just the Paragraph 
+    element, alone. This parameter entity may
+    be redefined by a customization to name any
+    element(s) that the Tag Set wishes to be
+    able to use anywhere within textual elements
+    that a paragraph may occur. Such elements
+    would also need to be added to the PE
+    %block-display.class; and to some individual
+    element PEs.
+  -->
+  <define name="just-para.class">
+    <ref name="p"/>
+  </define>
+  <!-- NOTHING BUT PARAGRAPH CLASS -->
+  <!--
+    To hold the paragraph element <p>, alone.
+    This parameter entity should be left
+    untouched by any customization
+  -->
+  <define name="nothing-but-para.class">
+    <ref name="p"/>
+  </define>
+  <!-- STATEMENT CLASS -->
+  <!--
+    To hold the paragraph element <statement>, 
+    alone.
+  -->
+  <define name="statement.class">
+    <ref name="statement"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PHRASE CLASSES (%phrase.ent;) -->
+  <!-- ============================================================= -->
+  <!-- ABBREVIATION CLASS ELEMENTS -->
+  <!--
+    The element <abbrev>, so it can be added
+    to title elements without adding milestones.
+  -->
+  <define name="abbrev.class">
+    <ref name="abbrev"/>
+  </define>
+  <!-- FUNDING CLASS ELEMENTS -->
+  <!--
+    Small inline elements, that surround a word
+    or phrase in the text to identify pieces of
+    funding metadata. where such material is not
+    pulled out separately but just mixed into
+    text as phrases or sentences within a
+    paragraph. These elements may be used to mark,
+    for example, the <award-id> (such as a grant
+    number or contract number) or the
+    <funding-source> such as the sponsoring
+    organization or trust that awarded the grant.
+  -->
+  <define name="funding.class">
+    <choice>
+      <ref name="award-id"/>
+      <ref name="funding-source"/>
+      <ref name="open-access"/>
+    </choice>
+  </define>
+  <!-- PHRASE CLASS ELEMENTS -->
+  <!--
+    Small inline elements, that surround a word
+    or phrase in the text because the subject
+    (content) should be identified as something
+    special or different
+  -->
+  <define name="phrase.class">
+    <choice>
+      <ref name="abbrev"/>
+      <ref name="index-term"/>
+      <ref name="index-term-range-end"/>
+      <ref name="milestone-end"/>
+      <ref name="milestone-start"/>
+      <ref name="named-content"/>
+      <ref name="styled-content"/>
+    </choice>
+  </define>
+  <!-- STYLED CONTENT CLASS ELEMENTS -->
+  <!--
+    The <styled-content> element alone, so it
+    can be used in places where emphasis is used.
+  -->
+  <!-- PHRASE CONTENT CLASS ELEMENTS -->
+  <!--
+    Small inline elements, that surround a word
+    or phrase in the text because the subject
+    (content) should be identified as something
+    special or different. This class in is
+    intended to be a subset of the  Phrase Class,
+    for use in restricted situations, such as
+    within metadata paragraphs, to record
+    publisher-identified semantic or usage
+    material.
+  -->
+  <define name="phrase-content.class">
+    <choice>
+      <ref name="named-content"/>
+      <ref name="styled-content"/>
+    </choice>
+  </define>
+  <!-- PRICE CLASS ELEMENTS -->
+  <!--
+    Created to hold the <price> element so that
+    it can be selectively added to elements,
+    initially to <product>.
+  -->
+  <define name="price.class">
+    <ref name="price"/>
+  </define>
+  <!-- PRODUCT ELEMENTS -->
+  <!--
+    Created to hold the <product> element so that
+    it can be selectively added to elements,
+    initially to <note>.
+  -->
+  <define name="product.class">
+    <ref name="product"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- REFERENCES CLASSES (references.ent) -->
+  <!-- ============================================================= -->
+  <!-- BIBLIOGRAPHIC REFERENCE (CITATION) CLASS -->
+  <!--
+    The elements that may be included inside a
+    citation (bibliographic reference), either
+    in an all-element-content (<element-citation>)
+    or in a mixed-content citation
+    (<mixed-citation>).
+  -->
+  <define name="references.class">
+    <choice>
+      <ref name="annotation"/>
+      <ref name="article-title"/>
+      <ref name="chapter-title"/>
+      <ref name="collab"/>
+      <ref name="collab-alternatives"/>
+      <ref name="comment"/>
+      <ref name="conf-acronym"/>
+      <ref name="conf-date"/>
+      <ref name="conf-loc"/>
+      <ref name="conf-name"/>
+      <ref name="conf-sponsor"/>
+      <ref name="data-title"/>
+      <ref name="date"/>
+      <ref name="date-in-citation"/>
+      <ref name="day"/>
+      <ref name="edition"/>
+      <ref name="email"/>
+      <ref name="elocation-id"/>
+      <ref name="etal"/>
+      <ref name="ext-link"/>
+      <ref name="fpage"/>
+      <ref name="gov"/>
+      <ref name="institution"/>
+      <ref name="institution-wrap"/>
+      <ref name="isbn"/>
+      <ref name="issn"/>
+      <ref name="issn-l"/>
+      <ref name="issue"/>
+      <ref name="issue-id"/>
+      <ref name="issue-part"/>
+      <ref name="issue-title"/>
+      <ref name="lpage"/>
+      <ref name="month"/>
+      <ref name="name"/>
+      <ref name="name-alternatives"/>
+      <ref name="object-id"/>
+      <ref name="page-range"/>
+      <ref name="part-title"/>
+      <ref name="patent"/>
+      <ref name="person-group"/>
+      <ref name="pub-id"/>
+      <ref name="publisher-loc"/>
+      <ref name="publisher-name"/>
+      <ref name="role"/>
+      <ref name="season"/>
+      <ref name="series"/>
+      <ref name="size"/>
+      <ref name="source"/>
+      <ref name="std"/>
+      <ref name="string-name"/>
+      <ref name="supplement"/>
+      <ref name="trans-source"/>
+      <ref name="trans-title"/>
+      <ref name="uri"/>
+      <ref name="version"/>
+      <ref name="volume"/>
+      <ref name="volume-id"/>
+      <ref name="volume-series"/>
+      <ref name="year"/>
+    </choice>
+  </define>
+  <!-- JUST REFERENCE-LIST CLASS -->
+  <!--
+    The reference list and only the reference
+    list
+  -->
+  <define name="ref-list.class">
+    <ref name="ref-list"/>
+  </define>
+  <!-- STANDARDS CLASS -->
+  <!--
+    The elements that can be used in the mixed
+    content model of a <std>, which is a
+    cited standard inside a citation:
+      source contains the name of the standard
+      pub-id contains the standard designator
+      date elements name the official date
+      std-organization names the standards body
+      named-content takes anything else a 
+        publisher/archive needs (come in 
+        from %rendition-plus.
+  -->
+  <define name="std.class">
+    <choice>
+      <ref name="day"/>
+      <ref name="month"/>
+      <ref name="pub-id"/>
+      <ref name="source"/>
+      <ref name="std-organization"/>
+      <ref name="year"/>
+    </choice>
+  </define>
+  <!-- JUST REFERENCE CLASS -->
+  <!-- The element <ref> for use in models. -->
+  <define name="ref.class">
+    <ref name="ref"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- SECTION CLASS (%section.ent;) -->
+  <!-- ============================================================= -->
+  <!-- SECTION CLASS ELEMENTS -->
+  <!--
+    Information for the reader that is at the
+    same structural level as a Section, which is
+    a headed structure full of smaller elements
+    such as paragraphs.
+  -->
+  <define name="sec.class">
+    <ref name="sec"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- TABLE MODEL CLASSES -->
+  <!-- ============================================================= -->
+  <!-- JUST TABLE CLASS -->
+  <!--
+    To include just a table <table-wrap>
+    element
+  -->
+  <define name="just-table.class">
+    <ref name="table-wrap"/>
+  </define>
+  <!-- TABLE CLASS ELEMENTS -->
+  <!--
+    Elements that will be used to contain the
+    rows and columns inside the Table Wrapper
+    element <table-wrap>.  The following elements
+    can be set up for inclusion:
+      XHTML Table Model    table
+  -->
+  <define name="table.class">
+    <ref name="table"/>
+  </define>
+  <!-- TABLE FOOT CLASS -->
+  <!--
+    Elements to include at the end of a table
+    in the table.
+  -->
+  <define name="table-foot.class">
+    <ref name="table-wrap-foot"/>
+  </define>
+  <!-- TABLE BODY CLASS -->
+  <!--
+    To include just a table <table-wrap>
+    element
+  -->
+  <define name="tbody.class">
+    <ref name="tbody"/>
+  </define>
+</grammar>
+<!-- ================== End Journal Suite Default Classes  ======= -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-default-mixes1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-default-mixes1.ent.rng
@@ -1,0 +1,500 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Default Element Mixes Module -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) Default Element Mixes Module v1.2 20190208//EN"
+  Delivered as file "JATS-default-mixes1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Declares default values for all the element mixes -->
+<!-- used in the content models of the DTD Suite -->
+<!---->
+<!-- Mixes are Or-groups of classes, used in many -->
+<!-- different content models. Mixes should not use -->
+<!-- element names directly, only through classes. -->
+<!---->
+<!-- Note: Since PEs must be declared before they -->
+<!-- are used, this module must be called after the -->
+<!-- customize mixes module (if any). -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- August 2004 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- This module is part of the JATS DTD Suite. The -->
+<!-- Suite is a continuation of work done by NCBI, -->
+<!-- Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--              Journal Archiving and Interchange DTD Suite, which -->
+<!-- was originally released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   14. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   13. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   12. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   11. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   10. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+       =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+    9. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    8. JATS became version "1.1d3" and "v1.1 20150301//EN"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    7. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    6. PARAGRAPH IN TABLE CELL - Added <p> to the contents of
+       table cells, through %inside-cell; (using
+       %nothing-but-para.class;).
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    5. PARA-LEVEL PARAMETER ENTITY CONFLICT - Changed the parameter
+       entity %para-level; to use the PE %nothing-but-para.class;,
+       removing the similar PE "just-para.class;". It is possible to 
+       add element(s) to %just-para.class;, so that the added element(s)
+       may be used everywhere <p> is used. Such elements would also be
+       named in %block-display.class;. This would lead to a conflict
+       in %para-level; if both %just-para.class; and
+       %block-display.class; named <p>. So %just-para.class; is replaced
+       here in %para-level;. This is backward compatible for all XML
+       documents. If a JATS customization has modified %just-para.class;
+       they may need to change their customization to accommodate.
+  
+    4. Updated the DTD-version attribute to "1.0" and the formal
+       public identifier to the date: "v1.0 20120330//EN".
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    3. Updated the DTD-version attribute to "0.4" 
+  
+    2. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+             http://jats.nlm.nih.gov/0.4.
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- ELEMENT MIXES FOR USE IN CONTENT MODELS -->
+<!-- (MIXES ARE COMPOSED USING CLASSES) -->
+<!-- ============================================================= -->
+<!-- SECTION-LEVEL ELEMENTS -->
+<!--
+  Elements that may be used at the same
+  structural level as a Section for example
+  inside the Body <body>
+-->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <define name="sec-level">
+    <ref name="sec.class"/>
+  </define>
+  <!-- ============================================================= -->
+  <!--                     BACK MATTER ELEMENT MIXES(%backmatter.ent;) -->
+  <!-- ============================================================= -->
+  <!-- DOCUMENT BACK MATTER ELEMENTS -->
+  <!--
+    Back Matter Elements used by a full document
+    such as a journal article. This is an element
+    grouping rather than a class. These
+    elements may also appear in the content models
+    of structural elements, such as back matter.
+    (Note: Technically this should have used
+    %sec.class;, but %sec-level; was used in an
+    earlier release and backwards compatibility
+    must be maintained.
+  -->
+  <!-- SECTION BACK MATTER ELEMENTS -->
+  <!--
+    Back matter elements used inside smaller
+    structures, such as sections and sidebars
+  -->
+  <define name="sec-back-matter-mix">
+    <choice>
+      <ref name="front-back.class"/>
+      <ref name="sec-back.class"/>
+    </choice>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PARAGRAPH-LEVEL ELEMENT MIXES -->
+  <!-- ============================================================= -->
+  <!-- PARAGRAPH-LEVEL ELEMENTS -->
+  <!--
+    Elements that may be used at the same
+    structural level as a paragraph, for
+    example inside a Section
+    Note: There a major overlap between this
+    parameter entity and that for the elements
+    that are at the same level as a paragraph.
+    Inline elements appear only inside a
+    paragraph, but block elements such as quotes
+    and lists may appear either within a
+    paragraph or at the same level as a
+    paragraph. This serves a requirement in a
+    repository DTD, since some incoming material
+    will have restricted such elements to only
+    inside a paragraph,  some incoming material
+    will have restricted them to only outside a
+    paragraph and some may allow them in both
+    places. Thus the DTD must allow for them to
+    be in either or both.
+  -->
+  <!-- ============================================================= -->
+  <!-- TABLE ELEMENT MIXES -->
+  <!-- ============================================================= -->
+  <!-- INSIDE TABLE CELL ELEMENTS -->
+  <!--
+    Mixed with #PCDATA inside a table cell, such
+    as a <td> or <th> element in the XHTML table
+    model, the <entry> element in the OASIS CALS
+    table model, etc.  This PE will be used as the
+    value of %Flow.mix;, %paracon;, etc.
+    ### Usage Alert ###
+    Design Note: Inside cell is an exception, an
+    inline mix that does not start with an OR
+    bar. This is because is used within the
+    PE -%Flow.mix;, which is an inline mix
+    defined in the course of the XHTML Table DTD,
+    a DTD not under control of this DTD Suite.
+  -->
+  <!-- INSIDE TABLE WRAPPER ELEMENTS -->
+  <!--
+    Usually a Table Wrapper contains a table,
+    properly tagged with rows and columns, but
+    sometimes, a structure that is labeled as
+    a "table" is actually a list, or two
+    paragraphs.  This Parameter Entity names
+    all the alternatives to table that may
+    occur inside a table wrapper.
+  -->
+  <define name="inside-table-wrap">
+    <choice>
+      <ref name="intable-para.class"/>
+      <ref name="list.class"/>
+      <ref name="simple-intable-display.class"/>
+      <ref name="table.class"/>
+    </choice>
+  </define>
+</grammar>
+<!-- ============================================================= -->
+<!-- INLINE ELEMENT MIXES -->
+<!-- ============================================================= -->
+<!-- EMPHASIS MIX ELEMENTS -->
+<!--
+  Elements that may be used inside most of the
+  emphasis class elements
+  Design Note: Inline mixes begin with an
+  OR bar
+-->
+<!-- JUST RENDITION -->
+<!--
+  Only the simplest of the typographic
+  emphasis elements, as well as subscript and
+  superscript.  Usually used in a model that
+  allows #PCDATA and this restricted mixture.
+  This mix may be stripped down to only
+  subscript and superscript by some, more
+  restrictive DTDs.
+  MAINTENANCE NOTE: This Parameter Entity
+  and the related PE "rendition-plus" have
+  been put in place to restrict the amount of
+  variability that a person modifying the DTD
+  through PE redefinition can achieve. Some
+  elements have been set #PCDATA plus one PE
+  and some have been set to #PCDATA plus the
+  other in an effort to allow designers to
+  modify entire groups of elements, but not
+  to change similar models individually .
+  Design Note: Inline mixes begin with an
+  OR bar
+-->
+<!-- RENDITION MARKUP PLUS -->
+<!--
+  Only the simplest of the typographic
+  emphasis elements, as well as subscript and
+  superscript.  Usually used in a model that
+  allows #PCDATA and this restricted mixture.
+  This mix may be enhanced slightly in some
+  more permissive DTDs, and should always
+  contain at least typographic emphasis,
+  subscript, and superscript.
+  MAINTENANCE NOTE:: This Parameter Entity
+  and the related PE "just-rendition" have
+  been put in place to restrict the amount of
+  variability that a person modifying the DTD
+  through PE redefinition can achieve. Some
+  elements have been set #PCDATA plus one PE
+  and some have been set to #PCDATA plus the
+  other in an effort to allow designers to
+  modify entire groups of elements, but not
+  to individually change similar models.
+  modify entire groups of elements, but not
+  to change similar models individually .
+  Design Note: Inline mixes begin with an
+  OR bar
+-->
+<!-- SIMPLE PHRASE-LEVEL TEXTUAL ELEMENTS -->
+<!--
+  Elements that may be used almost anywhere
+  text is used, for example, inside a title.
+  Simple text plus inline display and math
+  elements. In practice, This is the next step
+  up from "simple-text", adding the links.
+  Design Note: Inline mixes begin with an
+  OR bar
+-->
+<!-- SIMPLE TEXTUAL CONTENT -->
+<!--
+  Elements that may be used inside elements
+  that are really expected to be #PCDATA and
+  not to contain any of these things.
+  Note that there is only inline math and no 
+  links.
+  Simpler even than %simple-phrase;
+  Design Note: Inline mixes begin with an
+  OR bar
+-->
+<!-- ================== End Archiving DTD Mixes Customization ==== -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-display1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-display1.ent.rng
@@ -1,0 +1,1488 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Display Class Elements -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) JATS DTD Suite Display Class Elements v1.2 20190208//EN"
+       Delivered as file "JATS-display1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Describes display-related elements such as -->
+<!-- Figures, Graphics, Math, Chemical Structures, -->
+<!-- Graphics, etc. -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- December 2002 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- This module is part of the JATS DTD Suite. The -->
+<!-- Suite is a continuation of work done by NCBI, -->
+<!-- Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--              Journal Archiving and Interchange DTD Suite, which -->
+<!-- was originally released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd) 
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   24. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   23. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+       =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   22. INLINE-MEDIA - Added new element <inline-media>, which is to
+       <media> as <inline-graphic> is to <graphic>. The content
+       model is the same as <inline-supplementary-material>, in
+       other words there should be content, this is not typically 
+       an empty element. The attributes are the same as <media>,
+       except without @position and @orientation.
+  
+   21. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   20. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   19. INLINE GRAPHIC and PRIVATE-CHAR - Both <inline-graphic> and
+       <private-char> added to elements allowed in <code>.
+  
+   18. INLINE GRAPHIC - Changed from small-access.class to
+       access.class to add <long-desc>
+  
+   17. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+       =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+   16. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   15. JATS became version "1.1d3" and "v1.1d3 20150301"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    14. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+   13. CAPTION ATTRIBUTE - Changed the mechanism by which the @style
+        attribute is associated with the element <caption>. 
+        Previously, the <caption> element's base attributes were 
+        declared in this module and additional attributes (@style) 
+        for it were declared in the XHTML Table Module. The @style 
+        attribute is now declared in this module, and the caption 
+        attributes in the XHTML table model have been set to IGNORE. 
+        This was done to make sure that the attributes available on 
+        the JATS <caption> element did not change based on which table
+        model a JATS user was using.
+  
+   12. CODE - Added the new element <code> (using code-atts and
+       code-elements). Resembles <preformat>, but different
+       semantics.
+  
+   11. CAPTION ATTRIBUTES - Added the new PE %jats-common-atts; to
+       the caption attributes, even though doing so while making
+       no other changes would mean multiple definitions
+       of the @id and @content-type attributes. This would produce a
+       warning, which should be ignored, so see item #13 above.
+  
+   10. GLOBAL ATTRIBUTES - Added the new parameter entity 
+           %jats-common-atts;
+       to every element in this module. This PE adds (for now) the
+       @id attribute and the @xml:base attribute to every element,
+       whether metadata or narrative.
+       Since the @id in this parameter entity is optional, a second
+       parameter entity jats-common-atts-id-required was also added.
+       The two are kept in sync with the jats-base-atts parameter 
+       entity.
+  
+    9. ABSTRACT AND KEYWORDS ON NEW STRUCTURES
+       - Added <abstract> (through %abstract.class;) and <kwd-group> 
+         (through %kwd-group.class;) to the following elements:
+          - chem-struct-wrap (through %chem-struct-wrap-model;)
+          - fig (through %fig-model;)
+          - fig-group (through %fig-group-model;)
+          - graphic (through %graphic-model;)
+          - media (through %media-model;)
+          - table-wrap (through %table-wrap-model;)
+          - table-wrap-group (through %table-wrap-group-model;)
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    8. Updated the DTD-version attribute to "1.0" and the formal
+       public identifier to the date: "v1.0 20120330//EN".
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    7. Updated the DTD-version attribute to "0.4" 
+  
+    6. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+  
+    5. INLINE GRAPHIC - Uses new class %small-access.class; (no
+       model change)
+  
+    4. POSITION ATTRIBUTE - Added the value "background"
+  
+    3. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+       @xml:lang to %display-atts;. If these attribute were
+       already part of the list, deleted them. These attributes were
+       added to:
+        - array       (already there)
+        - boxed-text  (already there)
+        - caption     (already there)
+        - chem-struct (added @xml:lang, @specific-use already)
+        - chem-struct-wrap (added @xml:lang, @specific-use already)
+        - fig (already there)
+        - fig-group (added @xml:lang, @specific-use already there)
+        - graphic (added @xml:lang, @specific-use already there)
+        - inline-graphic (both)
+        - media (added @xml:lang, @specific -use already there)
+        - preformat (already there)
+        - supplementary-material (already there)
+        - table-wrap (already there)
+        - table-wrap-group (added @xml:lang, @specific -use
+            already there)
+  
+    2. GRAPHIC MODEL - Removed the dependency which had both
+       <graphic> and <media> modeled with the same parameter
+       entity %graphic-model;. Created new PE for %media-model;
+       but set it (as the default) to %graphic-model; so that no
+       customization would break. NEW PE
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- ATTRIBUTES FOR MULTIPLE ELEMENTS -->
+<!-- ============================================================= -->
+<!-- DISPLAY ATTRIBUTES -->
+<!--
+  Attributes used for several of the block
+  display elements
+-->
+<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="display-atts">
+    <optional>
+      <attribute name="position" a:defaultValue="float">
+        <choice>
+          <value>anchor</value>
+          <value>background</value>
+          <value>float</value>
+          <value>margin</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="orientation" a:defaultValue="portrait">
+        <choice>
+          <value>portrait</value>
+          <value>landscape</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ============================================================= -->
+  <!-- SPECIFIC ATTRIBUTE LISTS -->
+  <!-- ============================================================= -->
+  <!-- ARRAY ATTRIBUTES -->
+  <!-- Attributes for the <array> element -->
+  <define name="array-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="orientation" a:defaultValue="portrait">
+        <choice>
+          <value>portrait</value>
+          <value>landscape</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- BOXED TEXT ATTRIBUTES -->
+  <!-- Attributes for the <boxed-text> element -->
+  <define name="boxed-text-atts">
+    <ref name="jats-common-atts"/>
+    <ref name="display-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+  </define>
+  <!-- CAPTION ATTRIBUTES -->
+  <!-- Attributes for <caption> element -->
+  <!--
+    The attribute @style was added to make all
+    JATS captions the same as XHTML table
+    captions.
+  -->
+  <define name="caption-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="style"/>
+    </optional>
+  </define>
+  <!-- CHEMICAL STRUCTURE ATTRIBUTES -->
+  <!--
+    Attributes for <chem-struct>, a wrapper
+    around one (typically inline) chemical
+    structure, or one of several structures in
+    a <chem-struct-wrap>
+  -->
+  <define name="chem-struct-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- CHEMICAL STRUCTURE WRAPPER ATTRIBUTES -->
+  <!--
+    Attributes for the <chem-struct-wrap>
+    element, the outer wrapper around one or more
+    block-level chemical structures
+  -->
+  <define name="chem-struct-wrap-atts">
+    <ref name="jats-common-atts"/>
+    <ref name="display-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+  </define>
+  <!-- CODE ATTRIBUTES -->
+  <!-- Attributes for the <code> element -->
+  <define name="code-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="code-type"/>
+    </optional>
+    <optional>
+      <attribute name="code-version"/>
+    </optional>
+    <optional>
+      <attribute name="executable">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="language"/>
+    </optional>
+    <optional>
+      <attribute name="language-version"/>
+    </optional>
+    <optional>
+      <attribute name="platforms"/>
+    </optional>
+    <ref name="display-atts"/>
+    <optional>
+      <attribute name="xml:space" a:defaultValue="preserve">
+        <value>preserve</value>
+      </attribute>
+    </optional>
+  </define>
+  <!-- FIGURE ATTRIBUTES -->
+  <!-- Attributes for Figures <fig> -->
+  <define name="fig-atts">
+    <ref name="jats-common-atts"/>
+    <ref name="display-atts"/>
+    <optional>
+      <attribute name="fig-type"/>
+    </optional>
+  </define>
+  <!-- FIGURE GROUP ATTRIBUTES -->
+  <!-- Attributes for Figure Groups <fig-group> -->
+  <define name="fig-group-atts">
+    <ref name="jats-common-atts"/>
+    <ref name="display-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+  </define>
+  <!-- GRAPHIC ATTRIBUTES -->
+  <!-- Attributes for the <graphic> element -->
+  <define name="graphic-atts">
+    <ref name="jats-common-atts"/>
+    <ref name="display-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="mime-subtype"/>
+    </optional>
+    <optional>
+      <attribute name="mimetype"/>
+    </optional>
+    <ref name="link-atts"/>
+  </define>
+  <!-- INLINE GRAPHIC ATTRIBUTES -->
+  <!--                     Attributes for the <inline-graphic> element -->
+  <define name="inline-graphic-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="baseline-shift"/>
+    </optional>
+    <optional>
+      <attribute name="mimetype"/>
+    </optional>
+    <optional>
+      <attribute name="mime-subtype"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="link-atts"/>
+  </define>
+  <!-- MEDIA ATTRIBUTES -->
+  <!-- Attributes for the <media> element -->
+  <define name="inline-media-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="mimetype"/>
+    </optional>
+    <optional>
+      <attribute name="mime-subtype"/>
+    </optional>
+    <optional>
+      <attribute name="vocab"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="link-atts"/>
+  </define>
+  <!-- MEDIA ATTRIBUTES -->
+  <!-- Attributes for the <media> element -->
+  <define name="media-atts">
+    <ref name="jats-common-atts"/>
+    <ref name="display-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="mimetype"/>
+    </optional>
+    <optional>
+      <attribute name="mime-subtype"/>
+    </optional>
+    <ref name="link-atts"/>
+  </define>
+  <!-- PREFORMATTED TEXT ATTRIBUTES -->
+  <!-- Attributes for the <preformat> element -->
+  <define name="preformat-atts">
+    <ref name="jats-common-atts"/>
+    <ref name="display-atts"/>
+    <optional>
+      <attribute name="preformat-type"/>
+    </optional>
+    <optional>
+      <attribute name="xml:space" a:defaultValue="preserve">
+        <value>preserve</value>
+      </attribute>
+    </optional>
+  </define>
+  <!-- SUPPLEMENTARY INFORMATION ATTRIBUTES -->
+  <!--
+    Attributes for Supplementary Material
+    <supplementary-material>
+  -->
+  <define name="supplementary-material-atts">
+    <ref name="jats-common-atts"/>
+    <ref name="display-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="mimetype"/>
+    </optional>
+    <optional>
+      <attribute name="mime-subtype"/>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- TABLE ATTRIBUTES -->
+  <!-- ============================================================= -->
+  <!-- TABLE WRAPPER ATTRIBUTES -->
+  <!--
+    Attributes to be added to the regular NLM
+    table attributes, for example, when the
+    Elsevier or OASIS Exchange table models are
+    used.
+  -->
+  <define name="other-table-wrap-atts">
+    <empty/>
+  </define>
+  <!-- TABLE GROUP ATTRIBUTES -->
+  <!--
+    Attributes for groups of <table-wrap>
+    elements <table-wrap-group>
+  -->
+  <define name="table-wrap-group-atts">
+    <ref name="jats-common-atts"/>
+    <ref name="display-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <ref name="other-table-wrap-atts"/>
+  </define>
+  <!-- TABLE WRAPPER ATTRIBUTES -->
+  <!--
+    Attributes for the <table-wrap> element,
+    the container for <table>s
+  -->
+  <define name="table-wrap-atts">
+    <ref name="jats-common-atts"/>
+    <ref name="display-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <ref name="other-table-wrap-atts"/>
+  </define>
+  <!-- TABLE WRAP FOOT ATTRIBUTES -->
+  <!-- Attributes for the <table-wrap-foot> element -->
+  <define name="table-wrap-foot-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PARAMETER ENTITIES FOR CONTENT MODELS -->
+  <!-- ============================================================= -->
+  <!-- FIGURE-LIKE CONTENT MODEL -->
+  <!--
+    Content model for the Figure element and any
+    similarly structured elements
+  -->
+  <define name="fig-model">
+    <zeroOrMore>
+      <ref name="id.class"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="caption.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="abstract.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="kwd-group.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="access.class"/>
+        <ref name="address-link.class"/>
+      </choice>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="block-math.class"/>
+        <ref name="chem-struct-wrap.class"/>
+        <ref name="intable-para.class"/>
+        <ref name="just-table.class"/>
+        <ref name="just-para.class"/>
+        <ref name="list.class"/>
+        <ref name="simple-display.class"/>
+      </choice>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="display-back-matter.class"/>
+    </zeroOrMore>
+  </define>
+  <!-- ============================================================= -->
+  <!-- ARRAY ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- ARRAY CONTENT MODEL -->
+  <!-- Content model for the <array> element -->
+  <define name="array-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <zeroOrMore>
+      <choice>
+        <ref name="access.class"/>
+        <ref name="address-link.class"/>
+      </choice>
+    </zeroOrMore>
+    <choice>
+      <zeroOrMore>
+        <ref name="just-base-display.class"/>
+      </zeroOrMore>
+      <ref name="tbody.class"/>
+    </choice>
+    <zeroOrMore>
+      <ref name="display-back-matter.class"/>
+    </zeroOrMore>
+  </define>
+  <!-- ARRAY (SIMPLE TABULAR ARRAY) -->
+  <!--
+    Used to define in-text table-like (columnar)
+    material.  Uses the XHTML table body element
+    or a graphic to express the rows and columns.
+    These have neither labels nor captions,
+    arrays with labels and captions are table
+    wrappers.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=array
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=array
+  -->
+  <define name="array">
+    <element name="array">
+      <ref name="array-attlist"/>
+      <ref name="array-model"/>
+    </element>
+  </define>
+  <define name="array-attlist" combine="interleave">
+    <ref name="array-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- BOXED TEXT ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- BOXED TEXT MODEL -->
+  <!--
+    Complete content model for the boxed text
+    element <boxed-text>
+  -->
+  <define name="boxed-text-model">
+    <zeroOrMore>
+      <ref name="id.class"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="sec-meta"/>
+    </optional>
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="caption"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="para-level"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="sec-level"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="sec-back-matter-mix"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="display-back-matter.class"/>
+    </zeroOrMore>
+  </define>
+  <!-- BOXED TEXT -->
+  <!--
+    Textual material that is outside the flow
+    of the narrative text, for example, a
+    sidebar, marginalia, text insert, caution or
+    note box, etc.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=boxed-text
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=boxed-text
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=boxed-text
+  -->
+  <define name="boxed-text">
+    <element name="boxed-text">
+      <ref name="boxed-text-attlist"/>
+      <ref name="boxed-text-model"/>
+    </element>
+  </define>
+  <define name="boxed-text-attlist" combine="interleave">
+    <ref name="boxed-text-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- CHEMICAL STRUCTURE ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- CHEMICAL STRUCTURE WRAPPER MODEL -->
+  <!--
+    Content model for the Chemical Structure
+    Wrapper <chem-struct-wrap> element
+  -->
+  <define name="chem-struct-wrap-model">
+    <zeroOrMore>
+      <ref name="id.class"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="caption.class"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="abstract.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="kwd-group.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="access.class"/>
+        <ref name="address-link.class"/>
+      </choice>
+    </zeroOrMore>
+    <oneOrMore>
+      <ref name="inside-chem-struct-wrap.class"/>
+    </oneOrMore>
+    <zeroOrMore>
+      <ref name="display-back-matter.class"/>
+    </zeroOrMore>
+  </define>
+  <!-- CHEMICAL STRUCTURE WRAPPER -->
+  <!--
+    A chemical expression, reaction, equation,
+    etc. that is set apart within the text.
+    These may be numbered.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=chem-struct-wrap
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=chem-struct-wrap
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=chem-struct-wrap
+  -->
+  <define name="chem-struct-wrap">
+    <element name="chem-struct-wrap">
+      <ref name="chem-struct-wrap-attlist"/>
+      <ref name="chem-struct-wrap-model"/>
+    </element>
+  </define>
+  <define name="chem-struct-wrap-attlist" combine="interleave">
+    <ref name="chem-struct-wrap-atts"/>
+  </define>
+  <!-- CHEMICAL STRUCTURE ELEMENTS -->
+  <!--
+    Those elements that may mix with the data
+    characters inside a Chemical Structure
+    <chem-struct>
+  -->
+  <!-- CHEMICAL STRUCTURE MODEL -->
+  <!--
+    A chemical expression, reaction, equation,
+    etc. that is set apart within the text
+  -->
+  <define name="chem-struct-model">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="chem-struct-elements"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <!-- CHEMICAL STRUCTURE (DISPLAY) -->
+  <!--
+    A chemical expression, reaction, equation,
+    etc. that is set apart within the text.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=chem-struct
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=chem-struct
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=chem-struct
+  -->
+  <define name="chem-struct">
+    <element name="chem-struct">
+      <ref name="chem-struct-attlist"/>
+      <ref name="chem-struct-model"/>
+    </element>
+  </define>
+  <define name="chem-struct-attlist" combine="interleave">
+    <ref name="chem-struct-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- FIGURE ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- FIGURE GROUP MODEL -->
+  <!-- Content model for a Figure Group element -->
+  <define name="fig-group-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="caption.class"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="abstract.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="kwd-group.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="access.class"/>
+        <ref name="address-link.class"/>
+      </choice>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="fig-display.class"/>
+        <ref name="just-base-display.class"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <!-- FIGURE GROUP -->
+  <!--
+    Used for a group of figures that must be
+    displayed together
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=fig-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=fig-group
+  -->
+  <define name="fig-group">
+    <element name="fig-group">
+      <ref name="fig-group-attlist"/>
+      <ref name="fig-group-model"/>
+    </element>
+  </define>
+  <define name="fig-group-attlist" combine="interleave">
+    <ref name="fig-group-atts"/>
+  </define>
+  <!-- FIGURE -->
+  <!--
+    A block of graphic or textual material that
+    is identified as a "Figure", usually with
+    a caption and a label such as "Figure" or
+    "Figure 3.".The content of a Figure need not
+    be graphical in nature,.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=fig
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=fig
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=fig
+  -->
+  <define name="fig">
+    <element name="fig">
+      <ref name="fig-attlist"/>
+      <ref name="fig-model"/>
+    </element>
+  </define>
+  <define name="fig-attlist" combine="interleave">
+    <ref name="fig-atts"/>
+  </define>
+  <!-- CAPTION BODY PARTS -->
+  <!--
+    Elements that may be included in the body of
+    the <caption> element
+  -->
+  <define name="caption-body-parts">
+    <zeroOrMore>
+      <ref name="just-para.class"/>
+    </zeroOrMore>
+  </define>
+  <!-- CAPTION MODEL -->
+  <!-- Content model for the <caption> element -->
+  <define name="caption-model">
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <ref name="caption-body-parts"/>
+  </define>
+  <!-- CAPTION OF A FIGURE, TABLE, ETC. -->
+  <!--
+    Wrapper element for the textual description
+    associated with a figure, table, etc. In
+    some source document captions, the first
+    sentence is set off from the rest as a title.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=caption
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=caption
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=caption
+  -->
+  <define name="caption">
+    <element name="caption">
+      <ref name="caption-attlist"/>
+      <ref name="caption-model"/>
+    </element>
+  </define>
+  <define name="caption-attlist" combine="interleave">
+    <ref name="caption-atts"/>
+  </define>
+  <!-- ELEM  title        Defined in %common.ent; -->
+  <!-- ELEM  p            Defined in %common.ent; -->
+  <!-- ============================================================= -->
+  <!-- THE GRAPHIC AND MEDIA OBJECT ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- GRAPHIC MODEL -->
+  <!-- Content model for the <graphic> element -->
+  <define name="graphic-model">
+    <zeroOrMore>
+      <choice>
+        <ref name="access.class"/>
+        <ref name="abstract.class"/>
+        <ref name="address-link.class"/>
+        <ref name="caption.class"/>
+        <ref name="id.class"/>
+        <ref name="kwd-group.class"/>
+        <ref name="label.class"/>
+        <ref name="display-back-matter.class"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <!-- GRAPHIC -->
+  <!--
+    An external file that holds a picture,
+    illustration, etc., usually as some form of
+    binary object. The "content" of the <graphic>
+    element is not the object, but merely
+    information about the object. The "href"
+    attribute points to the file containing
+    the object.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=graphic
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=graphic
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=graphic
+  -->
+  <define name="graphic">
+    <element name="graphic">
+      <ref name="graphic-attlist"/>
+      <ref name="graphic-model"/>
+    </element>
+  </define>
+  <define name="graphic-attlist" combine="interleave">
+    <ref name="graphic-atts"/>
+  </define>
+  <!-- INLINE MEDIA MODEL -->
+  <!-- Content model for the <inline-media> element -->
+  <define name="inline-media-elements">
+    <choice>
+      <ref name="access.class"/>
+      <ref name="address-link.class"/>
+      <ref name="emphasis.class"/>
+      <ref name="phrase-content.class"/>
+      <ref name="subsup.class"/>
+    </choice>
+  </define>
+  <!-- INLINE MEDIA OBJECT -->
+  <!--
+    An external file that holds a media object
+      to be used inline, such as a pronunciation
+      file. "content" of the <media> element is not 
+      the object, but merely information about the
+      object or the word to be linked. The "href" 
+      attribute points to the file containing the 
+      object.
+      Details at:                      http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=inline-media
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=inline-media
+      http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=inline-media
+  -->
+  <define name="inline-media">
+    <element name="inline-media">
+      <ref name="inline-media-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="inline-media-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="inline-media-attlist" combine="interleave">
+    <ref name="inline-media-atts"/>
+  </define>
+  <!-- MEDIA MODEL -->
+  <!-- Content model for the <media> element -->
+  <define name="media-model">
+    <zeroOrMore>
+      <choice>
+        <ref name="access.class"/>
+        <ref name="abstract.class"/>
+        <ref name="address-link.class"/>
+        <ref name="caption.class"/>
+        <ref name="id.class"/>
+        <ref name="kwd-group.class"/>
+        <ref name="label.class"/>
+        <ref name="display-back-matter.class"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <!-- MEDIA OBJECT -->
+  <!--
+    An external file that holds a media object,
+    such as an animation or a movie. The
+    "content" of the <media> element is not the
+    object, but merely information about the
+    object. The "href" attribute points to the
+    file containing the object.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=media
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=media
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=media
+  -->
+  <define name="media">
+    <element name="media">
+      <ref name="media-attlist"/>
+      <ref name="media-model"/>
+    </element>
+  </define>
+  <define name="media-attlist" combine="interleave">
+    <ref name="media-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- INLINE GRAPHIC -->
+  <!-- ============================================================= -->
+  <!-- INLINE GRAPHIC MODEL -->
+  <!--
+    Content model for the <inline-graphic>
+    element
+  -->
+  <define name="inline-graphic-model">
+    <zeroOrMore>
+      <ref name="access.class"/>
+    </zeroOrMore>
+  </define>
+  <!-- INLINE GRAPHIC -->
+  <!--
+    A small graphic such as an icon or a small
+    picture symbol that is displayed or set
+    in the same line as the text.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=inline-graphic
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=inline-graphic
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=inline-graphic
+  -->
+  <define name="inline-graphic">
+    <element name="inline-graphic">
+      <ref name="inline-graphic-attlist"/>
+      <ref name="inline-graphic-model"/>
+    </element>
+  </define>
+  <define name="inline-graphic-attlist" combine="interleave">
+    <ref name="inline-graphic-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PRESERVE THE WHITESPACE TEXT -->
+  <!-- ============================================================= -->
+  <!-- PREFORMATTED TEXT ELEMENTS -->
+  <!--
+    Elements that may be used, along with data
+    characters, inside the content model for the
+    <preformat> element
+  -->
+  <!-- PREFORMAT MODEL -->
+  <!-- Content model for the <preformat> element -->
+  <define name="preformat-model">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="preformat-elements"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <!-- PREFORMATTED TEXT -->
+  <!--
+    Used for preformatted text such as
+    computer code in which whitespace, such as
+    tabs, line feeds, and spaces, should be
+    preserved.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=preformat
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=preformat
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=preformat
+  -->
+  <define name="preformat">
+    <element name="preformat">
+      <ref name="preformat-attlist"/>
+      <ref name="preformat-model"/>
+    </element>
+  </define>
+  <define name="preformat-attlist" combine="interleave">
+    <ref name="preformat-atts"/>
+  </define>
+  <!-- CODE ELEMENTS -->
+  <!--
+    Elements that may be used, along with data
+    characters, inside the content model for the
+    <code> element
+  -->
+  <define name="code-elements">
+    <choice>
+      <ref name="address-link.class"/>
+      <ref name="emphasis.class"/>
+      <ref name="inline-display-noalt.class"/>
+      <ref name="phrase.class"/>
+      <ref name="simple-link.class"/>
+      <ref name="subsup.class"/>
+    </choice>
+  </define>
+  <!-- CODE TEXT -->
+  <!--
+    A container element for technical content
+    such as programming language code, 
+    pseudo-code, schemas, or a markup fragment.
+      This material may be preformatted text, with
+    or without emphasis, or it may be an external
+    link to a binary executable file.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=code
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=code
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=code
+  -->
+  <define name="code">
+    <element name="code">
+      <ref name="code-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="code-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="code-attlist" combine="interleave">
+    <ref name="code-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- SUPPLEMENTARY MATERIAL -->
+  <!-- ============================================================= -->
+  <!-- SUPPLEMENTARY MATERIAL MODEL -->
+  <!--
+    Content model for the
+    <supplementary-material> element
+  -->
+  <define name="supplementary-material-model">
+    <ref name="fig-model"/>
+  </define>
+  <!-- SUPPLEMENTARY MATERIAL -->
+  <!--
+    Additional data files that contain
+    information directly supportive of the item,
+    for example, an audio clip, movie, database,
+    spreadsheet, applet, or other external file.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=supplementary-material
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=supplementary-material
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=supplementary-material
+  -->
+  <define name="supplementary-material">
+    <element name="supplementary-material">
+      <ref name="supplementary-material-attlist"/>
+      <ref name="supplementary-material-model"/>
+    </element>
+  </define>
+  <define name="supplementary-material-attlist" combine="interleave">
+    <ref name="supplementary-material-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- TABLE ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- TABLE WRAPPER GROUP MODEL -->
+  <!--
+    Content model for the <table-wrap-group>
+    element
+  -->
+  <define name="table-wrap-group-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="caption"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="abstract.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="kwd-group.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="access.class"/>
+        <ref name="address-link.class"/>
+      </choice>
+    </zeroOrMore>
+    <oneOrMore>
+      <ref name="just-table.class"/>
+    </oneOrMore>
+  </define>
+  <!-- TABLE WRAPPER GROUP -->
+  <!--
+    Used as a wrapper tag to contain a group of
+    tables that must be displayed together
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=table-wrap-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=table-wrap-group
+  -->
+  <define name="table-wrap-group">
+    <element name="table-wrap-group">
+      <ref name="table-wrap-group-attlist"/>
+      <ref name="table-wrap-group-model"/>
+    </element>
+  </define>
+  <define name="table-wrap-group-attlist" combine="interleave">
+    <ref name="table-wrap-group-atts"/>
+  </define>
+  <!-- TABLE WRAPPER CONTENT MODEL -->
+  <!--
+    Content model for the container element that
+    surrounds the standard table models for row
+    and columns.
+  -->
+  <define name="table-wrap-model">
+    <zeroOrMore>
+      <ref name="id.class"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="caption.class"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="abstract.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="kwd-group.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="access.class"/>
+        <ref name="address-link.class"/>
+      </choice>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="inside-table-wrap"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="table-foot.class"/>
+        <ref name="display-back-matter.class"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <!-- TABLE WRAPPER -->
+  <!--
+    Used to hold a complete table, that is, not
+    only the rows and columns that make up a
+    table, but also the table captions, list
+    of table footnotes, alternative descriptions
+    for accessibility, etc.  Within the Table
+    Wrapper element, the row and column tags that
+    describe the table cells are defined by one
+    of the popular "standard" table models, for
+    example the XHTML table model, OASIS Exchange
+    (CALS) table model, of the Elsevier Science
+    Full Length Article table body <tblbody>
+    model, et al.)
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=table-wrap
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=table-wrap
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=table-wrap
+  -->
+  <define name="table-wrap">
+    <element name="table-wrap">
+      <ref name="table-wrap-attlist"/>
+      <ref name="table-wrap-model"/>
+    </element>
+  </define>
+  <define name="table-wrap-attlist" combine="interleave">
+    <ref name="table-wrap-atts"/>
+  </define>
+  <!-- TABLE WRAP FOOTER MODEL -->
+  <!--
+    Content model for the <table-wrap-foot>
+    element
+  -->
+  <!-- TABLE WRAP FOOTER -->
+  <!--
+    Wrapper element to hold a group of footnotes
+    or other notes or general paragraphs at the
+    end of a table.  Not the same as the
+    Table Foot <tfoot>, which contains rows
+    and columns like the rest of the table.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=table-wrap-foot
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=table-wrap-foot
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=table-wrap-foot
+  -->
+  <define name="table-wrap-foot">
+    <element name="table-wrap-foot">
+      <ref name="table-wrap-foot-attlist"/>
+      <ref name="table-wrap-foot-model"/>
+    </element>
+  </define>
+  <define name="table-wrap-foot-attlist" combine="interleave">
+    <ref name="table-wrap-foot-atts"/>
+  </define>
+</grammar>
+<!-- ================== End Display Class Module ================= -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-format1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-format1.ent.rng
@@ -1,0 +1,1203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Formatting Element Classes -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) JATS DTD Suite Formatting Element Classes v1.2 20190208//EN"
+   Delivered as file "JATS-format1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Elements concerned with rendition of output, for -->
+<!-- example printing on a page or display on a screen -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- December 2002 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- This module is part of the JATS DTD Suite. The -->
+<!-- Suite is a continuation of work done by NCBI, -->
+<!-- Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--              Journal Archiving and Interchange DTD Suite, which -->
+<!-- was originally released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   19. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   18. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   17. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   16. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   15. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+       =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+   14. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   13. JATS became version "1.1d3" and "v1.1 20150301//EN"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    12. RUBY MODEL CHANGED TO MATCH HTML5
+        - changed the Ruby content model to allow only a single
+          Ruby annotation on a single Ruby base:
+              (rb, rt+)
+          The Ruby textual annotation may NOT take a pair of
+          Ruby parentheses. This is a simplification of the
+          HTML5 model:
+             (rb, (rt | (rp, rt, rp)) )
+          The simplification does not allow Ruby parenthesis.
+          Archiving and BITS both use the full model above.
+  
+    11. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+   10. RUBY ANNOTATIONS - Added new elements for:
+        - <ruby> The Ruby wrapper element, which contains the base
+            text and the annotation.
+        - <rb> Ruby Base text, acts in the same manner as face markup,
+          surrounding some text in the narrative.
+        - <rt> Ruby Text, the annotation that modifies a piece of
+           the narrative text, frequently typeset above the text.
+  
+    9. GLOBAL ATTRIBUTES - Added the new parameter entity 
+           %jats-common-atts;
+       to every element in this module. This PE adds (for now) the
+       @id attribute and the @xml:base attribute to every element,
+       whether metadata or narrative.
+       Since the @id in this parameter entity is optional, a second
+       parameter entity jats-common-atts-id-required was also added.
+       The two are kept in sync with the jats-base-atts parameter 
+       entity.
+       This added a new attribute list to:
+        - break 
+        - hr      
+        - rp               
+  
+    8. ADDED NEW ELEMENT <fixed-case> 
+       - defined as meaning that the case of the content is not to
+         change, even if the content around it is styled to all
+         upper case or all lower. For example "PhD".
+  
+    7. ADDED NEW ATTRIBUTE - @toggle added to:
+       - bold, italic (default="yes"), monospace, overline, 
+         roman (default="no"), sans-serif, sc, strike, and underline.
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    6. Updated the DTD-version attribute to "1.0" and the formal
+       public identifier to the date: "v1.0 20120330//EN".
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    5. Updated the DTD-version attribute to "0.4" 
+  
+    4. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+             http://jats.nlm.nih.gov/0.4.
+  
+    3. @SPECIAL-USE - Added the attribute @special-use to the
+       all 14 formatting (emphasis) elements. This includes all the
+       ones listed in 2. below as well as:
+         - sub             sub-atts  
+         - sup             sup-atts
+         - overline        overline-atts
+         - overline-start  overline-start-atts
+         - overline-end    overline-end-atts
+         - underline       underline-atts
+         - underline-start underline-start-atts
+         - underline-end   underline-end-atts
+  
+    2. PEs FOR ATTLISTS - Added parameter entity redefinitions for the
+       attribute lists of the following elements: (no attributes or
+       values were changed)
+         - bold            bold-atts       NEW PE
+         - italic          italic-atts     NEW PE
+         - monospace       monospace-atts  NEW PE
+         - roman           roman-atts      NEW PE
+         - sans-serif      sans-serif-atts NEW PE
+         - sc              sc-atts         NEW PE
+         - strike          strike-atts     NEW PE
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- PARAMETER ENTITIES FOR ATTRIBUTE LISTS -->
+<!-- ============================================================= -->
+<!-- BOLD ATTRIBUTES -->
+<!-- Attributes for the <bold> element -->
+<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="bold-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="toggle">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- BREAK ATTRIBUTES -->
+  <!-- Attributes for the <break> element -->
+  <define name="break-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- FIXED CASE ATTRIBUTES -->
+  <!-- Attributes for the <fixed-case> element -->
+  <define name="fixed-case-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- HORIZONTAL RULE ATTRIBUTES -->
+  <!-- Attributes for the <hr> element -->
+  <define name="hr-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- ITALIC ATTRIBUTES -->
+  <!-- Attributes for the <italic> element -->
+  <define name="italic-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="toggle" a:defaultValue="yes">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- MONOSPACE ATTRIBUTES -->
+  <!-- Attributes for the <bold> element -->
+  <define name="monospace-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="toggle">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- OVERLINE START ATTRIBUTES -->
+  <!-- Attributes for the <overline> element -->
+  <define name="overline-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="toggle">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- OVERLINE START ATTRIBUTES -->
+  <!--                     Attributes for the <overline-start> element -->
+  <define name="overline-start-atts">
+    <ref name="jats-common-atts-id-required"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- OVERLINE END ATTRIBUTES -->
+  <!-- Attributes for the <overline-end> element -->
+  <define name="overline-end-atts">
+    <ref name="jats-common-atts"/>
+    <attribute name="rid">
+      <data type="IDREF"/>
+    </attribute>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- ROMAN ATTRIBUTES -->
+  <!-- Attributes for the <roman> element -->
+  <define name="roman-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="toggle" a:defaultValue="no">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- RUBY BASE ATTRIBUTES -->
+  <!-- Attributes for the <rb> element -->
+  <define name="rb-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- RUBY PARENTHESIS ATTRIBUTES -->
+  <!-- Attributes for the <rp> element -->
+  <define name="rp-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- RUBY TEXTUAL ANNOTATION ATTRIBUTES -->
+  <!-- Attributes for the <rt> element -->
+  <define name="rt-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- RUBY ATTRIBUTES -->
+  <!-- Attributes for the <ruby> element -->
+  <define name="ruby-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- SANS SERIF ATTRIBUTES -->
+  <!-- Attributes for the <sans-serif> element -->
+  <define name="sans-serif-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="toggle">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- SMALL CAPS ATTRIBUTES -->
+  <!-- Attributes for the <sc> element -->
+  <define name="sc-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="toggle">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- STRIKE THROUGH ATTRIBUTES -->
+  <!-- Attributes for the <strike> element -->
+  <define name="strike-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="toggle">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- SUBSCRIPT ATTRIBUTES -->
+  <!-- Attributes for the subscript <sub> element -->
+  <define name="sub-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="arrange">
+        <choice>
+          <value>stack</value>
+          <value>stagger</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- SUPERSCRIPT ATTRIBUTES -->
+  <!--
+    Attributes for the superscript <sup>
+    element
+  -->
+  <define name="sup-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="arrange">
+        <choice>
+          <value>stack</value>
+          <value>stagger</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- UNDERLINE ATTRIBUTES -->
+  <!-- Attributes for the <underline> element -->
+  <define name="underline-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="toggle">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="underline-style"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- UNDERLINE START ATTRIBUTES -->
+  <!--
+    Attributes for the <underline-start>
+    element
+  -->
+  <define name="underline-start-atts">
+    <ref name="jats-common-atts-id-required"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- UNDERLINE END ATTRIBUTES -->
+  <!-- Attributes for the <underline-end> element -->
+  <define name="underline-end-atts">
+    <ref name="jats-common-atts"/>
+    <attribute name="rid">
+      <data type="IDREF"/>
+    </attribute>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- ============================================================= -->
+  <!-- APPEARANCE CLASS ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- HORIZONTAL RULE -->
+  <!--
+    Defined to allow the user to specify an
+    explicit (non machine-generated) rule.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=hr
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=hr
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=hr
+  -->
+  <define name="hr">
+    <element name="hr">
+      <ref name="hr-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="hr-attlist" combine="interleave">
+    <ref name="hr-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- BREAK CLASS ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- LINE BREAK -->
+  <!--
+    Defined to allow the user to specify an
+    explicit (non machine-generated) line break.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=break
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=break
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=break
+  -->
+  <define name="break">
+    <element name="break">
+      <ref name="break-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="break-attlist" combine="interleave">
+    <ref name="break-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- EMPHASIS/RENDITION CLASS ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- BOLD -->
+  <!--
+    Used to mark text that should appear in bold
+    face type for print or display
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=bold
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=bold
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=bold
+  -->
+  <define name="bold">
+    <element name="bold">
+      <ref name="bold-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="emphasized-text"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="bold-attlist" combine="interleave">
+    <ref name="bold-atts"/>
+  </define>
+  <!-- FIXED CASE -->
+  <!--
+    Used to mark text in which the case of the 
+    content should not be changed, even if the 
+    content around it is styled to all
+    upper case or all lower. For example "PhD".
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=fixed-case
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=fixed-case
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=fixed-case
+  -->
+  <define name="fixed-case">
+    <element name="fixed-case">
+      <ref name="fixed-case-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="emphasized-text"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="fixed-case-attlist" combine="interleave">
+    <ref name="fixed-case-atts"/>
+  </define>
+  <!-- ITALIC -->
+  <!--
+    Used to mark text that should appear in
+    italic type on output.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=italic
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=italic
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=italic
+  -->
+  <define name="italic">
+    <element name="italic">
+      <ref name="italic-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="emphasized-text"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="italic-attlist" combine="interleave">
+    <ref name="italic-atts"/>
+  </define>
+  <!-- MONOSPACE TEXT (TYPEWRITER TEXT) -->
+  <!--
+    Used to mark text that should appear in
+    a non-proportional font, such as courier
+    for display or print.  This is common for
+    computer code examples, man-machine
+    dialogues, etc.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=monospace
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=monospace
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=monospace
+  -->
+  <define name="monospace">
+    <element name="monospace">
+      <ref name="monospace-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="emphasized-text"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="monospace-attlist" combine="interleave">
+    <ref name="monospace-atts"/>
+  </define>
+  <!-- ROMAN -->
+  <!--
+    Used to mark text that should remain in
+    roman script no matter what style the
+    surrounding text takes on.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=roman
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=roman
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=roman
+  -->
+  <define name="roman">
+    <element name="roman">
+      <ref name="roman-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="emphasized-text"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="roman-attlist" combine="interleave">
+    <ref name="roman-atts"/>
+  </define>
+  <!-- SANS SERIF -->
+  <!--
+    Used to mark text that should appear in a
+    special sans-serif font, typically used in
+    math or chemistry
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=sans-serif
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=sans-serif
+  -->
+  <define name="sans-serif">
+    <element name="sans-serif">
+      <ref name="sans-serif-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="emphasized-text"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="sans-serif-attlist" combine="interleave">
+    <ref name="sans-serif-atts"/>
+  </define>
+  <!-- SMALL CAPS -->
+  <!--
+    Used to mark text that should appear in a
+    font which creates smaller capital letters
+    on output.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=sc
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=sc
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=sc
+  -->
+  <define name="sc">
+    <element name="sc">
+      <ref name="sc-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="emphasized-text"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="sc-attlist" combine="interleave">
+    <ref name="sc-atts"/>
+  </define>
+  <!-- OVERLINE -->
+  <!--
+    Used to mark text that should appear with a
+    horizontal line above each character in
+    display or print. There is no PE for
+    override because this was added to handle
+    a specific publisher tag set and should not
+    grow beyond what they need.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=overline
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=overline
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=overline
+  -->
+  <define name="overline">
+    <element name="overline">
+      <ref name="overline-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="emphasized-text"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="overline-attlist" combine="interleave">
+    <ref name="overline-atts"/>
+  </define>
+  <!-- STRIKE THROUGH -->
+  <!--
+    Used to mark text that should appear with
+    a line through it so as to appear "struck out"
+    on display or print
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=strike
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=strike
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=strike
+  -->
+  <define name="strike">
+    <element name="strike">
+      <ref name="strike-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="emphasized-text"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="strike-attlist" combine="interleave">
+    <ref name="strike-atts"/>
+  </define>
+  <!-- SUBSCRIPT -->
+  <!--
+    A number or expression that is set lower
+    than the baseline and slightly smaller,
+    to act as an inferior or subscript
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=sub
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=sub
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=sub
+  -->
+  <define name="sub">
+    <element name="sub">
+      <ref name="sub-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="emphasized-text"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="sub-attlist" combine="interleave">
+    <ref name="sub-atts"/>
+  </define>
+  <!-- SUPERSCRIPT -->
+  <!--
+    A number or expression that is set higher
+    than the baseline and slightly smaller,
+    to act as a superior or superscript
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=sup
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=sup
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=sup
+  -->
+  <define name="sup">
+    <element name="sup">
+      <ref name="sup-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="emphasized-text"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="sup-attlist" combine="interleave">
+    <ref name="sup-atts"/>
+  </define>
+  <!-- UNDERLINE -->
+  <!--
+    Used to mark text that should appear with a
+    horizontal line below each character in
+    display or print.
+    Details at:
+     http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=underline
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=underline
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=underline
+  -->
+  <define name="underline">
+    <element name="underline">
+      <ref name="underline-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="emphasized-text"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="underline-attlist" combine="interleave">
+    <ref name="underline-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!--
+    ADVANCED UNDERLINE AND OVERLINE ELEMENTS
+    (From the Elsevier DTD, used mostly within
+    mathematics, when ordinary MathML underline
+    and overline functions are inadequate. The
+    elements act as milestone tags marking the
+    start and end of over or underlining that
+    may extend across element boundaries.)
+  -->
+  <!-- ============================================================= -->
+  <!-- OVERLINE START -->
+  <!--
+    The start of a milestone-created overline, the
+    end of ornament will be marked by an
+    Overline End element.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=overline-start
+  -->
+  <define name="overline-start">
+    <element name="overline-start">
+      <ref name="overline-start-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="overline-start-attlist" combine="interleave">
+    <ref name="overline-start-atts"/>
+  </define>
+  <!-- OVERLINE END -->
+  <!--
+    The end of a milestone-created overline, the
+    start of ornament will be marked by an
+    Overline Start element.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=overline-end
+  -->
+  <define name="overline-end">
+    <element name="overline-end">
+      <ref name="overline-end-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="overline-end-attlist" combine="interleave">
+    <ref name="overline-end-atts"/>
+  </define>
+  <!-- UNDERLINE START -->
+  <!--
+    The start of a milestone-created underline,
+    the end of ornament will be marked by an
+    Underline End element
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=underline-start
+  -->
+  <define name="underline-start">
+    <element name="underline-start">
+      <ref name="underline-start-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="underline-start-attlist" combine="interleave">
+    <ref name="underline-start-atts"/>
+  </define>
+  <!-- UNDERLINE END -->
+  <!--
+    The end of a milestone-created underline, the
+    start of ornament will be marked by an
+    Underline Start element.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=underline-end
+  -->
+  <define name="underline-end">
+    <element name="underline-end">
+      <ref name="underline-end-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="underline-end-attlist" combine="interleave">
+    <ref name="underline-end-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- RUBY MARKUP -->
+  <!-- ============================================================= -->
+  <!-- RUBY WRAPPER Model -->
+  <!-- Content model for the <ruby> element -->
+  <!-- RUBY WRAPPER -->
+  <!--
+    A Ruby textual annotation is an annotation,
+    typically short, applied to a letter, word,
+    phrase, or name that appears in the narrative
+    text. Ruby annotations can indicate,
+    for example, pronunciation advice, notes for 
+    translation, semantic annotations, et al.
+      The <ruby> element is an inline wrapper  
+    element that contains some of the document 
+    narrative text (inside a Ruby Base <rb> 
+    element) and one or more Ruby textual 
+    annotations (inside <rt> elements) that are
+    associated with the base text.
+      In display or print, the characters of the
+    Ruby annotation are frequently placed above 
+    the characters they modify, in parenthesis 
+    after the characters they modify, or to the
+    right of vertically set text.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=ruby
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=ruby
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=ruby
+  -->
+  <define name="ruby">
+    <element name="ruby">
+      <ref name="ruby-attlist"/>
+      <ref name="ruby-model"/>
+    </element>
+  </define>
+  <define name="ruby-attlist" combine="interleave">
+    <ref name="ruby-atts"/>
+  </define>
+  <!-- RUBY BASE ELEMENTS -->
+  <!--
+    Those elements that may mix with the data
+    characters inside a Ruby Base <rb>.
+  -->
+  <!-- RUBY BASE -->
+  <!--
+    The <rb> element is one half of a Ruby 
+    Annotation <ruby>, and it contains the 
+    narrative text to which a Ruby textual 
+    annotation <rt> should be applied.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=rb
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=rb
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=rb
+  -->
+  <define name="rb">
+    <element name="rb">
+      <ref name="rb-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="rb-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="rb-attlist" combine="interleave">
+    <ref name="rb-atts"/>
+  </define>
+  <!-- RUBY TEXTUAL ANNOTATION ELEMENTS -->
+  <!--
+    Those elements that may mix with the data
+    characters inside a Ruby Textual Annotation
+    <rt>.
+  -->
+  <define name="rt-elements">
+    <notAllowed/>
+  </define>
+  <!-- RUBY TEXTUAL ANNOTATION -->
+  <!--
+    The <rt> element is one half of a Ruby 
+    Annotation <ruby>, and it contains the 
+    Ruby textual annotation that is applied to
+    the Ruby Base text <rb>.
+    Details at:
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=rt
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=rt
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=rt
+  -->
+  <define name="rt">
+    <element name="rt">
+      <ref name="rt-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="rt-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="rt-attlist" combine="interleave">
+    <ref name="rt-atts"/>
+  </define>
+  <!-- RUBY PARENTHESIS -->
+  <!--
+    The <rp> element is an optional element used
+    to provide spacing and a parenthesis to 
+    surround Ruby Text <rt>, for older systems 
+    that do not handle Ruby properly.
+    Remarks. This optional element never holds
+    any text except a space, an open 
+    parenthesis, or a close parenthesis:
+      <ruby><rb>text</rb>
+      <rp> (</rp><rt>annotation</rt><rp>) </rp>
+      </ruby>
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=rp
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=rp
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=rp
+  -->
+  <define name="rp">
+    <element name="rp">
+      <ref name="rp-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <define name="rp-attlist" combine="interleave">
+    <ref name="rp-atts"/>
+  </define>
+</grammar>
+<!-- ================== End Format Class Module ================== -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-funding1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-funding1.ent.rng
@@ -1,0 +1,1195 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Funding Elements -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) JATS DTD Suite Funding Elements v1.2 20190208//EN"
+       Delivered as file "JATS-funding1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Defines the elements which describe funding for -->
+<!-- the research reported in a work or the open -->
+<!-- access funding for the work -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- February 2008 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- The Journal Publishing DTD is built from the -->
+<!-- Archiving and Interchange DTD Suite. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   21. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   20. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   19. NON-MONETARY SUPPORT - Previous support descriptions in JATS
+       used the <funding-group> element, which could only be used to
+       describe monetary support for the research described in the
+       article.
+         Added new element <contributed-resource-group> to hold 
+       descriptions of non-monetary support (such as data, facilities, 
+       or any in-kind support) for the research described in the
+       article.
+  
+       This changed the JATS models in several ways:
+        - Inside <article-meta>, added a new element <support-group>
+          to hold both <funding-group> and <contributed-resource-group>.
+          For backwards compatibility, <support-group> is a 
+          peer to <funding-group> inside <article-meta>, and (as the 
+          path going forward) <support-group> also contains 
+          <funding-group> as a child.
+        - New elements inside <contributed-resource-group> (as its 
+          children or descendants) include:
+            - support-description
+            - resource-group
+            - resource-name
+            - resource-wrap
+            - resource-id
+        - Inside <award-group>, added a new element <support-source>
+          to describe the source of a non-monetary award. The
+          element <support-source> is as an alternative to 
+          <funding-source> (which describes the source of a monetary
+          award).  
+  
+   18. AWARD ID ATTRIBUTES - Made the award-id attributes match 
+       Green and BITS, adding @award-type and the might link
+       attributes.
+  
+   17. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   16. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   15. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+       =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+   14. JATS became version "1.1" and "v1.1 20151215"
+  
+        =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   13. JATS became version "1.1d3" and "v1.1 20150301//EN"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    12. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+   11. INSTITUTION WRAP ADDED
+       Added the elements <institution-wrap> to the following elements
+       through the institution-wrap.class:
+        - funding-source
+  
+   10. GLOBAL ATTRIBUTES - Added the new parameter entity 
+           %jats-common-atts;
+       to every element in this module. This PE adds (for now) the
+       @id attribute and the @xml:base attribute to every element,
+       whether metadata or narrative.
+       Since the @id in this parameter entity is optional, a second
+       parameter entity jats-common-atts-id-required was also added.
+       The two are kept in sync with the jats-base-atts parameter 
+       entity.
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    9. PRINCIPAL-AWARD-RECIPIENT MODEL - Added "contrib-id.class" to 
+       the <principal-award-recipient> through 
+       principal-award-recipient-elements, to hold identifiers for 
+       people, such as publishers-specific IDs, ORCIDs, etc..
+  
+    8. PRINCIPAL INVESTIGATOR MODEL - Added "contrib-id.class" to 
+       the <principal-investigator> through 
+       principal-investigator-elements, to hold identifiers for 
+       people, such as publishers-specific IDs, ORCIDs, etc..
+  
+    7. Updated the public identifier to "v1.0 20120330//EN", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "1".
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    6. Updated the DTD-version attribute to "0.4" 
+  
+    5. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+             http://jats.nlm.nih.gov/0.4.
+  
+    4. FUNDING GROUP- Allowed <open-access> to repeat within
+       <funding-group>
+  
+    3. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+       @xml:lang to the following elements:
+  
+        - award-group through award-group-atts (both)
+        - award-id through award-id-atts (both)
+        - funding-group through funding-group-atts (both) NEW PE
+        - funding-source through funding-source-atts (both)
+        - funding-statement through funding-statement-atts (both)
+        - open-access through open-access-atts (both) NEW PE
+        - principal-award-recipient through
+            principal-award-recipient-atts (both) NEW PE
+        - principal-investigator through principal-investigator-atts
+            (both) NEW PE
+  
+    2. OPEN ACCESS MODEL - Changed the model from
+           "(p+)"
+       to
+            "(%just-para.class;+)"
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- PARAMETER ENTITIES FOR ATTRIBUTE LISTS -->
+<!-- ============================================================= -->
+<!-- AWARD GROUP ATTRIBUTES -->
+<!-- Attributes for the <award-group> element -->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="award-group-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="rid">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="award-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- AWARD IDENTIFIER ATTRIBUTES -->
+  <!-- Attributes for the <award-id> element -->
+  <!-- CONTRIBUTED RESOURCE GROUP ATTRIBUTES -->
+  <!--
+    Attributes for the 
+    <contributed-resource-group> element
+  -->
+  <define name="contributed-resource-group-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="resource-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- FUNDING GROUP ATTRIBUTES -->
+  <!--
+    Attributes for the <funding-group>
+    element
+  -->
+  <define name="funding-group-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- FUNDING SOURCE ATTRIBUTES -->
+  <!--                     Attributes for the <funding-source> element -->
+  <define name="funding-source-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="rid">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="source-type"/>
+    </optional>
+    <optional>
+      <attribute name="country"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- FUNDING STATEMENT ATTRIBUTES -->
+  <!--
+    Attributes for the <funding-statement>
+    element
+  -->
+  <!-- OPEN ACCESS ATTRIBUTES -->
+  <!--
+    Attributes for the <open-access>
+    element
+  -->
+  <define name="open-access-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- PRINCIPAL AWARD RECIPIENT ATTRIBUTES -->
+  <!--
+    Attributes for the <principal-award-recipient>
+    element
+  -->
+  <define name="principal-award-recipient-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- PRINCIPAL INVESTIGATOR ATTRIBUTES -->
+  <!--
+    Attributes for the <principal-investigator>
+    element
+  -->
+  <define name="principal-investigator-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- RESOURCE GROUP ATTRIBUTES -->
+  <!--
+    Attributes for the <resource-group>
+    element
+  -->
+  <define name="resource-group-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- RESOURCE WRAPPER ATTRIBUTES -->
+  <!--
+    Attributes for the <institution-wrap>
+    element
+  -->
+  <define name="resource-wrap-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- RESOURCE IDENTIFIER ATTRIBUTES -->
+  <!-- Attribute list for <resource-id> -->
+  <define name="resource-id-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="resource-id-type"/>
+    </optional>
+    <optional>
+      <attribute name="vocab"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- RESOURCE NAME ATTRIBUTES -->
+  <!-- Attribute list for <resource-name> -->
+  <define name="resource-name-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- SUPPORT DESCRIPTION ATTRIBUTES -->
+  <!--
+    Attributes for the <support-description>
+    element
+  -->
+  <define name="support-description-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="rid">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- SUPPORT GROUP ATTRIBUTES -->
+  <!--
+    Attributes for the <support-group>
+    element
+  -->
+  <define name="support-group-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- SUPPORT SOURCE ATTRIBUTES -->
+  <!--                     Attributes for the <support-source> element -->
+  <define name="support-source-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="rid">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="support-type"/>
+    </optional>
+    <optional>
+      <attribute name="country"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- FUNDING ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- FUNDING GROUP MODEL -->
+  <!-- Model for the <funding-group> element -->
+  <define name="funding-group-model">
+    <zeroOrMore>
+      <ref name="award-group"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="funding-statement"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="open-access"/>
+    </zeroOrMore>
+  </define>
+  <!-- FUNDING GROUP -->
+  <!--
+    Container element for information concerning
+    grants, contracts, sponsors, or other
+    funding for the research reported in the
+    work (typically an article), as well as for
+    material on the open access funding for the
+    work, for example, which model of open access
+    funding was used or who paid the open access
+    charges.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=funding-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=funding-group
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=funding-group
+  -->
+  <define name="funding-group">
+    <element name="funding-group">
+      <ref name="funding-group-attlist"/>
+      <ref name="funding-group-model"/>
+    </element>
+  </define>
+  <define name="funding-group-attlist" combine="interleave">
+    <ref name="funding-group-atts"/>
+  </define>
+  <!-- FUNDING STATEMENT ELEMENTS -->
+  <!--
+    Elements that may be mixed with text inside  
+    the <funding-statement> element
+  -->
+  <!-- FUNDING STATEMENT -->
+  <!--
+    A displayable prose statement that describes
+    the funding for the research on which a work
+    was based. Such a statement is required, for
+    example, by research funded in whole or part
+    by the Wellcome Trust. The statement may
+    mention (and therefore repeat) the funding
+    source, PI, or other funding information.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=funding-statement
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=funding-statement
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=funding-statement
+  -->
+  <define name="funding-statement">
+    <element name="funding-statement">
+      <ref name="funding-statement-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="funding-statement-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="funding-statement-attlist" combine="interleave">
+    <ref name="funding-statement-atts"/>
+  </define>
+  <!-- OPEN ACCESS MODEL -->
+  <!-- Model for the <open-access> element -->
+  <define name="open-access-model">
+    <oneOrMore>
+      <ref name="just-para.class"/>
+    </oneOrMore>
+  </define>
+  <!-- OPEN ACCESS -->
+  <!--
+    A container element to hold metadata
+    concerning the open access provisions that
+    apply to a work, for example which model
+    of charging was used or who paid the open
+    access charges for a journal article.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=open-access
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=open-access
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=open-access
+  -->
+  <define name="open-access">
+    <element name="open-access">
+      <ref name="open-access-attlist"/>
+      <ref name="open-access-model"/>
+    </element>
+  </define>
+  <define name="open-access-attlist" combine="interleave">
+    <ref name="open-access-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- NON-MONETARY SUPPORT ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- SUPPORT GROUP MODEL -->
+  <!-- Model for the <support-group> element -->
+  <define name="support-group-model">
+    <zeroOrMore>
+      <ref name="funding-group"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="contributed-resource-group"/>
+    </zeroOrMore>
+  </define>
+  <!-- SUPPORT GROUP -->
+  <!--
+    Container element for information concerning
+    both funding and non-monetary support for the 
+    research reported in the work (typically an 
+    article). This includes both monetary awards,
+    grants,investigators, etc. but also facilities
+    computer resources, data acquisition or 
+    donation, and other non-monetary support 
+    (including in-kind support).
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=support-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=support-group
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=support-group
+  -->
+  <define name="support-group">
+    <element name="support-group">
+      <ref name="support-group-attlist"/>
+      <ref name="support-group-model"/>
+    </element>
+  </define>
+  <define name="support-group-attlist" combine="interleave">
+    <ref name="support-group-atts"/>
+  </define>
+  <!-- CONTRIBUTED RESOURCE GROUP MODEL -->
+  <!--
+    Model for the <contributed-resource-group> 
+    element
+  -->
+  <define name="contributed-resource-group-model">
+    <zeroOrMore>
+      <ref name="award-group"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="support-description"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="resource-group"/>
+    </zeroOrMore>
+  </define>
+  <!-- CONTRIBUTED RESOURCE GROUP -->
+  <!--
+    Container element for information concerning
+    non-financial support for the research 
+    reported in the work (typically an article). 
+    This may include awards and investigators, 
+    but also facilities, computer resources, data 
+    acquisition or donation, and other 
+    non-monetary support (including in-kind 
+    support).
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=contributed-resource-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=contributed-resource-group
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=contributed-resource-group
+  -->
+  <define name="contributed-resource-group">
+    <element name="contributed-resource-group">
+      <ref name="contributed-resource-group-attlist"/>
+      <ref name="contributed-resource-group-model"/>
+    </element>
+  </define>
+  <define name="contributed-resource-group-attlist" combine="interleave">
+    <ref name="contributed-resource-group-atts"/>
+  </define>
+  <!-- SUPPORT DESCRIPTION ELEMENTS -->
+  <!--                     Model for the <support-description> element -->
+  <define name="support-description-model">
+    <oneOrMore>
+      <ref name="p"/>
+    </oneOrMore>
+  </define>
+  <!-- SUPPORT DESCRIPTION -->
+  <!--
+    A displayable prose statement that describes
+    the non-financial support given for the 
+    research on which a work was based. 
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=support-description
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=support-description
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=support-description
+  -->
+  <define name="support-description">
+    <element name="support-description">
+      <ref name="support-description-attlist"/>
+      <ref name="support-description-model"/>
+    </element>
+  </define>
+  <define name="support-description-attlist" combine="interleave">
+    <ref name="support-description-atts"/>
+  </define>
+  <!-- RESOURCE GROUP MODEL -->
+  <!-- Model for the <resource-group> element -->
+  <define name="resource-group-model">
+    <oneOrMore>
+      <choice>
+        <ref name="resource-name"/>
+        <ref name="resource-wrap"/>
+      </choice>
+    </oneOrMore>
+  </define>
+  <!-- RESOURCE GROUP -->
+  <!--
+    Container element to hold the descriptions of
+    specific resources supplied in the 
+    non-financial support of the work described 
+    in this article.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=resource-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=resource-group
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=resource-group
+  -->
+  <define name="resource-group">
+    <element name="resource-group">
+      <ref name="resource-group-attlist"/>
+      <ref name="resource-group-model"/>
+    </element>
+  </define>
+  <define name="resource-group-attlist" combine="interleave">
+    <ref name="resource-group-atts"/>
+  </define>
+  <!-- RESOURCE WRAP MODEL -->
+  <!-- Model for the <resource-wrap> element -->
+  <define name="resource-wrap-model">
+    <ref name="resource-name"/>
+    <zeroOrMore>
+      <ref name="resource-id"/>
+    </zeroOrMore>
+  </define>
+  <!-- RESOURCE WRAP -->
+  <!--
+    A wrapper element to hold together the name 
+    of an resource (<resource-name>) and one or 
+    more external identifiers for that resource 
+    (<resource-id>, for example a Research 
+    Resource Identifier).
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=resource-wrap
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=resource-wrap
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=resource-wrap
+  -->
+  <define name="resource-wrap">
+    <element name="resource-wrap">
+      <ref name="resource-wrap-attlist"/>
+      <ref name="resource-wrap-model"/>
+    </element>
+  </define>
+  <define name="resource-wrap-attlist" combine="interleave">
+    <ref name="resource-wrap-atts"/>
+  </define>
+  <!-- RESOURCE NAME MODEL -->
+  <!--
+    Elements that may be mixed with text inside  
+    the <resource-name> element
+  -->
+  <define name="resource-name-elements">
+    <choice>
+      <ref name="face-markup.class"/>
+      <ref name="subsup.class"/>
+    </choice>
+  </define>
+  <!-- RESOURCE NAME -->
+  <!--
+    A displayable name of or description for a 
+    specific resource provided in support of the 
+    work described in this article.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=resource-name
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=resource-name
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=resource-name
+  -->
+  <define name="resource-name">
+    <element name="resource-name">
+      <ref name="resource-name-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="resource-name-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="resource-name-attlist" combine="interleave">
+    <ref name="resource-name-atts"/>
+  </define>
+  <!-- RESOURCE IDENTIFIER MODEL -->
+  <!--
+    Elements that may be mixed with text inside  
+    the <resource-id> element
+  -->
+  <define name="resource-id-elements">
+    <notAllowed/>
+  </define>
+  <!-- RESOURCE IDENTIFIER -->
+  <!--
+    An external, ideally machine-readable, 
+    identifier such as a Research Resource 
+    Identifier, for a specific resource provided
+    in support of the work described in this 
+    article.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=resource-id
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=resource-id
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=resource-id
+  -->
+  <define name="resource-id">
+    <element name="resource-id">
+      <ref name="resource-id-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="resource-id-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="resource-id-attlist" combine="interleave">
+    <ref name="resource-id-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- AWARD GROUP ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- AWARD GROUP MODEL -->
+  <!-- Model for the <award-group> element -->
+  <define name="award-group-model">
+    <choice>
+      <zeroOrMore>
+        <ref name="funding-source"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="support-source"/>
+      </zeroOrMore>
+    </choice>
+    <zeroOrMore>
+      <ref name="award-id"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="principal-award-recipient"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="principal-investigator"/>
+    </zeroOrMore>
+  </define>
+  <!-- AWARD GROUP -->
+  <!--
+    Container element for information concerning
+    one award that sponsored a work or the
+    research on which the work was based. There
+    may be more than source of funding, a grant
+    or contract number, PI, etc.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=award-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=award-group
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=award-group
+  -->
+  <define name="award-group">
+    <element name="award-group">
+      <ref name="award-group-attlist"/>
+      <ref name="award-group-model"/>
+    </element>
+  </define>
+  <define name="award-group-attlist" combine="interleave">
+    <ref name="award-group-atts"/>
+  </define>
+  <!-- FUNDING SOURCE ELEMENTS -->
+  <!--
+    Elements that may be mixed with text inside  
+    the <funding-source> element
+  -->
+  <define name="funding-source-elements">
+    <choice>
+      <ref name="simple-text"/>
+      <ref name="institution-wrap.class"/>
+    </choice>
+  </define>
+  <!-- FUNDING SOURCE -->
+  <!--
+    Agency or organization (such as a foundation,
+    corporation, or an educational institution)
+    that funded the research on which a work was
+    based, for example, the Wellcome Trust, NIH,
+    HHS, Princeton University, or Alcoa
+    sponsoring the research for a journal
+    article
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=funding-source
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=funding-source
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=funding-source
+  -->
+  <define name="funding-source">
+    <element name="funding-source">
+      <ref name="funding-source-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="funding-source-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="funding-source-attlist" combine="interleave">
+    <ref name="funding-source-atts"/>
+  </define>
+  <!-- AWARD IDENTIFIER ELEMENTS -->
+  <!--
+    Elements that may be mixed with text inside  
+    the <award-id> element
+  -->
+  <define name="award-id-elements">
+    <ref name="simple-text"/>
+  </define>
+  <!-- AWARD IDENTIFIER -->
+  <!--
+    An identifier that has been assigned to the
+    award, for example, a grant number, a grant
+    reference number, or a contract number.
+    [Note, this is a real-world identifier not
+    an XML ID.]
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=award-id
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=award-id
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=award-id
+  -->
+  <define name="award-id">
+    <element name="award-id">
+      <ref name="award-id-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="award-id-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="award-id-attlist" combine="interleave">
+    <ref name="award-id-atts"/>
+  </define>
+  <!-- PRINCIPAL AWARD RECIPIENT ELEMENTS -->
+  <!--
+    Elements that may be mixed with text inside  
+    the <principal-award-recipient> element
+  -->
+  <define name="principal-award-recipient-elements">
+    <choice>
+      <ref name="contrib-id.class"/>
+      <ref name="recipient-name.class"/>
+    </choice>
+  </define>
+  <!-- PRINCIPAL AWARD RECIPIENT -->
+  <!--
+    The institution or individuals to whom the
+    award was given, for example the principal
+    grant holder
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=principal-award-recipient
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=principal-award-recipient
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=principal-award-recipient
+  -->
+  <define name="principal-award-recipient">
+    <element name="principal-award-recipient">
+      <ref name="principal-award-recipient-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="principal-award-recipient-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="principal-award-recipient-attlist" combine="interleave">
+    <ref name="principal-award-recipient-atts"/>
+  </define>
+  <!-- PRINCIPAL INVESTIGATOR ELEMENTS -->
+  <!--
+    Elements that may be mixed with text inside  
+    the <principal-investigator> element
+  -->
+  <define name="principal-investigator-elements">
+    <choice>
+      <ref name="contrib-id.class"/>
+      <ref name="investigator-name.class"/>
+    </choice>
+  </define>
+  <!-- PRINCIPAL INVESTIGATOR RECIPIENT -->
+  <!--
+    Individual responsible for the intellectual
+    content of the work reported in the article.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=principal-investigator
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=principal-investigator
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=principal-investigator
+  -->
+  <define name="principal-investigator">
+    <element name="principal-investigator">
+      <ref name="principal-investigator-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="principal-investigator-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="principal-investigator-attlist" combine="interleave">
+    <ref name="principal-investigator-atts"/>
+  </define>
+  <!-- SUPPORT SOURCE ELEMENTS -->
+  <!--
+    Elements that may be mixed with text inside  
+    the  <support-source> element
+  -->
+  <define name="support-source-elements">
+    <choice>
+      <ref name="simple-text"/>
+      <ref name="institution-wrap.class"/>
+    </choice>
+  </define>
+  <!-- SUPPORT SOURCE -->
+  <!--
+    Agency or organization (such as a foundation,
+    corporation, or an educational institution)
+    that provided non-monetary support (such as
+    facilities or data) in support of the
+    research on which a work was based.
+    article
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=support-source
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=support-source
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=support-source
+  -->
+  <define name="support-source">
+    <element name="support-source">
+      <ref name="support-source-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="support-source-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="support-source-attlist" combine="interleave">
+    <ref name="support-source-atts"/>
+  </define>
+</grammar>
+<!-- ================== End Funding Module ======================= -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-journalmeta1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-journalmeta1.ent.rng
@@ -1,0 +1,638 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Journal Metadata Elements -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) JATS DTD Suite Journal Metadata Elements v1.2 20190208//EN"
+       Delivered as file "JATS-journalmeta1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Names all elements used to describe the journal -->
+<!-- in which the journal article is published. -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- December 2002 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- This module is part of the JATS DTD Suite. The -->
+<!-- Suite is a continuation of work done by NCBI, -->
+<!-- Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--              Journal Archiving and Interchange DTD Suite, which -->
+<!-- was originally released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   18. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   17. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   16. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   15. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   14. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+       =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+   13. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   12. JATS became version "1.1d3" and "v1.1d3 20150301"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    11. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+   10. GLOBAL ATTRIBUTES - Added the new parameter entity 
+           %jats-common-atts;
+       to every element in this module. This PE adds (for now) the
+       @id attribute and the @xml:base attribute to every element,
+       whether metadata or narrative.
+       Since the @id in this parameter entity is optional, a second
+       parameter entity jats-common-atts-id-required was also added.
+       The two are kept in sync with the jats-base-atts parameter 
+       entity.
+       This added a new attribute list to:
+        - journal-meta
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    9. JOURNAL METADATA MODEL
+       - Added <issn-l> as an optional element to <journal-meta>
+       - Added contributors and affiliations to journal metadata through
+         contrib-group.class (which resolves to <contrib-group>) and 
+         aff-alternatives.class (which resolves to <aff> or
+         <aff-alternatives>), using the journal-meta-model.
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    8. Updated the DTD-version attribute to "0.4" 
+  
+    7. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+  
+    6. I18N - Changed the default for @xml:lang from "en" to
+       #IMPLIED, so that the @xml:lang would inherit properly and
+       not need to be over-ridden in
+        - <abbrev-journal-title> through %abbrev-journal-title-atts;
+        - <journal-title> through %journal-title-atts;
+        - <journal-subtitle> through %journal-subtitle-atts;
+  
+    5. JOURNAL METADATA- Added <notes> to repeat within <journal-meta>
+       (through %journal-meta-model; and added @xml:lang and
+       @specific-use to the attributes of <notes> through %notes-atts;
+  
+    4. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+       @xml:lang to the following elements:
+        - abbrev-journal-title through abbrev-journal-title-atts
+            (@specific-use-only; @xml:lang already)
+        - journal-title through journal-title-atts
+            (@specific-use-only;
+        - journal-subtitle through journal-subtitle-atts
+            (@specific-use-only)
+  
+    3. JOURNAL TITLE ELEMENTS - Removed the dependency which had both
+       <journal-title> and <journal-subtitle> modeled with the same
+       parameter entity %journal-title-elements;. Created new PE for
+       %journal-subtitle-elements; but set it (as the default) to
+       %journal-title-elements; so that no customization would break.
+  
+    2. SELF URI - Added <self-uri> to <journal-meta> (directly
+       following <notes>) so that an XML document can point to the
+       journal home page.
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    2. Changed default @xml:lang from "EN" from "en" to match latest
+       RFC 4646/W3C/IANA Subtag Registry recommendations
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- DEFAULTS FOR ATTRIBUTE LISTS -->
+<!-- ============================================================= -->
+<!-- ABBREVIATED JOURNAL TITLE ATTRIBUTES -->
+<!--
+  Attribute list for Abbreviated Journal Title
+  <abbrev-journal-title> element
+-->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="abbrev-journal-title-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="abbrev-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- JOURNAL METADATA ATTRIBUTES -->
+  <!--
+    Attributes for the <journal-meta>
+    element
+  -->
+  <define name="journal-meta-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- JOURNAL TITLE ATTRIBUTES -->
+  <!--
+    Attributes for the <journal-title>
+    element
+  -->
+  <define name="journal-title-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- JOURNAL TITLE GROUP ATTRIBUTES -->
+  <!--
+    Attributes for the <journal-title-group>
+    element
+  -->
+  <define name="journal-title-group-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+  </define>
+  <!-- JOURNAL SUBTITLE GROUP ATTRIBUTES -->
+  <!--
+    Attributes for the <journal-subtitle>
+    element
+  -->
+  <define name="journal-subtitle-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ============================================================= -->
+  <!-- JOURNAL METADATA -->
+  <!-- ============================================================= -->
+  <!-- JOURNAL METADATA MODEL -->
+  <!--
+    Content model for the journal metadata
+    element <journal-meta>
+  -->
+  <define name="journal-meta-model">
+    <zeroOrMore>
+      <ref name="journal-id"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="journal-title-group"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="contrib-group.class"/>
+        <ref name="aff-alternatives.class"/>
+      </choice>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="issn"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="issn-l"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="isbn"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="publisher"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="notes"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="self-uri"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="custom-meta-group"/>
+    </optional>
+  </define>
+  <!-- ELEM   journal-id   Defined in %common.ent; -->
+  <!-- ELEM   issn         Defined in %common.ent; -->
+  <!-- ELEM   issn-l       Defined in %common.ent; -->
+  <!-- ELEM   publisher    Defined in %common.ent; -->
+  <!-- ELEM   notes        Defined in %common.ent; -->
+  <!--
+    ELEM   custom-meta-group
+    Defined in %common.ent;
+  -->
+  <!-- JOURNAL METADATA -->
+  <!--
+    Metadata that identifies the journal in which
+    the article was published
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=journal-meta
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=journal-meta
+  -->
+  <define name="journal-meta">
+    <element name="journal-meta">
+      <ref name="journal-meta-attlist"/>
+      <ref name="journal-meta-model"/>
+    </element>
+  </define>
+  <define name="journal-meta-attlist" combine="interleave">
+    <ref name="journal-meta-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- JOURNAL TITLE ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- JOURNAL TITLE GROUP MODEL -->
+  <!--
+    Content model for the element
+    <journal-title-group>
+  -->
+  <define name="journal-title-group-model">
+    <zeroOrMore>
+      <ref name="journal-title"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="journal-subtitle"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="trans-title-group"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="abbrev-journal-title"/>
+    </zeroOrMore>
+  </define>
+  <!--
+    ELEM   trans-title-group
+    Defined in %common.ent;
+  -->
+  <!-- JOURNAL TITLE GROUP -->
+  <!--
+    A container element to hold the title and
+    its subtitle (if any) for the journal in which
+    the article was published.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=journal-title-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=journal-title-group
+  -->
+  <define name="journal-title-group">
+    <element name="journal-title-group">
+      <ref name="journal-title-group-attlist"/>
+      <ref name="journal-title-group-model"/>
+    </element>
+  </define>
+  <define name="journal-title-group-attlist" combine="interleave">
+    <ref name="journal-title-group-atts"/>
+  </define>
+  <!-- JOURNAL TITLE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <journal-title>
+    Design Note: This PE begins with an OR
+    bar because %just-rendition; begins with an
+    OR bar.
+  -->
+  <define name="journal-title-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- JOURNAL TITLE (FULL) -->
+  <!--
+    The title of the journal in which the
+    article is published.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=journal-title
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=journal-title
+  -->
+  <define name="journal-title">
+    <element name="journal-title">
+      <ref name="journal-title-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="journal-title-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="journal-title-attlist" combine="interleave">
+    <ref name="journal-title-atts"/>
+  </define>
+  <!-- JOURNAL SUBTITLE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <journal-subtitle>
+  -->
+  <define name="journal-subtitle-elements">
+    <ref name="journal-title-elements"/>
+  </define>
+  <!-- JOURNAL SUBTITLE -->
+  <!--
+    The subtitle of the journal in which the
+    article is published.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=journal-subtitle
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=journal-subtitle
+  -->
+  <define name="journal-subtitle">
+    <element name="journal-subtitle">
+      <ref name="journal-subtitle-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="journal-subtitle-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="journal-subtitle-attlist" combine="interleave">
+    <ref name="journal-subtitle-atts"/>
+  </define>
+  <!-- ABBREVIATED JOURNAL TITLE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <abbrev-journal-title>
+    Design Note: This PE begins with an OR
+    bar because %just-rendition; begins with an
+    OR bar.
+  -->
+  <define name="abbrev-journal-title-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- ABBREVIATED JOURNAL TITLE -->
+  <!--
+    A short form of the title of the journal
+    in which the article is published.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=abbrev-journal-title
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=abbrev-journal-title
+  -->
+  <define name="abbrev-journal-title">
+    <element name="abbrev-journal-title">
+      <ref name="abbrev-journal-title-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="abbrev-journal-title-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="abbrev-journal-title-attlist" combine="interleave">
+    <ref name="abbrev-journal-title-atts"/>
+  </define>
+</grammar>
+<!-- ================== End Journal Metadata Elements  =========== -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-link1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-link1.ent.rng
@@ -1,0 +1,571 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Link Element Classes -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) JATS DTD Suite Link Class Elements v1.2 20190208//EN"
+       Delivered as file "JATS-link1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Names all elements in the link class. These are -->
+<!-- elements that are links (internal or external) -->
+<!-- by definition, such as URLs <uri> and -->
+<!-- Cross(X)-references <xref>. -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- December 2002 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- This module is part of the JATS DTD Suite. The -->
+<!-- Suite is a continuation of work done by NCBI, -->
+<!-- Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--              Journal Archiving and Interchange DTD Suite, which -->
+<!-- was originally released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd) 
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   17. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   16. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   15. XREF - Changed @ref-type from CDATA back to a fixed 
+       value list, reversing what was done in version 1.2d1.
+       Added new values "award" and "bio".
+  
+   14. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   13. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   12. XREF - Changed @ref-type from a fixed value list to CDATA
+  
+   11. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+        =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+   10. JATS became version "1.1" and "v1.1 20151215"
+  
+      =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    9. JATS became version "1.1d3" and "v1.1 20150301//EN"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    8. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+    7. REFERENCE TYPES
+        - Added "collab"
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+             http://jats.nlm.nih.gov/1.1/
+  
+    6. GLOBAL ATTRIBUTES - Added the new parameter entity 
+           %jats-common-atts;
+       to every element in this module. This PE adds (for now) the
+       @id attribute and the @xml:base attribute to every element,
+       whether metadata or narrative.
+       Since the @id in this parameter entity is optional, a second
+       parameter entity jats-common-atts-id-required was also added.
+       The two are kept in sync with the jats-base-atts parameter 
+       entity.
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    5. Updated the DTD-version attribute to "1.0" and the formal
+       public identifier to the date: "v1.0 20120330//EN".
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    4. Updated the DTD-version attribute to "0.4" 
+  
+    3. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+  
+    2. ACCESSIBILITY - Added @alt to <xref> through %xref-atts;
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- DEFAULTS FOR ATTRIBUTE VALUES -->
+<!-- ============================================================= -->
+<!-- DEFAULT TYPE OF CROSS(X)-REFERENCE -->
+<!--
+  Used to say to what the reference is pointing.
+  May be used for type-specific processing or
+  validation. Values are, for example:
+  Affiliation "aff" and Figure "fig", and
+  Bibliographic ref (to a citation.
+-->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="ref-types">
+    <choice>
+      <value>aff</value>
+      <value>app</value>
+      <value>author-notes</value>
+      <value>award</value>
+      <value>bibr</value>
+      <value>bio</value>
+      <value>boxed-text</value>
+      <value>chem</value>
+      <value>collab</value>
+      <value>contrib</value>
+      <value>corresp</value>
+      <value>disp-formula</value>
+      <value>fig</value>
+      <value>fn</value>
+      <value>kwd</value>
+      <value>list</value>
+      <value>plate</value>
+      <value>scheme</value>
+      <value>sec</value>
+      <value>statement</value>
+      <value>supplementary-material</value>
+      <value>table</value>
+      <value>table-fn</value>
+      <value>other</value>
+    </choice>
+  </define>
+  <!-- ============================================================= -->
+  <!-- DEFAULTS FOR ATTRIBUTE LISTS -->
+  <!-- ============================================================= -->
+  <!-- FOOTNOTE ATTRIBUTES -->
+  <!-- Attribute list for Footnote element -->
+  <define name="fn-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="symbol"/>
+    </optional>
+    <optional>
+      <attribute name="fn-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- INLINE SUPPLEMENTARY MATERIAL -->
+  <!--
+    Attribute list for inline supplementary
+    material
+  -->
+  <define name="inline-supplementary-material-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="mimetype"/>
+    </optional>
+    <optional>
+      <attribute name="mime-subtype"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- TARGET ATTRIBUTES -->
+  <!-- Attribute list for <target> element -->
+  <define name="target-atts">
+    <ref name="jats-common-atts-id-required"/>
+    <optional>
+      <attribute name="target-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- X(CROSS) REFERENCE ATTRIBUTES -->
+  <!-- Attribute list for cross references -->
+  <!-- ============================================================= -->
+  <!-- INTERNAL LINKS -->
+  <!-- ============================================================= -->
+  <!-- FOOTNOTE MODEL -->
+  <!-- Content model for Footnote <fn> -->
+  <define name="fn-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <oneOrMore>
+      <ref name="just-para.class"/>
+    </oneOrMore>
+  </define>
+  <!-- FOOTNOTE -->
+  <!--
+    Additional information concerning material in
+    a particular location in the text. This
+    material is not considered to be part of the
+    body of the text, but in addition to or a
+    commentary on the body.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=fn
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=fn
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=fn
+  -->
+  <define name="fn">
+    <element name="fn">
+      <ref name="fn-attlist"/>
+      <ref name="fn-model"/>
+    </element>
+  </define>
+  <define name="fn-attlist" combine="interleave">
+    <ref name="fn-atts"/>
+  </define>
+  <!-- TARGET ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <target>
+    Design Note: All inline mixes begin with an
+    OR bar, but since %link-elements; is an inline
+    mix, the OR bar is already there.
+  -->
+  <define name="target-elements">
+    <ref name="link-elements"/>
+  </define>
+  <!-- TARGET OF AN INTERNAL LINK -->
+  <!--
+    May be placed anywhere within textual
+    material such as a paragraph to provide a
+    location (anchor) to which a cross reference
+    can point
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=target
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=target
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=target
+  -->
+  <define name="target">
+    <element name="target">
+      <ref name="target-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="target-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="target-attlist" combine="interleave">
+    <ref name="target-atts"/>
+  </define>
+  <!-- X(CROSS) REFERENCE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    an <xref>
+    Design Note: All inline mixes begin with an
+    OR bar, but since %link-elements; is an inline
+    mix, the OR bar is already there.
+  -->
+  <define name="xref-elements">
+    <ref name="link-elements"/>
+  </define>
+  <!-- X(CROSS) REFERENCE -->
+  <!--
+    Used for any kind of internal article
+    referencing. The content of the reference
+    (if present) will be displayed as the link.
+    This element may be used to point to any
+    element that takes an "id" attribute.
+    The @ref-type attribute may be used to name
+    the element or type of object to which the
+    <xref> is pointing.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=xref
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=xref
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=xref
+  -->
+  <define name="xref">
+    <element name="xref">
+      <ref name="xref-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="xref-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="xref-attlist" combine="interleave">
+    <ref name="xref-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- EXTERNAL LINKS -->
+  <!-- ============================================================= -->
+  <!-- INLINE SUPPLEMENTARY MATERIAL ELEMENTS -->
+  <!--
+    Elements for use in the
+    <inline-supplementary-material> element
+  -->
+  <!-- INLINE SUPPLEMENTARY MATERIAL -->
+  <!--
+    An in-text link to an external file that
+    provides supplementary information for
+    the document, for example, an audio clip
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=inline-supplementary-material
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=inline-supplementary-material
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=inline-supplementary-material
+  -->
+  <define name="inline-supplementary-material">
+    <element name="inline-supplementary-material">
+      <ref name="inline-supplementary-material-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="inline-supplementary-material-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="inline-supplementary-material-attlist" combine="interleave">
+    <ref name="inline-supplementary-material-atts"/>
+  </define>
+</grammar>
+<!-- ================== End Link Class Module ==================== -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-list1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-list1.ent.rng
@@ -1,0 +1,687 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    List Element Classes -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) JATS DTD Suite List Class Elements v1.2 20190208//EN"
+       Delivered as file "JATS-list1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Names all elements in the list class. These are -->
+<!-- all lists except the lists of bibliographic -->
+<!-- references (citations). Lists are considered -->
+<!-- to be composed of items. -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- December 2002 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- This module is part of the JATS DTD Suite. The -->
+<!-- Suite is a continuation of work done by NCBI, -->
+<!-- Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--              Journal Archiving and Interchange DTD Suite, which -->
+<!-- was originally released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   19. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   18. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   17. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   16. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   15. TERM ATTRIBUTES - Added to <term> the following attributes:
+       - @term-type
+       - @term-status
+       - the four vocabulary attributes described below
+  
+   14. VOCABULARY/TAXONOMY ATTRIBUTES - Added 4 new attributes for
+       naming (and possibly linking to) a general or controlled
+       taxonomy, vocabulary, index, database or other source of
+       terms: @vocab, @vocab-identifier, @vocab-term, and
+       @vocab-term-identifier
+        - All 4 added to <term>, to name a vocabulary 
+          as the source of the term being identified
+  
+   13. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+       =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+   12. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   11. JATS became version "1.1d3" and "v1.1 20150301//EN"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   10. TITLE FOR LIST ITEMS
+       Added an optional <title> to the beginning of each <list-item>.
+  
+    9. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    8. GLOBAL ATTRIBUTES - Added the new parameter entity 
+           %jats-common-atts;
+       to every element in this module. This PE adds (for now) the
+       @id attribute and the @xml:base attribute to every element,
+       whether metadata or narrative.
+       Since the @id in this parameter entity is optional, a second
+       parameter entity jats-common-atts-id-required was also added.
+       The two are kept in sync with the jats-base-atts parameter 
+       entity.
+       This added a new attribute list to:
+        - def-head
+        - term-head
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    7. Updated the DTD-version attribute to "1.0" and the formal
+       public identifier to the date: "v1.0 20120330//EN".
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    6. Updated the DTD-version attribute to "0.4" 
+  
+    5. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+  
+    4. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+       @xml:lang to the following elements:
+  
+        - def-item through def-item-atts (both)
+        - def-list through def-list-atts (@xml:lang-only;
+            @specific-use already)
+        - list through list-atts (@xml:lang-only; @specific-use already)
+        - list-item through list-item-atts (both)
+        - term through term-atts (both)
+  
+    3. DEFINITION LIST HEADS - Removed the dependency in which
+       <term-head> and <def-head> both used the parameter entity
+       %def-list-head-elements; One uses %term-head-elements; and
+       the other uses %def-head-elements; But the
+       %def-list-head-elements; was retained for backward
+       compatibility.
+  
+    2. DEF LIST ATTRIBUTES - Removed the dependency whereby <def-list>
+       used both %def-list-atts; and %list-atts;. <def-list> now uses
+       only %def-list-atts; No documents need change.
+       *****Customization Alert: New parameter entity could break some
+       customizations. Check your <def-list> attributes.        *****
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- DEFAULT PE FOR ATTRIBUTE LISTS -->
+<!-- ============================================================= -->
+<!--                     DEFINITION LIST: DEFINITION HEAD ATTRIBUTES -->
+<!-- Attributes for the <def-head> element -->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="def-head-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!--                     DEFINITION LIST: DEFINITION ITEM ATTRIBUTES -->
+  <!-- Attributes for the <def-item> element -->
+  <define name="def-item-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- DEFAULT DEFINITION LIST ATTRIBUTES -->
+  <!--
+    Default attribute lists to be used for
+    Definition (2-part) lists
+  -->
+  <define name="def-list-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="list-type"/>
+    </optional>
+    <optional>
+      <attribute name="prefix-word"/>
+    </optional>
+    <optional>
+      <attribute name="list-content"/>
+    </optional>
+    <optional>
+      <attribute name="continued-from">
+        <data type="IDREF"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- DEFAULT LIST CLASS ATTRIBUTES -->
+  <!--
+    Default attribute lists to be used for most
+    of the types of lists.
+  -->
+  <define name="list-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="list-type"/>
+    </optional>
+    <optional>
+      <attribute name="prefix-word"/>
+    </optional>
+    <optional>
+      <attribute name="list-content"/>
+    </optional>
+    <optional>
+      <attribute name="continued-from">
+        <data type="IDREF"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- DEFAULT LIST ITEM ATTRIBUTES -->
+  <!-- Default attribute for list items -->
+  <define name="list-item-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- DEFINITION LIST: TERM ATTRIBUTES -->
+  <!-- Attributes for the <term> element -->
+  <define name="term-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="rid">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="term-status"/>
+    </optional>
+    <optional>
+      <attribute name="term-type"/>
+    </optional>
+    <optional>
+      <attribute name="vocab"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- DEFINITION LIST: TERM HEAD ATTRIBUTES -->
+  <!-- Attributes for the <term-head> element -->
+  <define name="term-head-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- DEFINITION LIST -->
+  <!-- ============================================================= -->
+  <!-- DEFINITION LIST MODEL -->
+  <!-- Content model for the <def-list> element -->
+  <!-- DEFINITION LIST -->
+  <!--
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=def-list
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=def-list
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=def-list
+  -->
+  <define name="def-list">
+    <element name="def-list">
+      <ref name="def-list-attlist"/>
+      <ref name="def-list-model"/>
+    </element>
+  </define>
+  <define name="def-list-attlist" combine="interleave">
+    <ref name="def-list-atts"/>
+  </define>
+  <!-- DEFINITION LIST HEAD ELEMENTS -->
+  <!--
+    Elements for use in the <def-list> heading
+    elements <term-head> and <def-head>.
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-phrase; is an
+    inline mix, the OR bar is already there.
+  -->
+  <define name="def-list-head-elements">
+    <ref name="simple-phrase"/>
+  </define>
+  <!-- DEFINITION LIST TERM HEAD ELEMENTS -->
+  <!--                     Elements for use in the <term-head> element -->
+  <define name="term-head-elements">
+    <ref name="def-list-head-elements"/>
+  </define>
+  <!-- DEFINITION LIST DEFINITION HEAD ELEMENTS -->
+  <!-- Elements for use in the <def-head> element -->
+  <define name="def-head-elements">
+    <ref name="def-list-head-elements"/>
+  </define>
+  <!-- DEFINITION LIST: TERM HEAD -->
+  <!--
+    Title over the first (term) column of a
+    two-part list
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=term-head
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=term-head
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=term-head
+  -->
+  <define name="term-head">
+    <element name="term-head">
+      <ref name="term-head-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="term-head-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="term-head-attlist" combine="interleave">
+    <ref name="term-head-atts"/>
+  </define>
+  <!-- DEFINITION LIST: DEFINITION HEAD -->
+  <!--
+    Title over the second (definition) column
+    of a two-part list
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=def-head
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=def-head
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=def-head
+  -->
+  <define name="def-head">
+    <element name="def-head">
+      <ref name="def-head-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="def-head-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="def-head-attlist" combine="interleave">
+    <ref name="def-head-atts"/>
+  </define>
+  <!-- DEFINITION LIST: DEFINITION ITEM MODEL -->
+  <!-- The content model of a <def-item> -->
+  <!-- DEFINITION LIST: DEFINITION ITEM -->
+  <!--
+    A term and definition pair inside a
+    definition or two-part list
+    of a two-part list
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=def-item
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=def-item
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=def-item
+  -->
+  <define name="def-item">
+    <element name="def-item">
+      <ref name="def-item-attlist"/>
+      <ref name="def-item-model"/>
+    </element>
+  </define>
+  <define name="def-item-attlist" combine="interleave">
+    <ref name="def-item-atts"/>
+  </define>
+  <!-- ELEM   def          Defined in %common.ent; -->
+  <!-- DEFINITION LIST: TERM ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <term>.
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-phrase; is an
+    inline mix, the OR bar is already there.
+  -->
+  <!-- DEFINITION LIST: TERM -->
+  <!--
+    The word, phrase, picture, or other noun
+    being defined or description that occupies
+    the first column of a definition or 2-part
+    list and is the subject of the definition or
+    description.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=term
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=term
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=term
+  -->
+  <define name="term">
+    <element name="term">
+      <ref name="term-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="term-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="term-attlist" combine="interleave">
+    <ref name="term-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- LIST ELEMENTS (PARAGRAPH-LEVEL ELEMENTS) -->
+  <!-- ============================================================= -->
+  <!-- LIST MODEL -->
+  <!-- Content model for the <list> element -->
+  <!-- LIST -->
+  <!--
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=list
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=list
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=list
+  -->
+  <define name="list">
+    <element name="list">
+      <ref name="list-attlist"/>
+      <ref name="list-model"/>
+    </element>
+  </define>
+  <define name="list-attlist" combine="interleave">
+    <ref name="list-atts"/>
+  </define>
+  <!-- LIST ITEM ELEMENTS -->
+  <!-- The content model of a <list-item>. -->
+  <define name="list-item-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <oneOrMore>
+      <choice>
+        <ref name="just-para.class"/>
+        <ref name="list.class"/>
+      </choice>
+    </oneOrMore>
+  </define>
+  <!-- LIST ITEM -->
+  <!--
+    One item in a list
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=list-item
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=list-item
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=list-item
+  -->
+  <define name="list-item">
+    <element name="list-item">
+      <ref name="list-item-attlist"/>
+      <ref name="list-item-model"/>
+    </element>
+  </define>
+  <define name="list-item-attlist" combine="interleave">
+    <ref name="list-item-atts"/>
+  </define>
+</grammar>
+<!-- ================== End List Class Module ==================== -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-math1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-math1.ent.rng
@@ -1,0 +1,545 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Math Class Elements -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) JATS DTD Suite Math Class Elements v1.2 20190208//EN"
+       Delivered as file "JATS-math1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Names all elements in the math classes -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- December 2002 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- This module is part of the JATS DTD Suite. The -->
+<!-- Suite is a continuation of work done by NCBI, -->
+<!-- Mulberry Technologies, and Inera Inc. on the NLM -->
+<!--              Journal Archiving and Interchange DTD Suite, which -->
+<!-- was originally released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   17. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   16. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   15. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   14. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   13. INLINE FORMULA - Added accessibility elements <alt-text> and
+       <long-desc> to the model of <inline-formula>, by adding the 
+       access.class PE.
+  
+   12. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+       =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+   11. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   10. JATS became version "1.1d3" and "v1.1 20150301//EN"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    9. TEXT-MATH - Added @specific-use to the attributes for
+       <text-math>, primarily for use when <tex-math> is used
+       inside <alternatives>.
+  
+    8. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    7. GLOBAL ATTRIBUTES - Added the new parameter entity 
+           %jats-common-atts;
+       to every element in this module. This PE adds (for now) the
+       @id attribute and the @xml:base attribute to every element,
+       whether metadata or narrative.
+       Since the @id in this parameter entity is optional, a second
+       parameter entity jats-common-atts-id-required was also added.
+       The two are kept in sync with the jats-base-atts parameter 
+       entity.
+  
+    6. ABSTRACTS AND KEYWORDS ON NEW STRUCTURES
+       - Added <abstract> (through %abstract.class;) and <kwd-group> 
+         (through %kwd-group.class;) to the following elements:
+          - disp-formula (through %disp-formula-elements;)
+          - disp-formula-group (through %disp-formula-group-model;)
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    5. Updated the DTD-version attribute to "1.0" and the formal
+       public identifier to the date: "v1.0 20120330//EN".
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    4. Updated the DTD-version attribute to "0.4" 
+  
+    3. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+  
+    2. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+       @xml:lang to the following elements:
+  
+        - disp-formula through disp-formula-atts (@xml:lang-only;
+            @specific-use already)
+        - disp-formula-group through disp-formula-group-atts
+            (@xml:lang-only; @specific-use already)
+        - inline-formula through inline-formula-atts
+            (@specific-use-only; @xml:lang already)
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- PARAMETER ENTITIES FOR ATTRIBUTE LISTS -->
+<!-- ============================================================= -->
+<!-- DISPLAY FORMULA ATTRIBUTES -->
+<!-- Attributes for the <disp-formula> element -->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="disp-formula-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- DISPLAY FORMULA GROUP ATTRIBUTES -->
+  <!--
+    Attributes for the <disp-formula-group>
+    element
+  -->
+  <define name="disp-formula-group-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- INLINE FORMULA ATTRIBUTES -->
+  <!--
+    Attribute list for the <inline-formula>
+    element
+  -->
+  <define name="inline-formula-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- TEX MATH ATTRIBUTES -->
+  <!-- Attributes for the <disp-formula> element -->
+  <define name="tex-math-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="notation">
+        <choice>
+          <value>LaTeX</value>
+          <value>tex</value>
+          <value>TEX</value>
+          <value>TeX</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="version"/>
+    </optional>
+  </define>
+  <!-- ============================================================= -->
+  <!-- MATH ELEMENTS (INLINE LEVEL) -->
+  <!-- ============================================================= -->
+  <!-- FORMULA, INLINE ELEMENTS -->
+  <!--
+    Elements for use in the <inline-formula>
+    element
+  -->
+  <!-- FORMULA, INLINE MODEL -->
+  <!-- Content model for an <inline-formula> -->
+  <define name="inline-formula-model">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="inline-formula-elements"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <!-- FORMULA, INLINE -->
+  <!--
+    Inline element for a mathematical
+    equation, expression, or formula
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=inline-formula
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=inline-formula
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=inline-formula
+  -->
+  <define name="inline-formula">
+    <element name="inline-formula">
+      <ref name="inline-formula-attlist"/>
+      <ref name="inline-formula-model"/>
+    </element>
+  </define>
+  <define name="inline-formula-attlist" combine="interleave">
+    <ref name="inline-formula-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- MATH ELEMENTS (INLINE LEVEL) -->
+  <!-- ============================================================= -->
+  <!-- DISPLAY FORMULA ELEMENTS -->
+  <!--
+    Elements for use in the <disp-formula>
+    element
+  -->
+  <!-- FORMULA, DISPLAY MODEL -->
+  <!-- Content model for an <disp-formula> -->
+  <define name="disp-formula-model">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="disp-formula-elements"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <!-- FORMULA, DISPLAY -->
+  <!--
+    Block-level (callout) element for a
+    mathematical equation, expression, or
+    formula.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=disp-formula
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=disp-formula
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=disp-formula
+  -->
+  <define name="disp-formula">
+    <element name="disp-formula">
+      <ref name="disp-formula-attlist"/>
+      <ref name="disp-formula-model"/>
+    </element>
+  </define>
+  <define name="disp-formula-attlist" combine="interleave">
+    <ref name="disp-formula-atts"/>
+  </define>
+  <!-- FORMULA, DISPLAY GROUP MODEL -->
+  <!-- Content model for an <disp-formula-group> -->
+  <define name="disp-formula-group-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="caption.class"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="abstract.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="kwd-group.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="access.class"/>
+        <ref name="address-link.class"/>
+      </choice>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="block-math.class"/>
+    </zeroOrMore>
+  </define>
+  <!-- FORMULA, DISPLAY GROUP -->
+  <!--
+    Used for a group of equations or other
+    mathematical expressions that are displayed
+    together.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=disp-formula-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=disp-formula-group
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=disp-formula-group
+  -->
+  <define name="disp-formula-group">
+    <element name="disp-formula-group">
+      <ref name="disp-formula-group-attlist"/>
+      <ref name="disp-formula-group-model"/>
+    </element>
+  </define>
+  <define name="disp-formula-group-attlist" combine="interleave">
+    <ref name="disp-formula-group-atts"/>
+  </define>
+  <!-- TEX MATH EQUATION -->
+  <!--
+    Used to hold encoded math, expressed in TeX
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=tex-math
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=tex-math
+  -->
+  <define name="tex-math">
+    <element name="tex-math">
+      <ref name="tex-math-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <define name="tex-math-attlist" combine="interleave">
+    <ref name="tex-math-atts"/>
+  </define>
+</grammar>
+<!-- ================== End Math Class Elements Module =========== -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-mathmlsetup1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-mathmlsetup1.ent.rng
@@ -1,0 +1,400 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    MathML DTD SETUP MODULE -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) JATS DTD Suite MathML Setup Module v1.2 20190208//EN"
+       Delivered as file "JATS-mathmlsetup1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Provides the organization for using the -->
+<!-- MathML DTD: -->
+<!-- 1) Overrides the standard parameter entities used -->
+<!-- in the MathML 2.0 DTD -->
+<!-- 2) Calls the MathML 2.0 DTD -->
+<!---->
+<!-- MODULES REQUIRED: -->
+<!-- 1) mathml2.dtd  (MathML 2.0 DTD) -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- December 2002 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- This module is part of the JATS DTD Suite. The -->
+<!-- Suite is a continuation of work done by NCBI, -->
+<!-- Mulberry Technologies, and Inera Inc. on the NLM -->
+<!--              Journal Archiving and Interchange DTD Suite, which -->
+<!-- was originally released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   14. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   13. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   12. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   11. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   10. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+       =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+    9. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    8. JATS became version "1.1d3" and "v1.1d3 20150301"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    7. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    6. OASIS TABLE NAMESPACE MODIFICATIONS - Added a new module
+       that sets up the namespace URI and namespace prefix for
+       the OASIS tables models.
+  
+    5. Updated the DTD-version attribute to "1.1d1" and the formal
+       public identifier to the date: "v1.1d1 20130915//EN".
+  
+         =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    4. Updated the DTD-version attribute to "1.0" and the formal
+       public identifier to the date: "v1.0 20120330//EN".
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    3. Updated the DTD-version attribute to "0.4" 
+  
+    2. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- SET UP FOR THE MathML MODULE -->
+<!-- ============================================================= -->
+<!-- MathML DTD -->
+<!--
+  The official version of the MathML 2.0 can
+              be found at: http://www.w3.org/TR/MathML2/
+  
+              See also Mathematical Markup Language
+              (MathML) Version 2.0
+  
+              A. Parsing MathML
+              A.6 The MathML DTD
+  http://www.w3.org/TR/MathML2/appendixa.html#parsing-dtd
+  
+              A zip file with entity declarations is
+              available from
+  http://www.w3.org/TR/MathML2/DTD-MathML-20010221.zip
+-->
+<!-- ============================================================= -->
+<!-- SET UP W3C XML SCHEMA -->
+<!-- ============================================================= -->
+<!-- MAKE PREFIX EQUAL "xsi" (same as MathML) -->
+<!--
+  SET UP NAMESPACE FOR SCHEMA
+  (same as MathML)
+-->
+<!-- OVER-RIDE MATHML DTD TO MAKE EXPLICIT NS -->
+<!--
+  MathML sets this up but then lets the
+  attribute be a CDATA one, not the real
+  namespace URI
+-->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <define name="Schema.xmlns.attrib">
+    <empty/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- SET UP "mml" AS THE MATH PREFIX -->
+  <!-- ============================================================= -->
+  <!-- MAKE MATH PREFIX PARAMETER ENTITY HAPPEN -->
+  <!-- MAKE PREFIX EQUAL "mml" -->
+  <!-- SET UP "pfx" -->
+  <!-- USE "pfx" TO SET THE MATH ELEMENT NAME -->
+  <!-- ============================================================= -->
+  <!-- CALL THE MATHML ENTITIES -->
+  <!-- ============================================================= -->
+  <!-- MATHML CHARACTER ENTITIES -->
+  <!--
+    Set the "INCLUDE" or "IGNORE" marked section
+    switch for the MATHML 2.0 DTD. This switch
+    determines whether the math processing in
+    the -%mathml.dtd; module or the
+    -%xmlspecchars.ent; module in this DTD Suite
+    will invoke the sets of special characters
+    that are defined AND INVOKED in the
+    -%xmlspecchars.ent; module.
+    A value of "IGNORE" turns off the second
+    invocation from the MathML DTD.
+  -->
+  <!-- MATHML-SPECIFIC CHARACTER ENTITIES -->
+  <!--
+    Because the MATHML invocation is canceled
+    using the parameter entity just defined,
+    the two external entities below must be
+    invoked from here, as neither XMLspecchars
+    nor the MathML DTD will invoke them.
+  -->
+  <!-- New characters defined by MathML -->
+  <!--                     MathML aliases for characters defined above -->
+  <!-- ============================================================= -->
+  <!-- RESTRICT CONTENT OF ANNOTATION -->
+  <!-- ============================================================= -->
+  <!-- MATHML ANNOTATION MODEL -->
+  <!--
+    The MathML DTD establishes the content of the
+    <mml:annotation-xml> element as ANY. This is
+    unnecessarily broad, causing inconvenience for
+    conversion. The model has been restricted to
+    one or more paragraphs.
+  -->
+  <define name="Annotation-xml.content">
+    <oneOrMore>
+      <ref name="p"/>
+    </oneOrMore>
+  </define>
+  <!-- ============================================================= -->
+  <!-- MathML 2.0 INVOCATION -->
+  <!-- ============================================================= -->
+  <include href="mathml2.rng"/>
+</grammar>
+<!-- ================== End MATHML Setup Module ================== -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-nlmcitation1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-nlmcitation1.ent.rng
@@ -1,0 +1,465 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    NLM Citation -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) NLM Citation v1.2 20190208//EN"
+  Delivered as file "JATS-nlmcitation1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Deprecated 2012 -->
+<!-- This DTD Suite module adds the model for the -->
+<!-- NLM Structured bibliographic citation. This model -->
+<!-- The model loosely reflects NLM's style, in that -->
+<!-- the model allows the tagging of all "legal" NLM -->
+<!-- citations and enforces the sequence in which -->
+<!-- content must appear if it is present. However, -->
+<!-- this model does not provide guidance on what -->
+<!-- information is required for each type of cited -->
+<!-- content. -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- September 2004 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- The Journal Publishing DTD is built from the -->
+<!-- Archiving and Interchange DTD Suite. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     ==============================================================
+      JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                    (DAL/BTU) v1.2     (2019-02-08)
+  
+      NISO JATS is a continuing maintenance NISO Standard, which 
+      requires voting by the both the NISO and ANSI membership 
+      to be changed. This version of the NISO JATS was approved 
+      by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+      Drafts as well as the draft version JATS 1.2 2018 (the version
+      submitted for vote), becoming NISO JATS v1.2 20190208 
+      (ANSI/NISO Z39.96-2019).
+  
+  14. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+      "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+    ==============================================================
+      JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+      and BITS 2.1 (v2.0 20180401)
+                                    (DAL/BTU) v1.2     (2018-11-30)
+  
+      NISO JATS is a continuing maintenance NISO Standard, which 
+      requires voting by the both the NISO and ANSI membership 
+      to be changed. This version of the NISO JATS was approved 
+      by ANSI and NISO vote, so it supersedes all Committee Drafts
+      and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+  13. BITS "2.1" and "v2.0 20180401" remains unchanged.
+      JATS "1.2d2" and "v1.2d2 20180401" became
+      JATS "1.2" and "v1.2 20181130" 
+  
+     =============================================================
+      BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+      JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+      JATS is a continuing maintenance NISO Standard, which
+      requires voting by the ANSI and NISO memberships to be changed. 
+      BITS is under continuous maintenance, and is modified at the
+      discretion of the working group.
+  
+      This draft DTD represents an interim version of the
+      non-normative JATS DTD Suite, as an indication to JATS users
+      the decisions that have been made by the JATS Standing
+      Committee. This draft has not yet been given public review 
+      or voting. The formal public identifiers were changed in the 
+      modules and the catalogs.
+  
+  12. BITS "2.0" and "v2.0 20151225" became
+      BITS "2.1" and "v2.1 20180401". 
+  
+      JATS "1.2d1" and "v1.2d1 20171231" became
+      JATS "1.2d2" and "v1.2d2 20180401". 
+  
+      No module names were changed.
+  
+     =============================================================
+      JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                    (DAL/BTU) v1.2d1  (2017-12-31)
+  
+      NISO JATS is a continuing maintenance NISO Standard, which
+      requires voting by the ANSI and NISO memberships to be changed. 
+  
+      This draft DTD represents an interim version of the
+      non-normative JATS DTD Suite, as an indication to JATS users
+      the decisions that have been made by the JATS Standing
+      Committee. This draft has not yet been given public review 
+      or voting. The formal public identifiers were changed in the 
+      modules and the catalogs.
+  
+  11. JATS "1.2d1" and "v1.2d1 20170631" became
+      JATS "1.2d1" and "v1.2d1 20171231". 
+  
+     =============================================================
+      JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+      NISO JATS is a continuing maintenance NISO Standard, which
+      requires voting by the ANSI and NISO memberships to be changed. 
+  
+      This draft DTD represents an interim version of the
+      non-normative JATS DTD Suite, as an indication to JATS users
+      the decisions that have been made by the JATS Standing
+      Committee. This draft has not yet been given public review 
+      or voting. The formal public identifiers were changed in the 
+      modules and the catalogs.
+  
+  10. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+       =============================================================
+      JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+      JATS is a continuing maintenance NISO Standard, which
+      requires voting by the ANSI and NISO memberships to be changed. 
+      JATS 1.1 was approved in late 2015, so the formal public 
+      identifiers were changed in the modules and the catalogs.
+      No model or attribute changes were made at this time. 
+  
+   9. JATS became version "1.1" and "v1.1 20151215"
+  
+     =============================================================
+      JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+      The changes in this release are in response to NISO 
+      License and Indicators Recommended Practice.
+  
+      NISO JATS is a continuing maintenance NISO Standard, which 
+      requires voting by the NISO membership to be changed. This
+      Committee Draft 1.1d3 will be sent to the NISO voting
+      membership, to become (if approved) NISO JATS 1.1.
+  
+      This draft DTD represents an interim version of the
+      non-normative JATS DTD Suite, as an indication to JATS users
+      the decisions that have been made by the JATS Standing
+      Committee.
+  
+   8. JATS became version "1.1d3" and "v1.1d3 20150301"
+  
+      =============================================================
+      JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+      NISO JATS is a continuing maintenance NISO Standard, which 
+      requires voting by the NISO membership to be changed. This
+      Committee Draft 1.1d2 will be sent to the NISO voting
+      membership, to become (if approved) NISO JATS 1.1.
+  
+      This catalog represents an interim version of the
+      non-normative JATS DTD Suite, as an indication to JATS users
+      the decisions that have been made by the JATS Standing
+      Committee.
+  
+   7. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+  
+      =============================================================
+      NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+      ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+      NISO JATS Standing Committee met and answered the requests and
+      suggestions from the NISO request forms.
+  
+      Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+      XSDs, RNGs and supporting documentation are available at
+            http://jats.nlm.nih.gov/1.0/
+  
+   6. GLOBAL ATTRIBUTES - Added the new parameter entity 
+          %jats-common-atts;
+      to every element in this module. This PE adds (for now) the
+      @id attribute and the @xml:base attribute to every element,
+      whether metadata or narrative.
+      Since the @id in this parameter entity is optional, a second
+      parameter entity jats-common-atts-id-required was also added.
+      The two are kept in sync with the jats-base-atts parameter 
+      entity.
+  
+      =============================================================
+      NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+      ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+      Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+      XSDs, RNGs and supporting documentation are available at
+            http://jats.nlm.nih.gov/1.0/
+  
+   5. Updated the DTD-version attribute to "1.0" and the formal
+      public identifier to the date: "v1.0 20120330//EN".
+  
+      =============================================================
+      Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+      This Tag Set is in the process of becoming a NISO standard.
+      The version numbers are starting over from 0.4", as a Trial
+      Use Draft, to be made into "Version 1.0" when the Tag Suite 
+      becomes a NISO standard. Thus, the version number that would
+      have been "NLM Version 3.1 Draft" has become NISO JATS
+      "Version 0.4".
+  
+      Details on NISO Trial Use Draft Version 0.4 are available at
+            http://jats.nlm.nih.gov/JATS-0.4.
+  
+   4. Updated the DTD-version attribute to "0.4" 
+  
+   3. Updated the public identifier to "v0.4 20110131", 
+      modified the formal public identifier to include "JATS (Z39.96)",
+      and the filename as delivered to include "JATS" and the
+      new version number "0".
+  
+   2. NLM CITATION ATTRIBUTES - Removed the dependency whereby
+      the NLM citation used the same attributes as the other types
+      of citation via %citation-atts;. <nlm-citation> now uses
+      only %nlm-citation-atts; No documents need change.
+      - added @xml:lang
+      - added @specific-use
+  
+      =============================================================
+      Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+      Version 3.0 is the first non-backward-compatible release.
+      In addition to the usual incremental changes, some
+      elements and attributes have been renamed and/or remodeled
+      to better meet user needs and to increase tag set consistency.
+      All module change histories are available through the Tag Suite
+      web site at http://dtd.nlm.nih.gov.
+  
+      Details on version 3.0 are available at
+            http://dtd.nlm.nih.gov/3.0.
+  
+   1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- NEW ELEMENT DECLARATIONS -->
+<!-- Declarations of elements that are new to -->
+<!-- this DTD. -->
+<!-- NOTE: All new structures must be mappable -->
+<!-- to the archiving/interchange DTD and the -->
+<!-- mapping should be described when the new -->
+<!-- element is declared. -->
+<!-- ============================================================= -->
+<!-- NLM CITATION ATTRIBUTES -->
+<!--
+  Attributes for all three types of
+  citations (<mixed-citation>,
+  <element-citation>, and <nlm-citation>).
+-->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="nlm-citation-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="publication-type"/>
+    </optional>
+    <optional>
+      <attribute name="publisher-type"/>
+    </optional>
+    <optional>
+      <attribute name="publication-format"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- NLM CITATION MODEL -->
+  <!--
+    This structured citation model is loosely
+    reflects the NLM's house style, in that
+    it allows the tagging of all "legal" NLM
+    citations and enforces the sequence in which
+    content must appear if it is present.
+    This model assumes that punctuation between
+    the parts of a citation will be generated
+    on display or on export.
+    (Deprecated after Version 3.0)
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=nlm-citation
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=nlm-citation
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=nlm-citation
+  -->
+  <define name="nlm-citation">
+    <element name="nlm-citation">
+      <ref name="nlm-citation-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="person-group"/>
+          <ref name="collab"/>
+        </choice>
+      </zeroOrMore>
+      <zeroOrMore>
+        <choice>
+          <ref name="article-title"/>
+          <ref name="trans-title"/>
+        </choice>
+      </zeroOrMore>
+      <optional>
+        <ref name="source"/>
+      </optional>
+      <optional>
+        <ref name="patent"/>
+      </optional>
+      <optional>
+        <ref name="trans-source"/>
+      </optional>
+      <optional>
+        <ref name="year"/>
+      </optional>
+      <choice>
+        <group>
+          <optional>
+            <ref name="month"/>
+          </optional>
+          <optional>
+            <ref name="day"/>
+          </optional>
+          <optional>
+            <ref name="time-stamp"/>
+          </optional>
+        </group>
+        <optional>
+          <ref name="season"/>
+        </optional>
+      </choice>
+      <optional>
+        <ref name="access-date"/>
+      </optional>
+      <optional>
+        <ref name="volume"/>
+      </optional>
+      <optional>
+        <ref name="edition"/>
+      </optional>
+      <optional>
+        <ref name="conf-name"/>
+      </optional>
+      <optional>
+        <ref name="conf-date"/>
+      </optional>
+      <optional>
+        <ref name="conf-loc"/>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <ref name="issue"/>
+          <ref name="supplement"/>
+        </choice>
+      </zeroOrMore>
+      <optional>
+        <ref name="publisher-loc"/>
+      </optional>
+      <optional>
+        <ref name="publisher-name"/>
+      </optional>
+      <zeroOrMore>
+        <optional>
+          <ref name="fpage"/>
+        </optional>
+        <optional>
+          <ref name="lpage"/>
+        </optional>
+      </zeroOrMore>
+      <optional>
+        <ref name="page-count"/>
+      </optional>
+      <optional>
+        <ref name="series"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="comment"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="pub-id"/>
+      </zeroOrMore>
+      <optional>
+        <ref name="annotation"/>
+      </optional>
+    </element>
+  </define>
+  <define name="nlm-citation-attlist" combine="interleave">
+    <ref name="nlm-citation-atts"/>
+  </define>
+</grammar>
+<!-- ================== End NLM Citation Module ================== -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-para1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-para1.ent.rng
@@ -1,0 +1,710 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Paragraph-Like Elements -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) JATS DTD Suite Paragraph-Like Elements v1.2 20190208//EN"
+       Delivered as file "JATS-para1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Names structural elements that will appear in -->
+<!-- the same places as a paragraph -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- December 2002 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- This module is part of the JATS DTD Suite. The -->
+<!-- Suite is a continuation of work done by NCBI, -->
+<!-- Mulberry Technologies, and Inera Inc. on the NLM -->
+<!--              Journal Archiving and Interchange DTD Suite, which -->
+<!-- was originally released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   20. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   19. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   18. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   17. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   16. NEW VERSE ATTRIBUTES
+       - Added @indent-level, @style, @style-type, and @style-detail 
+         to <verse-line>
+       - Added @style, @style-type, and @style-detail to <verse-group>      
+  
+   15. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+       =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+   14. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   13. JATS became version "1.1d3" and "v1.1 20150301//EN"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   12. STATEMENT - Added new statement.class inside the model
+       for <statement>, so that statements can be recursive.
+  
+   11. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+   10. GLOBAL ATTRIBUTES - Added the new parameter entity 
+           %jats-common-atts;
+       to every element in this module. This PE adds (for now) the
+       @id attribute and the @xml:base attribute to every element,
+       whether metadata or narrative.
+       Since the @id in this parameter entity is optional, a second
+       parameter entity jats-common-atts-id-required was also added.
+       The two are kept in sync with the jats-base-atts parameter 
+       entity.
+  
+  
+    9. ABSTRACTS AND KEYWORDS ON NEW STRUCTURES
+       - Added <abstract> (through %abstract.class;) and <kwd-group> 
+         (through %kwd-group.class;) to the following elements:
+          - statement (through statement-model PE)
+  
+       =============================================================
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    5. Updated the DTD-version attribute to "1.0" and the formal
+       public identifier to the date: "v1.0 20120330//EN".
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    4. Updated the DTD-version attribute to "0.4" 
+  
+    3. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+  
+    2. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+       @xml:lang to the following elements:
+        - speaker through speaker-atts (both)
+        - statement through statement-atts (@xml:lang only; already
+            @specific-use))
+        - verse-line through verse-line-atts (both)
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- PARAMETER ENTITIES FOR ATTRIBUTE LISTS -->
+<!-- ============================================================= -->
+<!-- DISPLAY QUOTE ATTRIBUTES -->
+<!--                     Attribute list for the <disp-quote> element -->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="disp-quote-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- PARAGRAPH ATTRIBUTES -->
+  <!-- Attribute list for the <p> element -->
+  <define name="p-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- SPEAKER ATTRIBUTES -->
+  <!-- Attribute list for the <speaker> element -->
+  <define name="speaker-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- SPEECH ATTRIBUTES -->
+  <!-- Attribute list for the <speech> element -->
+  <define name="speech-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- STATEMENT ATTRIBUTES -->
+  <!-- Attribute list for the <statement> element -->
+  <define name="statement-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- VERSE GROUP ATTRIBUTES -->
+  <!-- Attribute list for the <verse-group> element -->
+  <define name="verse-group-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="style"/>
+    </optional>
+    <optional>
+      <attribute name="style-detail"/>
+    </optional>
+    <optional>
+      <attribute name="style-type"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- VERSE LINE ATTRIBUTES -->
+  <!--                     Attribute list for the <verse-line> element -->
+  <define name="verse-line-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="indent-level"/>
+    </optional>
+    <optional>
+      <attribute name="style"/>
+    </optional>
+    <optional>
+      <attribute name="style-detail"/>
+    </optional>
+    <optional>
+      <attribute name="style-type"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PARAGRAPH-LEVEL ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- PARAGRAPH -->
+  <!--
+    The basic block-unit of textual information
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=p
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=p
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=p
+  -->
+  <define name="p">
+    <element name="p">
+      <ref name="p-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="p-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="p-attlist" combine="interleave">
+    <ref name="p-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- THE REST OF THE PARAGRAPH ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- QUOTE, DISPLAYED MODEL -->
+  <!--                     Content model for the Display Quote element -->
+  <define name="disp-quote-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="para-level"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="display-back-matter.class"/>
+    </zeroOrMore>
+  </define>
+  <!-- QUOTE, DISPLAYED -->
+  <!--
+    Extract or extended quoted passage from
+    another work, usually made typographically
+    distinct from the surrounding text.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=disp-quote
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=disp-quote
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=disp-quote
+  -->
+  <define name="disp-quote">
+    <element name="disp-quote">
+      <ref name="disp-quote-attlist"/>
+      <ref name="disp-quote-model"/>
+    </element>
+  </define>
+  <define name="disp-quote-attlist" combine="interleave">
+    <ref name="disp-quote-atts"/>
+  </define>
+  <!-- SPEECH MODEL -->
+  <!-- Content model for the <speech> element -->
+  <define name="speech-model">
+    <ref name="speaker"/>
+    <oneOrMore>
+      <ref name="just-para.class"/>
+    </oneOrMore>
+  </define>
+  <!-- SPEECH -->
+  <!--
+    One exchange in a real or imaginary
+    conversation between two or more entities,
+    for example, between a an interviewer and the
+    person being interviewed, between a nurse or
+    doctor and a patient, between a person and a
+    computer, etc.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=speech
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=speech
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=speech
+  -->
+  <define name="speech">
+    <element name="speech">
+      <ref name="speech-attlist"/>
+      <ref name="speech-model"/>
+    </element>
+  </define>
+  <define name="speech-attlist" combine="interleave">
+    <ref name="speech-atts"/>
+  </define>
+  <!-- SPEAKER ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a speaker.
+  -->
+  <!-- SPEAKER -->
+  <!--
+    One who utters a speech as part of a
+    speech, for example the computer "HAL" in
+    the exchange 'Hal: "Hi Dave"'.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=speaker
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=speaker
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=speaker
+  -->
+  <define name="speaker">
+    <element name="speaker">
+      <ref name="speaker-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="speaker-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="speaker-attlist" combine="interleave">
+    <ref name="speaker-atts"/>
+  </define>
+  <!-- STATEMENT, FORMAL MODEL -->
+  <!-- Content model for the <statement> element -->
+  <define name="statement-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="abstract.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="kwd-group.class"/>
+    </zeroOrMore>
+    <oneOrMore>
+      <choice>
+        <ref name="just-para.class"/>
+        <ref name="statement.class"/>
+      </choice>
+    </oneOrMore>
+    <zeroOrMore>
+      <ref name="display-back-matter.class"/>
+    </zeroOrMore>
+  </define>
+  <!-- STATEMENT, FORMAL -->
+  <!--
+    A Theorem, Lemma, Proof, Postulate,
+    Hypothesis, Proposition, Corollary, or
+    other formal statement, identified as such
+    with a label, usually made typographically
+    distinct from the surrounding text
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=statement
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=statement
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=statement
+  -->
+  <define name="statement">
+    <element name="statement">
+      <ref name="statement-attlist"/>
+      <ref name="statement-model"/>
+    </element>
+  </define>
+  <define name="statement-attlist" combine="interleave">
+    <ref name="statement-atts"/>
+  </define>
+  <!-- VERSE GROUP MODEL -->
+  <!--                     Content model for the <verse-group> element -->
+  <define name="verse-group-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <optional>
+      <ref name="subtitle"/>
+    </optional>
+    <oneOrMore>
+      <choice>
+        <ref name="verse-line"/>
+        <ref name="verse-group"/>
+      </choice>
+    </oneOrMore>
+    <zeroOrMore>
+      <ref name="display-back-matter.class"/>
+    </zeroOrMore>
+  </define>
+  <!-- VERSE FORM FOR POETRY -->
+  <!--
+    A song, poem, or verse.
+    Implementer's Note: No attempt has been made
+    to retain the look or visual form of the
+    original.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=verse-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=verse-group
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=verse-group
+  -->
+  <define name="verse-group">
+    <element name="verse-group">
+      <ref name="verse-group-attlist"/>
+      <ref name="verse-group-model"/>
+    </element>
+  </define>
+  <define name="verse-group-attlist" combine="interleave">
+    <ref name="verse-group-atts"/>
+  </define>
+  <!-- VERSE-LINE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <verse-line>
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-text; is an inline
+    mix, the OR bar is already there.
+  -->
+  <!-- LINE OF A VERSE -->
+  <!--
+    One line of a poem or verse
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=verse-line
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=verse-line
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=verse-line
+  -->
+  <define name="verse-line">
+    <element name="verse-line">
+      <ref name="verse-line-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="verse-line-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="verse-line-attlist" combine="interleave">
+    <ref name="verse-line-atts"/>
+  </define>
+</grammar>
+<!-- ================== End Paragraph Class Module =============== -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-phrase1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-phrase1.ent.rng
@@ -1,0 +1,668 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Subject Phrase Class Elements -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) JATS DTD Suite Subject Phrase Class Elements v1.2 20190208//EN"
+       Delivered as file "JATS-phrase1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Defines the phrase.class, that is, names the -->
+<!-- inline, subject-specific elements -->
+<!---->
+<!-- If more specific subject words (such as "gene") -->
+<!-- are added to later version of this DTD, they -->
+<!-- should be added to the %phrase.class; entity and -->
+<!-- defined in this module or in %common.ent; -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- the DTD suite should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- December 2002 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- This module is part of the JATS DTD Suite. The -->
+<!-- Suite is a continuation of work done by NCBI, -->
+<!-- Mulberry Technologies, and Inera Inc. on the NLM -->
+<!--              Journal Archiving and Interchange DTD Suite, which -->
+<!-- was originally released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   20. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   19. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   18. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   17. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   16. STYLED CONTENT - Added new @style-detail attribute to
+       <styled-content>, to account for dots, sesamis, and
+       other non-western emphasis.
+  
+   15. VOCABULARY/TAXONOMY ATTRIBUTES - Added 4 new attributes for
+       naming (and possibly linking to) a general or controlled
+       taxonomy, vocabulary, index, database or other source of
+       terms: @vocab, @vocab-identifier, @vocab-term, and
+       @vocab-term-identifier
+        - All 4 added to <named-content>, to name a vocabulary 
+          as the source of the content being identified
+  
+   14. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+       =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+   13. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   12. JATS became version "1.1d3" and "v1.1 20150301//EN"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   11. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+   10. GLOBAL ATTRIBUTES - Added the new parameter entity 
+           %jats-common-atts;
+       to every element in this module. This PE adds (for now) the
+       @id attribute and the @xml:base attribute to every element,
+       whether metadata or narrative.
+       Since the @id in this parameter entity is optional, a second
+       parameter entity jats-common-atts-id-required was also added.
+       The two are kept in sync with the jats-base-atts parameter 
+       entity.
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    9. NAMED CONTENT ATTRIBUTE - Added @rid to the attributes of
+       <named-content>.
+  
+    8. Updated the DTD-version attribute to "1.0" and the formal
+       public identifier to the date: "v1.0 20120330//EN".
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    7. Updated the DTD-version attribute to "0.4" 
+  
+    6. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+  
+    5. MILESTONE END ATTRIBUTES - The new parameter entity
+       %milestone-end-atts; now uses %milestone-atts;, as it used to,
+       for compatibility purposes. This had not been done.
+  
+    4. ACCESSIBILITY- Added @alt to
+       - <abbrev> through %abbrev-atts;
+       - <named-content> through %named-content-atts;
+       - <styled-content> through %styled-content-atts:
+  
+    3. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+       @xml:lang to the following elements:
+        - abbrev through abbrev-atts (both)
+        - milestone-start through milestone-atts (@xml:lang only;
+             @specific-use already)
+        - milestone-end through milestone-end-atts (both)
+        - named-content through named-content-atts (@xml:lang only;
+             @specific-use already)
+        - styled-content through styled-content-atts (@xml:lang only;
+             @specific-use already)
+  
+    2. MILESTONE - The attribute list for <milestone-start> was
+       named milestone-atts not milestone-start-atts. Added the
+       new PE milestone-start-atts, but set it to the value of
+       milestone-atts so as not to break customizations.
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- PARAMETER ENTITIES FOR ATTRIBUTE LISTS -->
+<!-- ============================================================= -->
+<!-- ABBREVIATION ATTRIBUTES -->
+<!-- Attributes for the <abbrev> element -->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="abbrev-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="alt"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- MILESTONE ATTRIBUTES -->
+  <!--
+    Attributes for both the <milestone-start> 
+    and <milestone-end> elements
+  -->
+  <define name="milestone-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="rid">
+        <data type="IDREF"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="rationale"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- MILESTONE START ATTRIBUTES -->
+  <!--
+    Attributes for the <milestone-start>
+    element
+  -->
+  <define name="milestone-start-atts">
+    <ref name="milestone-atts"/>
+  </define>
+  <!-- MILESTONE END ATTRIBUTES -->
+  <!--
+    Attributes for the <milestone-end>
+    element
+  -->
+  <define name="milestone-end-atts">
+    <ref name="milestone-atts"/>
+  </define>
+  <!-- NAMED CONTENT ATTRIBUTES -->
+  <!-- Attributes for the <named-content> element -->
+  <define name="named-content-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="rid">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="alt"/>
+    </optional>
+    <attribute name="content-type"/>
+    <optional>
+      <attribute name="vocab"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term"/>
+    </optional>
+    <optional>
+      <attribute name="vocab-term-identifier"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- STYLED CONTENT ATTRIBUTES -->
+  <!--                     Attributes for the <styled-content> element -->
+  <define name="styled-content-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="toggle">
+        <choice>
+          <value>yes</value>
+          <value>no</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="style"/>
+    </optional>
+    <optional>
+      <attribute name="style-type"/>
+    </optional>
+    <optional>
+      <attribute name="style-detail"/>
+    </optional>
+    <optional>
+      <attribute name="alt"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ============================================================= -->
+  <!-- PHRASE-LEVEL ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- ABBREVIATION ELEMENTS -->
+  <!-- Elements for use in the <abbrev> element -->
+  <!-- ABBREVIATION OR ACRONYM -->
+  <!--
+    Used to identify an abbreviation or acronym
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=abbrev
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=abbrev
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=abbrev
+  -->
+  <define name="abbrev">
+    <element name="abbrev">
+      <ref name="abbrev-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="abbrev-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="abbrev-attlist" combine="interleave">
+    <ref name="abbrev-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- MILESTONE ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- MILESTONE MODEL -->
+  <!--
+    Model for both the <milestone-start> and
+    <milestone-end> elements
+  -->
+  <define name="milestone-model">
+    <empty/>
+  </define>
+  <!-- MILESTONE START MODEL -->
+  <!--
+    Model for the both the <milestone-start>
+    element
+  -->
+  <define name="milestone-start-model">
+    <ref name="milestone-model"/>
+  </define>
+  <!-- MILESTONE START -->
+  <!--
+    Used to mark the start of a non-hierarchically
+    nested object, that is, a textual component
+    which cannot be expressed in the normal
+    non-overlapping, OCHO structure of an XML
+    document. When this element is used, it is
+    assumed that the end of the textual
+    component will be marked with a
+    <milestone-end> element.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=milestone-start
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=milestone-start
+  -->
+  <define name="milestone-start">
+    <element name="milestone-start">
+      <ref name="milestone-start-attlist"/>
+      <ref name="milestone-start-model"/>
+    </element>
+  </define>
+  <define name="milestone-start-attlist" combine="interleave">
+    <ref name="milestone-start-atts"/>
+  </define>
+  <!-- MILESTONE END MODEL -->
+  <!--
+    Model for the both the <milestone-end>
+    element
+  -->
+  <define name="milestone-end-model">
+    <ref name="milestone-model"/>
+  </define>
+  <!-- MILESTONE END -->
+  <!--
+    Used to mark the end of a non-hierarchically
+    nested object, that is, a textual component
+    which cannot be expressed in the normal
+    non-overlapping, OCHO structure of an XML
+    document. When this element is used, it is
+    assumed that the start of the textual
+    component was marked with a <milestone-start>
+    element.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=milestone-end
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=milestone-end
+  -->
+  <define name="milestone-end">
+    <element name="milestone-end">
+      <ref name="milestone-end-attlist"/>
+      <ref name="milestone-end-model"/>
+    </element>
+  </define>
+  <define name="milestone-end-attlist" combine="interleave">
+    <ref name="milestone-end-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- NAMED CONTENT ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- NAMED CONTENT ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <named-content> element
+  -->
+  <!-- NAMED SPECIAL (SUBJECT) CONTENT -->
+  <!--
+    A semantically distinct word or phrase
+    within the text. Often such phrases are
+    treated differently, for example, given a
+    different typographic style or look, to call
+    attention to the subject matter. For
+    example, the word is a drug name or a
+    gene or the phrase identifies an organism
+    genus/species.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=named-content
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=named-content
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=named-content
+  -->
+  <define name="named-content">
+    <element name="named-content">
+      <ref name="named-content-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="named-content-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="named-content-attlist" combine="interleave">
+    <ref name="named-content-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- STYLED CONTENT ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- STYLED CONTENT ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <styled-content> element
+  -->
+  <!-- STYLED SPECIAL (SUBJECT) CONTENT -->
+  <!--
+    A stylistically distinct word or phrase
+    within the text, that cannot be tagged using
+    any of the other mechanisms for such content.
+    In other words: the content cannot be
+    described with bold, italic, monospace or any
+    of the other emphasis class elements and
+    <named-content> is inappropriate because the
+    semantic reason behind the typographic
+    distinction is not clear.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=styled-content
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=styled-content
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=styled-content
+  -->
+  <define name="styled-content">
+    <element name="styled-content">
+      <ref name="styled-content-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="styled-content-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="styled-content-attlist" combine="interleave">
+    <ref name="styled-content-atts"/>
+  </define>
+</grammar>
+<!-- ================== End Phrase Class Module ================== -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-references1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-references1.ent.rng
@@ -1,0 +1,1615 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Bibliographic Reference (Citation) Class Elements -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) JATS DTD Suite Bibliographic Reference (Citation) Class Elements v1.2 20190208//EN"
+  Delivered as file "JATS-references1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Defines the bibliographic reference elements -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- December 2002 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- This module is part of the JATS DTD Suite. The -->
+<!-- Suite is a continuation of work done by NCBI, -->
+<!-- Mulberry Technologies, and Inera Inc. on the NLM -->
+<!--              Journal Archiving and Interchange DTD Suite, which -->
+<!-- was originally released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   30. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   29. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   28. PUB-ID-TYPE - @pub-id-type changed back to a fixed list from 
+       CDATA, reversing the decision of Version 1.2d1. Although 
+       the value list is unchanged, best practice will be documented
+       as using @pub-id-type for type and @assigning-authority
+       for the responsible agency.
+           - <pub-id>
+  
+   27. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   26. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   25. INLINE-GRAPHIC and PRIVATE-CHAR - both <inline-graphic> and
+       <private-char> added to elements allowed in:
+        - <data-title>
+        - <std>
+  
+   24. PUB-ID-TYPE - @pub-id-type changed from a fixed list to
+       CDATA for all usages of the attribute.
+  
+   23. SOURCE/CHAPTER TITLE/PART TITLE - Added the following elements
+       to <source>, <chapter-title>, and <part-title> to more
+       closely mirror the model of <article-title>:
+          - abbrev class
+               abbrev
+          - inline-display class
+               alternatives | inline-graphic | private-char
+          - inline-math class 
+               chem-struct | inline-formula
+          - math class
+               tex-math | mml:math
+          - simple link class
+               fn | target | xref 
+  
+   22. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+       =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+   21. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   20. JATS became version "1.1d3" and "v1.1 20150301//EN"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+   19. ATTRIBUTES FOR PUB-ID
+     - Added the linking attributes (optional version) to <pub-id> , 
+       so that a <pub-id> that is a DOI, for example, can carry the 
+       linking attributes and be made into a live link. In this use
+       of <pub-id>, the element is acting both as an identifier
+       and as a link.
+     - Added new attribute @assigning-authority to <pub-id>, to
+       carry new values such as "CrossRef" and to take some of the
+       semantic burden off the '@pub-id-type' attribute, when
+       values are organizations such as "Genbank" or "PDB".
+  
+   18. VERSION FOR DATASETS - Added new element <version>
+       for citing datasets and software. Similar to <edition>
+       for printed material.
+  
+   17. DATA TITLE FOR DATASETS - Added new element <data-title>
+       to name datasets and parts of datasets. Acts both as an
+       <article-title> equivalent and as a <source> equivalent,
+       since many levels of data may be cited.
+  
+   16. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+   15. ACCESS DATE ELEMENT
+       Added attributes for @calendar and @iso-8601-date. The element is
+       deprecated but still in use.
+  
+   14. NEW <era> ELEMENT
+       Added <era> through date-parts.class to:
+        - <date-in-citation>
+  
+   13. INSTITUTIONS TO STANDARDS ORGANIZATIONS
+       Added the elements <institution-wrap> to the following elements
+       through the institution-wrap.class:
+        - <std-organization>
+  
+   12. GLOBAL ATTRIBUTES - Added the new parameter entity 
+           %jats-common-atts;
+       to every element in this module. This PE adds (for now) the
+       @id attribute and the @xml:base attribute to every element,
+       whether metadata or narrative.
+       Since the @id in this parameter entity is optional, a second
+       parameter entity jats-common-atts-id-required was also added.
+       The two are kept in sync with the jats-base-atts parameter 
+       entity.
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+   11. EDITION 
+         a) Changed the long name of the <edition> element
+            ("Edition, Cited)") to "Edition Statement, Cited" to
+            indicate that element MAY contain more than just the
+            edition number.
+         b) Changed the definition of <edition> to include the full
+            edition statement and not just the edition number.
+         c) Added new element @designator to hold the edition
+            number, since the definition of edition is changing.
+            (through %edition-atts).
+  
+   10. DATE IN CITATION ATTRIBUTES - Added to the attributes for
+       <date-in-citation> (through @date-in-citation-atts):
+         a) ISO 8601 standard date format attribute (@iso-8601-date) 
+            Format  YYYY-MM-DDThh:mm:ss 
+         b) Name of the calendar used (@calendar), to hold values
+            such as "Gregorian", "Japanese" (Emperor years), or
+            "Islamic".
+  
+    9. STANDARD ORGANIZATION - Added new element for the name of
+       the standards body that created or that promulgates a
+       standard. <std-organization> may be used as part of the
+       description of a cited standard inside a citation.
+       (New PEs: std-organization-atts; std-organization-elements)
+  
+    8. STANDARD MODEL - Updated the model for <std>, the description
+       of a cited standard in side a citation to include several
+       elements:
+           - <source> contains the name of the standard
+           - <pub-id> contains the standard designator
+           - date elements <month>, <day>, and <year> name the 
+                official date
+           - <std-organization> (new element) names the standards 
+               body
+           - <named-content> takes anything else a publisher/archive 
+               wishes to record, such as the standard status, et al.
+        The following elements were retained form the older model
+        and so will also be allowed inside <std:>
+  
+           - <styled-content> because archives cannot always know the
+               reason behind a typographic change
+           - the emphasis elements (all face markup)
+           - <sub> and <sup>
+  
+   7.  Updated the DTD-version attribute to "1.0" and the formal
+       public identifier to the date: "v1.0 20120330//EN".
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    6. Updated the DTD-version attribute to "0.4" 
+  
+    5. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+  
+    4. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+       @xml:lang to the following elements:
+        - access-date through access-date-atts (only @specific-use)
+        - annotation through annotation-atts (both)
+        - chapter-title through chapter-title-atts (both) NEW PE
+        - comment through comment-atts (both)
+        - date-in-citation through date-in-citation-atts (both)
+        - edition through edition-atts (both)
+        - gov through gov-atts (both)
+        - note through note-atts (both)
+        - part-title through part-title-atts (both) NEW PE
+        - patent through patent-atts (both)
+        - person-group through person-group-atts (both)
+        - pub-id through pub-id-atts (@specific-use only)
+        - ref through ref-atts (both)
+        - ref-list through ref-list-atts (@specific-use only)
+        - series through series-atts (both)
+        - source through source-atts (@specific-use only;
+            @xml:lang already)
+        - std through std-atts (both)
+        - time-stamp through time-stamp-atts (@specific-use only)
+        - trans-source through trans-source-atts (@specific-use only;
+            @xml:lang already)
+  
+    3. PERSON GROUP - Changed the model of <person-group> to mixed
+       content. This entailed: creating new PE %person-group-elements;
+       that contained the elements to be used and Changing PE
+       %person-group-model to (#PCDATA %person-group-elements;)*.
+       The PE person-group-model has been retained in this module for
+       compatibility, but has been set to the mixed model using
+       person-group-elements.
+  
+    2. ANNOTATION - Changed to content model to use the parameter
+       entity %annotation-model; Content model unchanged.
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- PARAMETER ENTITIES FOR #PCDATA MODELS -->
+<!-- ============================================================= -->
+<!-- SOURCE ELEMENTS -->
+<!--
+  The elements that can be included along with
+  data characters inside the content model of
+  a <source> or <trans-source>.
+-->
+<!-- ============================================================= -->
+<!-- PARAMETER ENTITIES FOR ATTRIBUTE LISTS -->
+<!-- ============================================================= -->
+<!-- ACCESS DATE ATTRIBUTES -->
+<!-- Attributes for the <access-date> element -->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="access-date-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="iso-8601-date"/>
+    </optional>
+    <optional>
+      <attribute name="calendar"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- ANNOTATION ATTRIBUTES -->
+  <!-- Attributes for the <annotation> element -->
+  <define name="annotation-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- CHAPTER TITLE ATTRIBUTES -->
+  <!-- Attributes for the <chapter-title> element -->
+  <define name="chapter-title-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- COMMENT ATTRIBUTES -->
+  <!-- Attributes for the <comment> element -->
+  <define name="comment-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- DATA TITLE ATTRIBUTES -->
+  <!-- Attributes for the <data-title> element -->
+  <define name="data-title-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- DATE IN CITATION ATTRIBUTES -->
+  <!--
+    Attributes for the <date-in-citation>
+    element
+  -->
+  <define name="date-in-citation-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="iso-8601-date"/>
+    </optional>
+    <optional>
+      <attribute name="calendar"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- EDITION ATTRIBUTES -->
+  <!-- Attributes for the <edition> element -->
+  <define name="edition-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="designator"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- GOVERNMENT ATTRIBUTES -->
+  <!-- Attributes for the <gov> element -->
+  <define name="gov-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- NOTE ATTRIBUTES -->
+  <!-- Attributes for the <note> element -->
+  <define name="note-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- PART TITLE ATTRIBUTES -->
+  <!-- Attributes for the <part-title> element -->
+  <define name="part-title-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- PATENT ATTRIBUTES -->
+  <!-- Attributes for the <patent> element -->
+  <define name="patent-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="country"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- PERSON GROUP ATTRIBUTES -->
+  <!-- Attributes for the <person-group> element -->
+  <define name="person-group-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="person-group-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- PUBLICATION IDENTIFIER ATTRIBUTES -->
+  <!-- Attributes for the <pub-id> element -->
+  <!-- REFERENCE ATTRIBUTES -->
+  <!-- Attributes for the <ref> element -->
+  <define name="ref-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- REFERENCE LIST ATTRIBUTES -->
+  <!-- Attributes for the <ref-list> element -->
+  <define name="ref-list-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- SERIES ATTRIBUTES -->
+  <!-- Attributes for the <series> element -->
+  <define name="series-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- SOURCE ATTRIBUTES -->
+  <!-- Attributes for the <source> element -->
+  <define name="source-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- STANDARDS ATTRIBUTES -->
+  <!-- Attributes for the <std> element -->
+  <define name="std-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- STANDARDS ORGANIZATION ATTRIBUTES -->
+  <!--
+    Attributes for the <std-organization> 
+    element
+  -->
+  <define name="std-organization-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- TIME STAMP ATTRIBUTES -->
+  <!-- Attributes for the <time-stamp> element -->
+  <define name="time-stamp-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- TRANSLATED SOURCE ATTRIBUTES -->
+  <!-- Attributes for the <trans-source> element -->
+  <define name="trans-source-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- VERSION ATTRIBUTES -->
+  <!-- Attributes for the <version> element -->
+  <define name="version-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="designator"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- ============================================================= -->
+  <!-- BIBLIOGRAPHIC REFERENCE LIST ELEMENTS -->
+  <!-- ============================================================= -->
+  <!--
+    ELEM   article-title
+    Defined in %common.ent;
+  -->
+  <!-- ELEM   collab       Defined in %common.ent; -->
+  <!-- ELEM   conf-date    Defined in %common.ent; -->
+  <!-- ELEM   conf-loc     Defined in %common.ent; -->
+  <!-- ELEM   conf-name    Defined in %common.ent; -->
+  <!-- ELEM   day          Defined in %common.ent; -->
+  <!-- ELEM   elocation-id Defined in %common.ent; -->
+  <!-- ELEM   email        Defined in %common.ent; -->
+  <!-- ELEM   fpage        Defined in %common.ent; -->
+  <!-- ELEM   issn         Defined in %common.ent; -->
+  <!-- ELEM   issn-l       Defined in %common.ent; -->
+  <!-- ELEM   issue        Defined in %common.ent; -->
+  <!-- ELEM   lpage        Defined in %common.ent; -->
+  <!-- ELEM   month        Defined in %common.ent; -->
+  <!--
+    ELEM   publisher-loc
+    Defined in %common.ent;
+  -->
+  <!--
+    ELEM   publisher-name
+    Defined in %common.ent;
+  -->
+  <!-- ELEM   season       Defined in %common.ent; -->
+  <!-- ELEM   title        Defined in %common.ent; -->
+  <!-- ELEM   trans-title  Defined in %common.ent; -->
+  <!-- ELEM   volume       Defined in %common.ent; -->
+  <!-- ELEM   year         Defined in %common.ent; -->
+  <!-- REFERENCE LIST MODEL -->
+  <!-- Content model for the <ref-list> element -->
+  <!-- REFERENCE LIST (BIBLIOGRAPHIC REFERENCE LIST) -->
+  <!--
+    List of references (citations) for the
+    article.  Often called "References",
+    "Bibliography", or "Additional Reading". No
+    distinction is made between lists of cited
+    references and lists of suggested references.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=ref-list
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=ref-list
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=ref-list
+  -->
+  <define name="ref-list">
+    <element name="ref-list">
+      <ref name="ref-list-attlist"/>
+      <ref name="ref-list-model"/>
+    </element>
+  </define>
+  <define name="ref-list-attlist" combine="interleave">
+    <ref name="ref-list-atts"/>
+  </define>
+  <!-- REFERENCE ITEM MODEL -->
+  <!-- Content model for the <ref> element -->
+  <!-- REFERENCE ITEM -->
+  <!--
+    One item in a bibliographic list, typically
+    a citation describing a referenced work, but
+    some journals may place notes in this list as
+    well as citations.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=ref
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=ref
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=ref
+  -->
+  <define name="ref">
+    <element name="ref">
+      <ref name="ref-attlist"/>
+      <ref name="ref-model"/>
+    </element>
+  </define>
+  <define name="ref-attlist" combine="interleave">
+    <ref name="ref-atts"/>
+  </define>
+  <!--
+    ELEM   element-citation
+    Defined in %common.ent;
+  -->
+  <!--
+    ELEM   mixed-citation
+    Defined in %common.ent;
+  -->
+  <!-- NOTE IN A REFERENCE LIST MODEL -->
+  <!--
+    Content model for a note in a reference
+    list element
+  -->
+  <define name="note-model">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <oneOrMore>
+      <choice>
+        <ref name="just-para.class"/>
+        <ref name="product.class"/>
+      </choice>
+    </oneOrMore>
+  </define>
+  <!-- NOTE IN A REFERENCE LIST -->
+  <!--
+    Used to tag non-citation material that
+    sometimes within a reference list, for
+    example, used to tag end note material when
+    such a note is placed within a reference
+    list.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=note
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=note
+  -->
+  <define name="note">
+    <element name="note">
+      <ref name="note-attlist"/>
+      <ref name="note-model"/>
+    </element>
+  </define>
+  <define name="note-attlist" combine="interleave">
+    <ref name="note-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- BIBLIOGRAPHIC REFERENCE CLASS -->
+  <!-- ============================================================= -->
+  <!-- ACCESS DATE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the Access Date <access-date> element
+  -->
+  <!-- ACCESS DATE FOR CITED WORK -->
+  <!--
+    The date on which the work which is cited
+    was examined. Some online resources are
+    changing so quickly that a citation to the
+    resource is not complete without the date
+    on which the cited resource was examined,
+    since a day before or a day later the
+    relevant material might be different.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=access-date
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=access-date
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=access-date
+  -->
+  <define name="access-date">
+    <element name="access-date">
+      <ref name="access-date-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="access-date-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="access-date-attlist" combine="interleave">
+    <ref name="access-date-atts"/>
+  </define>
+  <!-- ANNOTATION MODEL -->
+  <!--
+    The content model for the <annotation>
+    element
+  -->
+  <define name="annotation-model">
+    <oneOrMore>
+      <ref name="just-para.class"/>
+    </oneOrMore>
+  </define>
+  <!-- ANNOTATION IN A CITATION -->
+  <!--
+    Most citations just provide the bibliographic
+    information for a cited reference but a few
+    describe or comment upon the nature or
+    quality of the reference or summarize its
+    findings.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=annotation
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=annotation
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=annotation
+  -->
+  <define name="annotation">
+    <element name="annotation">
+      <ref name="annotation-attlist"/>
+      <ref name="annotation-model"/>
+    </element>
+  </define>
+  <define name="annotation-attlist" combine="interleave">
+    <ref name="annotation-atts"/>
+  </define>
+  <!-- CHAPTER TITLE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <chapter-title> element
+  -->
+  <define name="chapter-title-elements">
+    <ref name="source-elements"/>
+  </define>
+  <!-- CHAPTER TITLE IN A CITATION -->
+  <!--
+    Within a citation (such as a <mixed-citation>
+    or an <element-citation>), the title of a
+    cited book is tagged as <source> and the
+    title of a chapter within that book is tagged
+    as <chapter-title>.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=chapter-title
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=chapter-title
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=chapter-title
+  -->
+  <define name="chapter-title">
+    <element name="chapter-title">
+      <ref name="chapter-title-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="chapter-title-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="chapter-title-attlist" combine="interleave">
+    <ref name="chapter-title-atts"/>
+  </define>
+  <!-- COMMENT ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the Comment in a Citation <comment> element.
+    Design Note: All inline mixes begin with an
+    OR bar, but since %simple-phrase; is an
+    inline mix, the OR bar is already there.
+  -->
+  <!-- COMMENT IN A CITATION -->
+  <!--
+    Used to mark unstructured text within an
+    otherwise element structured reference.
+    In an unstructured reference, this text would
+    merely be data characters.
+    Typical comments could include:
+      <comment>[Abstract]</comment>
+      <comment> translated from Russian</comment>
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=comment
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=comment
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=comment
+  -->
+  <define name="comment">
+    <element name="comment">
+      <ref name="comment-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="comment-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="comment-attlist" combine="interleave">
+    <ref name="comment-atts"/>
+  </define>
+  <!-- DATA TITLE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <data-title>.
+  -->
+  <define name="data-title-elements">
+    <choice>
+      <ref name="address-link.class"/>
+      <ref name="inline-display-noalt.class"/>
+      <ref name="emphasis.class"/>
+      <ref name="phrase-content.class"/>
+      <ref name="subsup.class"/>
+    </choice>
+  </define>
+  <!-- DATA TITLE IN A CITATION -->
+  <!--
+    Within a citation (such as a <mixed-citation>
+    or an <element-citation>), the title of a
+    cited data source such as a dataset or
+    spreadsheet. 
+    REMARKS: Since datasets can contain very
+    complex relationships, for citing data, this 
+    element may describe different levels, taking
+    the place of both <article-title> and <source>
+    when citing data.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=data-title
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=data-title
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=data-title
+  -->
+  <define name="data-title">
+    <element name="data-title">
+      <ref name="data-title-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="data-title-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="data-title-attlist" combine="interleave">
+    <ref name="data-title-atts"/>
+  </define>
+  <!-- DATE IN CITATION ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the Date Inside Citation <date-in-citation>
+    element
+  -->
+  <!-- DATE INSIDE CITATION -->
+  <!--
+    A container element for any date that may be
+    referenced in a citation, other than the
+    publication date of the cited work.
+    The "content-type" attribute should be used
+    to identify the purpose/type of date. For
+    example, if the element contains the date
+    on which the article contributor examined the
+    cited work, the attribute might be
+    "access-date".
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=date-in-citation
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=date-in-citation
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=date-in-citation
+  -->
+  <define name="date-in-citation">
+    <element name="date-in-citation">
+      <ref name="date-in-citation-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="date-in-citation-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="date-in-citation-attlist" combine="interleave">
+    <ref name="date-in-citation-atts"/>
+  </define>
+  <!-- EDITION ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    <edition>
+    Design Note: -%just-rendition; begins with
+    an OR bar, so this inline mix begins with
+    an OR bar.
+  -->
+  <define name="edition-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- EDITION STATEMENT, CITED -->
+  <!--
+    The full edition statement for a cited or
+    referenced publication. This may include
+    textual words ("Third print edition revised"),
+    ordinals ("3rd"), superscripted ordinals
+    ("3<sup>rd</sup>), or simply the edition number
+    ("3"). 
+    Remarks: The @designator attribute may be used
+    to record the alphabetic or numerical 
+    edition number.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=edition
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=edition
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=edition
+  -->
+  <define name="edition">
+    <element name="edition">
+      <ref name="edition-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="edition-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="edition-attlist" combine="interleave">
+    <ref name="edition-atts"/>
+  </define>
+  <!-- GOVERNMENT REPORT ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    <gov>
+    Design Note: -%rendition-plus; begins with
+    an OR bar, so this inline mix begins with
+    an OR bar.
+  -->
+  <define name="gov-elements">
+    <ref name="rendition-plus"/>
+  </define>
+  <!-- GOVERNMENT REPORT, CITED -->
+  <!--
+    The identification information (typically the
+    title and/or an identification number) for
+    a cited governmental report or other
+    government publication
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=gov
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=gov
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=gov
+  -->
+  <define name="gov">
+    <element name="gov">
+      <ref name="gov-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="gov-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="gov-attlist" combine="interleave">
+    <ref name="gov-atts"/>
+  </define>
+  <!-- PART TITLE ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    the <part-title> element
+  -->
+  <define name="part-title-elements">
+    <ref name="source-elements"/>
+  </define>
+  <!-- PART TITLE IN A CITATION -->
+  <!--
+    Within a citation (such as a
+    <mixed-citation> or an <element-citation>),
+    when books are divided into Parts (which
+    may then contain smaller units such as
+    chapters), this element can be used to
+    record the title of the cited Part.
+    The book is tagged as <source>.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=part-title
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=part-title
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=part-title
+  -->
+  <define name="part-title">
+    <element name="part-title">
+      <ref name="part-title-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="part-title-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="part-title-attlist" combine="interleave">
+    <ref name="part-title-atts"/>
+  </define>
+  <!-- PATENT NUMBER ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    <patent>
+    Design Note: -%just-rendition; begins with
+    an OR bar, so this inline mix begins with
+    an OR bar.
+  -->
+  <define name="patent-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- PATENT NUMBER, CITED -->
+  <!--
+    The identification information (typically the
+    patent number or number and name) for a
+    cited patent
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=patent
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=patent
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=patent
+  -->
+  <define name="patent">
+    <element name="patent">
+      <ref name="patent-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="patent-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="patent-attlist" combine="interleave">
+    <ref name="patent-atts"/>
+  </define>
+  <!-- PERSON GROUP ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    <person-group>
+  -->
+  <!-- PERSON GROUP MODEL -->
+  <!-- Content model for the Person Group element -->
+  <define name="person-group-model">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="person-group-elements"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <!-- PERSON GROUP FOR A CITED PUBLICATION -->
+  <!--
+    Wrapper element for one or more authors,
+    editors, translators, etc. named in a cited
+    reference.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=person-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=person-group
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=person-group
+  -->
+  <define name="person-group">
+    <element name="person-group">
+      <ref name="person-group-attlist"/>
+      <ref name="person-group-model"/>
+    </element>
+  </define>
+  <define name="person-group-attlist" combine="interleave">
+    <ref name="person-group-atts"/>
+  </define>
+  <!-- PUBLICATION IDENTIFIER FOR A CITED PUBLICATION -->
+  <!--
+    The identifier of a publication such as a
+    related journal article that is listed
+    within a citation (such as a <mixed-citation>
+    or an <element-citation>) inside the
+    bibliographic reference list <ref-list> of
+    an article.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=pub-id
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=pub-id
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=pub-id
+  -->
+  <define name="pub-id">
+    <element name="pub-id">
+      <ref name="pub-id-attlist"/>
+      <text/>
+    </element>
+  </define>
+  <define name="pub-id-attlist" combine="interleave">
+    <ref name="pub-id-atts"/>
+  </define>
+  <!-- SERIES ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    <series>
+    Design Note: -%rendition-plus; begins with
+    an OR bar, so this inline mix begins with
+    an OR bar.
+  -->
+  <define name="series-elements">
+    <ref name="rendition-plus"/>
+  </define>
+  <!-- SERIES -->
+  <!--
+    Container element for any series information
+    used in a citation (such as a <mixed-citation>
+    or an <element-citation>). For example,
+    within a citation to a non-journal item that
+    spans multiple volumes, this element could
+    contain the unique title of the entire series:
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=series
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=series
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=series
+  -->
+  <define name="series">
+    <element name="series">
+      <ref name="series-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="series-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="series-attlist" combine="interleave">
+    <ref name="series-atts"/>
+  </define>
+  <!-- STANDARD ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    <std>
+    Design Note: -%rendition-plus; begins with
+    an OR bar, so this inline mix begins with
+    an OR bar.
+  -->
+  <define name="std-elements">
+    <choice>
+      <ref name="emphasis.class"/>
+      <ref name="inline-display-noalt.class"/>
+      <ref name="phrase-content.class"/>
+      <ref name="std.class"/>
+      <ref name="subsup.class"/>
+    </choice>
+  </define>
+  <!-- STANDARD, CITED -->
+  <!--
+    The identification information (typically the
+    standard number, organization, and name) for
+    a cited standard, where "standard" is defined
+    as a document produced by a recognized
+    standards body such ISO, IEEE, OASIS, ANSI,
+    etc.
+    The elements that can be used in the mixed
+    content model of a <std> include:
+      <source> contains the name of the standard
+      <pub-id> contains the standard designator
+      date elements name the official date
+      <std-organization> names the standards body
+      <named-content> takes anything else a 
+        publisher/archive needs.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=std
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=std
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=std
+  -->
+  <define name="std">
+    <element name="std">
+      <ref name="std-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="std-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="std-attlist" combine="interleave">
+    <ref name="std-atts"/>
+  </define>
+  <!-- STANDARDS ORGANIZATION ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    <std-organization>.
+  -->
+  <!-- STANDARDS ORGANIZATION -->
+  <!--
+    The name of the standards body that created 
+    or that promulgates a standard, such as
+    NISO, ISO, ANSI, or industry standards
+    organizations.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=std-organization
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=std-organization
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=std-organization
+  -->
+  <define name="std-organization">
+    <element name="std-organization">
+      <ref name="std-organization-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="std-organization-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="std-organization-attlist" combine="interleave">
+    <ref name="std-organization-atts"/>
+  </define>
+  <!-- SOURCE -->
+  <!--
+    Within a citation, this is the title of a
+    journal, book, conference proceedings, etc.
+    that is the source of the cited material.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=source
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=source
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=source
+  -->
+  <define name="source">
+    <element name="source">
+      <ref name="source-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="source-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="source-attlist" combine="interleave">
+    <ref name="source-atts"/>
+  </define>
+  <!-- TIME STAMP ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    a <time-stamp>.
+  -->
+  <!-- TIME STAMP FOR CITED WORK -->
+  <!--
+    Used to record any time stamp that was
+    found on the cited resource when it was
+    examined, for resources such as databases
+    that may use a time signature to identify
+    different versions.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=time-stamp
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=time-stamp
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=time-stamp
+  -->
+  <define name="time-stamp">
+    <element name="time-stamp">
+      <ref name="time-stamp-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="time-stamp-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="time-stamp-attlist" combine="interleave">
+    <ref name="time-stamp-atts"/>
+  </define>
+  <!-- TRANSLATED SOURCE -->
+  <!--
+    Within a citation, this is the title of a
+    journal, book, conference proceedings, etc.
+    that is the source of the cited material,
+    but with the source name given in a different
+    language from the source as given in the
+    <source> element. For example, if an article
+    is originally in French, the <source> name
+    would be the French name and the
+    <trans-source> might be in English.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=trans-source
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=trans-source
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=trans-source
+  -->
+  <define name="trans-source">
+    <element name="trans-source">
+      <ref name="trans-source-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="source-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="trans-source-attlist" combine="interleave">
+    <ref name="trans-source-atts"/>
+  </define>
+  <!-- VERSION ELEMENTS -->
+  <!--
+    The elements that can be included along with
+    data characters inside the content model of
+    <version>.
+    Design Note: -%just-rendition; begins with
+    an OR bar, so this inline mix begins with
+    an OR bar.
+  -->
+  <define name="version-elements">
+    <ref name="just-rendition"/>
+  </define>
+  <!-- VERSION STATEMENT, CITED -->
+  <!--
+    The version number for a cited dataset or
+    software package. This is similar to an
+    edition statement for a publication, in that it
+    may include textual words ("9th"), superscripted 
+    ordinals ("3<sup>rd</sup>), or simply the 
+    version number ("16.2"). 
+    Remarks: The @designator attribute may be used
+    to record the alphabetic or numerical 
+    version number, when the version number contains
+    more than just a number, so the numeric version
+    can be preserved for search and comparison.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=version
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=version
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=version
+  -->
+  <define name="version">
+    <element name="version">
+      <ref name="version-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="version-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="version-attlist" combine="interleave">
+    <ref name="version-atts"/>
+  </define>
+</grammar>
+<!-- ================== End Bibliographic Class Module =========== -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-related-object1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-related-object1.ent.rng
@@ -1,0 +1,387 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Related Object Element -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) JATS DTD Suite Related Object Element v1.2 20190208//EN"
+       Delivered as file "JATS-related-object1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Define the element <related-object>. [This -->
+<!--              module was previously part of the NLM Book Tag Set -->
+<!-- and named bookrelated-object.ent.] -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- February 2008 (book modules Oct 2006) -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- The Journal Publishing DTD is built from the -->
+<!-- Archiving and Interchange DTD Suite. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION\CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   15. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   14. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   13. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   12. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   11. JATS became version "1.2d1" and "v1.1d2 20170631" 
+  
+       =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+   10. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    9. JATS became version "1.1d3" and "v1.1 20150301//EN"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    8. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    7. GLOBAL ATTRIBUTES - Added the new parameter entity 
+           %jats-common-atts;
+       to every element in this module. This PE adds (for now) the
+       @id attribute and the @xml:base attribute to every element,
+       whether metadata or narrative.
+       Since the @id in this parameter entity is optional, a second
+       parameter entity jats-common-atts-id-required was also added.
+       The two are kept in sync with the jats-base-atts parameter 
+       entity.
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    6. RELATED-OBJECT ATTRIBUTES - Added the attribute @ext-link-type
+  
+    5. RELATED-OBJECT ATTRIBUTES - Added the linking attribute to
+       <related-object> through the "might-link-atts".
+  
+    4. Updated the DTD-version attribute to "1.0" and the formal
+       public identifier to the date: "v1.0 20120330//EN".
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    3. Updated the DTD-version attribute to "0.4" 
+  
+    2. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- RELATED OBJECT ATTRIBUTES -->
+<!-- ============================================================= -->
+<!-- RELATED OBJECT ATTRIBUTES -->
+<!-- Attributes for <related-object> -->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="related-object-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="link-type"/>
+    </optional>
+    <optional>
+      <attribute name="ext-link-type"/>
+    </optional>
+    <optional>
+      <attribute name="source-id"/>
+    </optional>
+    <optional>
+      <attribute name="source-id-type"/>
+    </optional>
+    <optional>
+      <attribute name="source-type"/>
+    </optional>
+    <optional>
+      <attribute name="document-id"/>
+    </optional>
+    <optional>
+      <attribute name="document-id-type"/>
+    </optional>
+    <optional>
+      <attribute name="document-type"/>
+    </optional>
+    <optional>
+      <attribute name="object-id"/>
+    </optional>
+    <optional>
+      <attribute name="object-id-type"/>
+    </optional>
+    <optional>
+      <attribute name="object-type"/>
+    </optional>
+    <optional>
+      <attribute name="content-type"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <ref name="might-link-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- RELATED OBJECT ELEMENT -->
+  <!-- ============================================================= -->
+  <!-- RELATED OBJECT ELEMENTS -->
+  <!-- Elements allowed inside <related-object> -->
+  <!-- RELATED OBJECT INFORMATION -->
+  <!--
+    Wrapper element, used as a container for
+    text links to a related object, possibly
+    accompanied by a very brief description of
+    the object, for example a related book, a
+    related chapter or figure in a book, a
+    related dataset, etc.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=related-object
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=related-object
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=related-object
+  -->
+  <define name="related-object">
+    <element name="related-object">
+      <ref name="related-object-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="related-object-elements"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="related-object-attlist" combine="interleave">
+    <ref name="related-object-atts"/>
+  </define>
+</grammar>
+<!-- ================== End Related Object Element Module ======== -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-section1.ent.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/JATS-section1.ent.rng
@@ -1,0 +1,429 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!-- MODULE:    Section Class Elements -->
+<!-- VERSION:   ANSI/NISO JATS Version 1.2 (Z39.96-2019) -->
+<!-- DATE:      February 2019 -->
+<!---->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- PUBLIC DOCUMENT TYPE DEFINITION -->
+<!-- TYPICAL INVOCATION -->
+<!--
+  "-//NLM//DTD JATS (Z39.96) JATS DTD Suite Section Class Elements v1.2 20190208//EN"
+       Delivered as file "JATS-section1.ent"
+-->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite -->
+<!---->
+<!-- PURPOSE:    Defines the member of the sec.class, that is, -->
+<!-- names all section-level elements in the -->
+<!-- JATS DTD Suite -->
+<!---->
+<!-- At the time of the initial DTD creation -->
+<!-- there is only one such element, Section itself -->
+<!-- <sec>, but future expansion to named sections -->
+<!-- (such as <methodology> or <materials> or any -->
+<!-- new section-level structures would be added here. -->
+<!---->
+<!-- TAG SET SPONSOR -->
+<!-- National Center for Biotechnology -->
+<!-- Information (NCBI) -->
+<!-- National Library of Medicine (NLM) -->
+<!---->
+<!-- CREATED FOR: -->
+<!-- This module was created for the JATS DTD Suite. -->
+<!-- Digital archives and publishers may use the -->
+<!-- DTD as is for markup of journal literature or -->
+<!-- related material for archiving and transferring -->
+<!-- such material between archives or create a -->
+<!-- custom XML DTD from the Suite for -->
+<!-- these purposes. -->
+<!---->
+<!-- This DTD is in the public domain. An organization -->
+<!-- that wishes to create its own DTD from the suite -->
+<!-- may do so without permission from NLM. -->
+<!---->
+<!-- The suite has been set up to be extended using a -->
+<!-- new DTD file and a new DTD-specific customization -->
+<!-- module to redefine the many Parameter Entities. -->
+<!-- Do not modify the suite directly or redistribute -->
+<!-- modified versions of the suite. -->
+<!---->
+<!-- In the interest of maintaining consistency and -->
+<!-- clarity for potential users, NLM requests: -->
+<!---->
+<!-- 1. If you create a DTD from the JATS DTD Suite -->
+<!-- and intend to stay compatible with the suite, -->
+<!-- then please include the following statement -->
+<!-- as a comment in all of your DTD modules: -->
+<!-- "Created from, and fully compatible with, -->
+<!-- the ANSI/NISO Z39.96 Journal Article Tag -->
+<!-- Suite (JATS)." -->
+<!---->
+<!-- 2. If you alter one or more modules of the suite, -->
+<!-- then please rename your version and all its -->
+<!-- modules to avoid any confusion with the -->
+<!-- original suite. Also, please include the -->
+<!-- following statement as a comment in all your -->
+<!-- DTD modules: -->
+<!-- "Based in part on, but not fully compatible -->
+<!-- with, the ANSI/NISO Z39.96 Journal Article -->
+<!-- Tag Suite (JATS)." -->
+<!---->
+<!-- ORIGINAL CREATION DATE: -->
+<!-- December 2002 -->
+<!---->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96 -->
+<!-- Working Group. Mulberry Technologies was -->
+<!-- supported by National Center for Biotechnology -->
+<!-- Information (NCBI), a center of the US National -->
+<!-- Library of Medicine (NLM). -->
+<!---->
+<!-- This module is part of the JATS DTD Suite. The -->
+<!-- Suite is a continuation of work done by NCBI, -->
+<!-- Mulberry Technologies, and Inera Inc. on the NLM -->
+<!--              Journal Archiving and Interchange DTD Suite, which -->
+<!-- was originally released in December, 2002. -->
+<!---->
+<!-- NLM thanks the Harvard University Libraries, both -->
+<!-- for proposing that a draft archiving NLM DTD for -->
+<!-- life sciences journals be extended to accommodate -->
+<!-- journals in all disciplines and for sponsoring -->
+<!-- Inera Inc.'s collaboration with other DTD -->
+<!-- authors in completing NLM Version 1.0. The -->
+<!-- Andrew W. Mellon Foundation provided support for -->
+<!-- these important contributions. -->
+<!---->
+<!-- Suggestions for refinements and enhancements to -->
+<!-- this DTD should be sent in email to: -->
+<!-- jats@ncbi.nlm.nih.gov -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- DTD VERSION/CHANGE HISTORY -->
+<!-- ============================================================= -->
+<!--
+  Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2019)
+                                     (DAL/BTU) v1.2     (2019-02-08)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI vote on Feb 08, 2019, so it supersedes all Committee 
+       Drafts as well as the draft version JATS 1.2 2018 (the version
+       submitted for vote), becoming NISO JATS v1.2 20190208 
+       (ANSI/NISO Z39.96-2019).
+  
+   13. JATS "1.2" becomes "v1.2 20190208" (final ANSI vote date)
+       "ANSI/NISO Z39.96-2015" becomes "ANSI/NISO Z39.96-2019"
+  
+     ==============================================================
+       JATS Version 1.2 (ANSI/NISO Z39.96-2018)
+       and BITS 2.1 (v2.0 20180401)
+                                     (DAL/BTU) v1.2     (2018-11-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the both the NISO and ANSI membership 
+       to be changed. This version of the NISO JATS was approved 
+       by ANSI and NISO vote, so it supersedes all Committee Drafts
+       and becoming NISO JATS 1.2 (ANSI/NISO Z39.96-2018).
+  
+   12. BITS "2.1" and "v2.0 20180401" remains unchanged.
+       JATS "1.2d2" and "v1.2d2 20180401" became
+       JATS "1.2" and "v1.2 20181130" 
+  
+      =============================================================
+       BITS Version 2.1                (DAL/BTU) v2.1    (2018-04-01)
+       JATS Version 1.2d2              (DAL/BTU) v1.2d2  (2018-04-01)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       BITS is under continuous maintenance, and is modified at the
+       discretion of the working group.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   11. BITS "2.0" and "v2.0 20151225" became
+       BITS "2.1" and "v2.1 20180401". 
+  
+       JATS "1.2d1" and "v1.2d1 20171231" became
+       JATS "1.2d2" and "v1.2d2 20180401". 
+  
+       No module names were changed.
+  
+      =============================================================
+       JATS Version 1.2d1 (ANSI/NISO Z39.96-2015)
+                                     (DAL/BTU) v1.2d1  (2017-12-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+   10. JATS "1.2d1" and "v1.2d1 20170631" became
+       JATS "1.2d1" and "v1.2d1 20171231". 
+  
+      =============================================================
+       JATS Version 1.2d1              (DAL/BTU) v1.2d1  (2017-06-31)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee. This draft has not yet been given public review 
+       or voting. The formal public identifiers were changed in the 
+       modules and the catalogs.
+  
+    9. JATS became version "1.2d1" and "v1.2d1 20170631" 
+  
+       =============================================================
+       JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+  
+       JATS is a continuing maintenance NISO Standard, which
+       requires voting by the ANSI and NISO memberships to be changed. 
+       JATS 1.1 was approved in late 2015, so the formal public 
+       identifiers were changed in the modules and the catalogs.
+       No model or attribute changes were made at this time. 
+  
+    8. JATS became version "1.1" and "v1.1 20151215"
+  
+       =============================================================
+       JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+  
+       The changes in this release are in response to NISO 
+       License and Indicators Recommended Practice.
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d3 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This draft DTD represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+  
+    7. JATS became version "1.1d3" and "v1.1 20150301//EN"
+  
+       =============================================================
+       JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+  
+       NISO JATS is a continuing maintenance NISO Standard, which 
+       requires voting by the NISO membership to be changed. This
+       Committee Draft 1.1d2 will be sent to the NISO voting
+       membership, to become (if approved) NISO JATS 1.1.
+  
+       This catalog represents an interim version of the
+       non-normative JATS DTD Suite, as an indication to JATS users
+       the decisions that have been made by the JATS Standing
+       Committee.
+    6. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+       =============================================================
+       NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+  
+       ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+  
+       NISO JATS Standing Committee met and answered the requests and
+       suggestions from the NISO request forms.
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    5. GLOBAL ATTRIBUTES - Added the new parameter entity 
+           %jats-common-atts;
+       to every element in this module. This PE adds (for now) the
+       @id attribute and the @xml:base attribute to every element,
+       whether metadata or narrative.
+       Since the @id in this parameter entity is optional, a second
+       parameter entity jats-common-atts-id-required was also added.
+       The two are kept in sync with the jats-base-atts parameter 
+       entity.
+       This added an attribute list to:
+        - floats-group
+        - sec-meta
+  
+       =============================================================
+       NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+  
+       ANSI/NISO Z39.96-2012 (Version 1.0) 
+  
+       Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+       XSDs, RNGs and supporting documentation are available at
+             http://jats.nlm.nih.gov/1.0/
+  
+    4. Updated the DTD-version attribute to "1.0" and the formal
+       public identifier to the date: "v1.0 20120330//EN".
+  
+       =============================================================
+       Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+  
+       This Tag Set is in the process of becoming a NISO standard.
+       The version numbers are starting over from 0.4", as a Trial
+       Use Draft, to be made into "Version 1.0" when the Tag Suite 
+       becomes a NISO standard. Thus, the version number that would
+       have been "NLM Version 3.1 Draft" has become NISO JATS
+       "Version 0.4".
+  
+       Details on NISO Trial Use Draft Version 0.4 are available at
+             http://jats.nlm.nih.gov/JATS-0.4.
+  
+    3. Updated the DTD-version attribute to "0.4" 
+  
+    2. Updated the public identifier to "v0.4 20110131", 
+       modified the formal public identifier to include "JATS (Z39.96)",
+       and the filename as delivered to include "JATS" and the
+       new version number "0".
+  
+       =============================================================
+       Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+  
+       Version 3.0 is the first non-backward-compatible release.
+       In addition to the usual incremental changes, some
+       elements and attributes have been renamed and/or remodeled
+       to better meet user needs and to increase tag set consistency.
+       All module change histories are available through the Tag Suite
+       web site at http://dtd.nlm.nih.gov.
+  
+       Details on version 3.0 are available at
+             http://dtd.nlm.nih.gov/3.0.
+  
+    1. Updated public identifier to "v3.0 20071031//EN"
+-->
+<!-- ============================================================= -->
+<!--
+  Details concerning 
+  ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+  RNGs and supporting documentation are available at
+        http://jats.nlm.nih.gov/1.1/
+-->
+<!-- ============================================================= -->
+<!-- DEFAULTS FOR ATTRIBUTE LISTS -->
+<!-- ============================================================= -->
+<!-- FLOATS GROUP ATTRIBUTES -->
+<!-- Attributes for the <floats-group> element -->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="floats-group-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- SECTION ATTRIBUTES -->
+  <!-- Attribute list for Section element -->
+  <define name="sec-atts">
+    <ref name="jats-common-atts"/>
+    <optional>
+      <attribute name="xml:lang">
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="sec-type"/>
+    </optional>
+    <optional>
+      <attribute name="disp-level"/>
+    </optional>
+    <optional>
+      <attribute name="specific-use"/>
+    </optional>
+  </define>
+  <!-- SECTION METADATA ATTRIBUTES -->
+  <!-- Attributes for the <sec-meta> element -->
+  <define name="sec-meta-atts">
+    <ref name="jats-common-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- FLOATS GROUP ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- FLOATS GROUP MODEL -->
+  <!--
+    Model for the container element
+    <floats-group>, which can be used to hold all
+    the floating elements such as tables and
+    figures within an <article>.
+  -->
+  <define name="floats-group-model">
+    <zeroOrMore>
+      <ref name="floats-display.class"/>
+    </zeroOrMore>
+  </define>
+  <!-- FLOATS GROUP -->
+  <!--
+    This container element is just a group to
+    hold the floating objects that occur within
+    an article. Some publishers like to
+    collect all these floating objects (figures,
+    tables, text boxes, graphics, etc.) together
+    at the end  rather than interspersing them
+    throughout the various parts of the document
+    where they are referenced.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=floats-group
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=floats-group
+  -->
+  <define name="floats-group">
+    <element name="floats-group">
+      <ref name="floats-group-attlist"/>
+      <ref name="floats-group-model"/>
+    </element>
+  </define>
+  <define name="floats-group-attlist" combine="interleave">
+    <ref name="floats-group-atts"/>
+  </define>
+  <!-- ============================================================= -->
+  <!-- SECTION ELEMENTS -->
+  <!-- ============================================================= -->
+  <!-- SECTION -->
+  <!--
+    A headed group of material; the basic
+    structural unit of the article
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=sec
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=sec
+    http://jats.nlm.nih.gov/articleauthoring/tag-library/1.2d2/index.html?elem=sec
+  -->
+  <define name="sec">
+    <element name="sec">
+      <ref name="sec-attlist"/>
+      <ref name="sec-model"/>
+    </element>
+  </define>
+  <define name="sec-attlist" combine="interleave">
+    <ref name="sec-atts"/>
+  </define>
+  <!-- SECTION METADATA -->
+  <!--
+    In some articles, each section has a different
+    author or some sections are authored by
+    different contributors from the enclosing
+    article. This container element for
+    section-level metadata is used to capture
+    information such as those contributors.
+    Details at:
+    http://jats.nlm.nih.gov/archiving/tag-library/1.2d2/index.html?elem=sec-meta
+    http://jats.nlm.nih.gov/publishing/tag-library/1.2d2/index.html?elem=sec-meta
+  -->
+  <define name="sec-meta">
+    <element name="sec-meta">
+      <ref name="sec-meta-attlist"/>
+      <ref name="sec-meta-model"/>
+    </element>
+  </define>
+  <define name="sec-meta-attlist" combine="interleave">
+    <ref name="sec-meta-atts"/>
+  </define>
+</grammar>
+<!-- ================== End Section Class Module ================= -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/mathml2-qname-1.mod.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/mathml2-qname-1.mod.rng
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ....................................................................... -->
+<!-- MathML Qualified Names Module  ........................................ -->
+<!--
+  file: mathml2-qname-1.mod
+  
+  This is the Mathematical Markup Language (MathML) 2.0, an XML 
+  application for describing mathematical notation and capturing 
+  both its structure and content.
+  
+  Copyright 1998-2000 W3C (MIT, INRIA, Keio), All Rights Reserved.
+  Revision: $Id: mathml2-qname-1.mod,v 1.2 2003/04/08 00:11:16 davidc Exp $ 
+  
+  This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+  
+    PUBLIC "-//W3C//ENTITIES MathML 2.0 Qualified Names 1.0//EN"
+    SYSTEM "mathml2-qname-1.mod"
+  
+  Revisions:
+  (none)
+  .......................................................................
+-->
+<!--
+  MathML Qualified Names
+  
+  This module is contained in two parts, labeled Section 'A' and 'B':
+  
+    Section A declares parameter entities to support namespace-
+    qualified names, namespace declarations, and name prefixing 
+    for MathML.
+  
+    Section B declares parameter entities used to provide
+    namespace-qualified names for all MathML element types.
+  
+  This module is derived from the XHTML Qualified Names Template module.
+-->
+<!-- Section A: XHTML XML Namespace Framework :::::::::::::::::::: -->
+<!-- XLink ............... -->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <define name="XLINK.xmlns.attrib">
+    <empty/>
+  </define>
+  <!-- W3C XML Schema ............... -->
+  <!-- MathML .............. -->
+  <define name="MATHML.xmlns.extra.attrib">
+    <empty/>
+  </define>
+  <define name="MATHML.xmlns.attrib">
+    <ref name="MATHML.xmlns.extra.attrib"/>
+  </define>
+</grammar>
+<!-- Section B: MathML Qualified Names ::::::::::::::::::::::::::::: -->
+<!--
+  9. This section declares parameter entities used to provide
+  namespace-qualified names for all MathML element types.
+-->
+<!--
+  ignores subsequent instantiation of this module when
+  used as external subset rather than module fragment.
+  NOTE: Do not modify this parameter entity, otherwise
+  a recursive parsing situation may result.
+-->
+<!-- end of template-qname-1.mod -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/mathml2.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/mathml2.rng
@@ -1,0 +1,3320 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- MathML 2.0 DTD  ....................................................... -->
+<!-- file: mathml2.dtd -->
+<!--
+  MathML 2.0 DTD
+  
+  This is the Mathematical Markup Language (MathML) 2.0, an XML
+  application for describing mathematical notation and capturing
+  both its structure and content.
+  
+  Copyright &#xa9; 1998-2003 W3C&#xae; (MIT, ERCIM, Keio), All Rights 
+  Reserved. W3C liability, trademark, document use and software
+  licensing rules apply. 
+  
+  Permission to use, copy, modify and distribute the MathML 2.0 DTD and
+  its accompanying documentation for any purpose and without fee is
+  hereby granted in perpetuity, provided that the above copyright notice
+  and this paragraph appear in all copies.  The copyright holders make
+  no representation about the suitability of the DTD for any purpose.
+  
+  It is provided "as is" without expressed or implied warranty.
+  
+     Revision:   $Id: mathml2.dtd,v 1.12 2003/11/04 13:14:35 davidc Exp $
+  
+  This entity may be identified by the PUBLIC and SYSTEM identifiers:
+  
+    PUBLIC "-//W3C//DTD MathML 2.0//EN"
+    SYSTEM "mathml2.dtd"
+  
+  Revisions: editor and revision history at EOF
+-->
+<!--
+  Entity used to enable marked sections which enforces stricter		
+  checking of MathML syntax rules		
+-->
+<!-- MathML Qualified Names module ............................... -->
+<grammar xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <include href="mathml2-qname-1.mod.rng"/>
+  <!--
+    if %NS.prefixed; is INCLUDE, include all NS attributes, 
+    otherwise just those associated with MathML
+  -->
+  <define name="MATHML.NamespaceDecl.attrib">
+    <ref name="MATHML.xmlns.attrib"/>
+  </define>
+  <!-- Attributes shared by all elements  .......................... -->
+  <define name="MATHML.Common.attrib">
+    <ref name="MATHML.NamespaceDecl.attrib"/>
+    <optional>
+      <attribute name="xlink:href"/>
+    </optional>
+    <optional>
+      <attribute name="xlink:type"/>
+    </optional>
+    <optional>
+      <attribute name="class"/>
+    </optional>
+    <optional>
+      <attribute name="style"/>
+    </optional>
+    <optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xref">
+        <data type="IDREF"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="other"/>
+    </optional>
+  </define>
+  <!-- Presentation element set  ................................... -->
+  <!-- Attribute definitions -->
+  <define name="att-fontsize">
+    <optional>
+      <attribute name="fontsize"/>
+    </optional>
+  </define>
+  <define name="att-fontweight">
+    <optional>
+      <attribute name="fontweight">
+        <choice>
+          <value>normal</value>
+          <value>bold</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="att-fontstyle">
+    <optional>
+      <attribute name="fontstyle">
+        <choice>
+          <value>normal</value>
+          <value>italic</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="att-fontfamily">
+    <optional>
+      <attribute name="fontfamily"/>
+    </optional>
+  </define>
+  <define name="att-color">
+    <optional>
+      <attribute name="color"/>
+    </optional>
+  </define>
+  <!-- MathML2 typographically-distinguished symbol attributes -->
+  <define name="att-mathvariant">
+    <optional>
+      <attribute name="mathvariant"/>
+    </optional>
+  </define>
+  <define name="att-mathsize">
+    <optional>
+      <attribute name="mathsize"/>
+    </optional>
+  </define>
+  <define name="att-mathcolor">
+    <optional>
+      <attribute name="mathcolor"/>
+    </optional>
+  </define>
+  <define name="att-mathbackground">
+    <optional>
+      <attribute name="mathbackground"/>
+    </optional>
+  </define>
+  <define name="att-fontinfo">
+    <ref name="att-fontsize"/>
+    <ref name="att-fontweight"/>
+    <ref name="att-fontstyle"/>
+    <ref name="att-fontfamily"/>
+    <ref name="att-color"/>
+    <ref name="att-mathvariant"/>
+    <ref name="att-mathsize"/>
+    <ref name="att-mathcolor"/>
+    <ref name="att-mathbackground"/>
+  </define>
+  <define name="att-form">
+    <optional>
+      <attribute name="form">
+        <choice>
+          <value>prefix</value>
+          <value>infix</value>
+          <value>postfix</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="att-fence">
+    <optional>
+      <attribute name="fence">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="att-separator">
+    <optional>
+      <attribute name="separator">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="att-lspace">
+    <optional>
+      <attribute name="lspace"/>
+    </optional>
+  </define>
+  <define name="att-rspace">
+    <optional>
+      <attribute name="rspace"/>
+    </optional>
+  </define>
+  <define name="att-stretchy">
+    <optional>
+      <attribute name="stretchy">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="att-symmetric">
+    <optional>
+      <attribute name="symmetric">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="att-maxsize">
+    <optional>
+      <attribute name="maxsize"/>
+    </optional>
+  </define>
+  <define name="att-minsize">
+    <optional>
+      <attribute name="minsize"/>
+    </optional>
+  </define>
+  <define name="att-largeop">
+    <optional>
+      <attribute name="largeop">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="att-movablelimits">
+    <optional>
+      <attribute name="movablelimits">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="att-accent">
+    <optional>
+      <attribute name="accent">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="att-opinfo">
+    <ref name="att-form"/>
+    <ref name="att-fence"/>
+    <ref name="att-separator"/>
+    <ref name="att-lspace"/>
+    <ref name="att-rspace"/>
+    <ref name="att-stretchy"/>
+    <ref name="att-symmetric"/>
+    <ref name="att-maxsize"/>
+    <ref name="att-minsize"/>
+    <ref name="att-largeop"/>
+    <ref name="att-movablelimits"/>
+    <ref name="att-accent"/>
+  </define>
+  <define name="att-width">
+    <optional>
+      <attribute name="width"/>
+    </optional>
+  </define>
+  <define name="att-height">
+    <optional>
+      <attribute name="height"/>
+    </optional>
+  </define>
+  <define name="att-depth">
+    <optional>
+      <attribute name="depth"/>
+    </optional>
+  </define>
+  <define name="att-linebreak">
+    <optional>
+      <attribute name="linebreak"/>
+    </optional>
+  </define>
+  <define name="att-sizeinfo">
+    <ref name="att-width"/>
+    <ref name="att-height"/>
+    <ref name="att-depth"/>
+  </define>
+  <define name="att-lquote">
+    <optional>
+      <attribute name="lquote"/>
+    </optional>
+  </define>
+  <define name="att-rquote">
+    <optional>
+      <attribute name="rquote"/>
+    </optional>
+  </define>
+  <define name="att-linethickness">
+    <optional>
+      <attribute name="linethickness"/>
+    </optional>
+  </define>
+  <define name="att-scriptlevel">
+    <optional>
+      <attribute name="scriptlevel"/>
+    </optional>
+  </define>
+  <define name="att-displaystyle">
+    <optional>
+      <attribute name="displaystyle">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="att-scriptsizemultiplier">
+    <optional>
+      <attribute name="scriptsizemultiplier"/>
+    </optional>
+  </define>
+  <define name="att-scriptminsize">
+    <optional>
+      <attribute name="scriptminsize"/>
+    </optional>
+  </define>
+  <define name="att-background">
+    <optional>
+      <attribute name="background"/>
+    </optional>
+  </define>
+  <define name="att-veryverythinmathspace">
+    <optional>
+      <attribute name="veryverythinmathspace"/>
+    </optional>
+  </define>
+  <define name="att-verythinmathspace">
+    <optional>
+      <attribute name="verythinmathspace"/>
+    </optional>
+  </define>
+  <define name="att-thinmathspace">
+    <optional>
+      <attribute name="thinmathspace"/>
+    </optional>
+  </define>
+  <define name="att-mediummathspace">
+    <optional>
+      <attribute name="mediummathspace"/>
+    </optional>
+  </define>
+  <define name="att-thickmathspace">
+    <optional>
+      <attribute name="thickmathspace"/>
+    </optional>
+  </define>
+  <define name="att-verythickmathspace">
+    <optional>
+      <attribute name="verythickmathspace"/>
+    </optional>
+  </define>
+  <define name="att-veryverythickmathspace">
+    <optional>
+      <attribute name="veryverythickmathspace"/>
+    </optional>
+  </define>
+  <define name="att-open">
+    <optional>
+      <attribute name="open"/>
+    </optional>
+  </define>
+  <define name="att-close">
+    <optional>
+      <attribute name="close"/>
+    </optional>
+  </define>
+  <define name="att-separators">
+    <optional>
+      <attribute name="separators"/>
+    </optional>
+  </define>
+  <define name="att-subscriptshift">
+    <optional>
+      <attribute name="subscriptshift"/>
+    </optional>
+  </define>
+  <define name="att-superscriptshift">
+    <optional>
+      <attribute name="superscriptshift"/>
+    </optional>
+  </define>
+  <define name="att-accentunder">
+    <optional>
+      <attribute name="accentunder">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="att-align">
+    <optional>
+      <attribute name="align"/>
+    </optional>
+  </define>
+  <define name="att-numalign">
+    <optional>
+      <attribute name="numalign"/>
+    </optional>
+  </define>
+  <define name="att-denomalign">
+    <optional>
+      <attribute name="denomalign"/>
+    </optional>
+  </define>
+  <define name="att-rowalign-list">
+    <optional>
+      <attribute name="rowalign"/>
+    </optional>
+  </define>
+  <define name="att-columnalign-list">
+    <optional>
+      <attribute name="columnalign"/>
+    </optional>
+  </define>
+  <define name="att-rowalign">
+    <optional>
+      <attribute name="rowalign"/>
+    </optional>
+  </define>
+  <define name="att-columnalign">
+    <optional>
+      <attribute name="columnalign"/>
+    </optional>
+  </define>
+  <define name="att-columnwidth">
+    <optional>
+      <attribute name="columnwidth"/>
+    </optional>
+  </define>
+  <define name="att-groupalign-list">
+    <optional>
+      <attribute name="groupalign"/>
+    </optional>
+  </define>
+  <define name="att-groupalign">
+    <optional>
+      <attribute name="groupalign"/>
+    </optional>
+  </define>
+  <define name="att-alignmentscope">
+    <optional>
+      <attribute name="alignmentscope"/>
+    </optional>
+  </define>
+  <define name="att-rowspacing">
+    <optional>
+      <attribute name="rowspacing"/>
+    </optional>
+  </define>
+  <define name="att-columnspacing">
+    <optional>
+      <attribute name="columnspacing"/>
+    </optional>
+  </define>
+  <define name="att-rowlines">
+    <optional>
+      <attribute name="rowlines"/>
+    </optional>
+  </define>
+  <define name="att-columnlines">
+    <optional>
+      <attribute name="columnlines"/>
+    </optional>
+  </define>
+  <define name="att-frame">
+    <optional>
+      <attribute name="frame">
+        <choice>
+          <value>none</value>
+          <value>solid</value>
+          <value>dashed</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="att-side">
+    <optional>
+      <attribute name="side">
+        <choice>
+          <value>left</value>
+          <value>right</value>
+          <value>leftoverlap</value>
+          <value>rightoverlap</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="att-framespacing">
+    <optional>
+      <attribute name="framespacing"/>
+    </optional>
+  </define>
+  <define name="att-minlabelspacing">
+    <optional>
+      <attribute name="minlabelspacing"/>
+    </optional>
+  </define>
+  <define name="att-equalrows">
+    <optional>
+      <attribute name="equalrows"/>
+    </optional>
+  </define>
+  <define name="att-equalcolumns">
+    <optional>
+      <attribute name="equalcolumns"/>
+    </optional>
+  </define>
+  <define name="att-tableinfo">
+    <ref name="att-align"/>
+    <ref name="att-rowalign-list"/>
+    <ref name="att-columnalign-list"/>
+    <ref name="att-columnwidth"/>
+    <ref name="att-groupalign-list"/>
+    <ref name="att-alignmentscope"/>
+    <ref name="att-side"/>
+    <ref name="att-rowspacing"/>
+    <ref name="att-columnspacing"/>
+    <ref name="att-rowlines"/>
+    <ref name="att-columnlines"/>
+    <ref name="att-width"/>
+    <ref name="att-frame"/>
+    <ref name="att-framespacing"/>
+    <ref name="att-minlabelspacing"/>
+    <ref name="att-equalrows"/>
+    <ref name="att-equalcolumns"/>
+    <ref name="att-displaystyle"/>
+  </define>
+  <define name="att-rowspan">
+    <optional>
+      <attribute name="rowspan"/>
+    </optional>
+  </define>
+  <define name="att-columnspan">
+    <optional>
+      <attribute name="columnspan"/>
+    </optional>
+  </define>
+  <define name="att-edge">
+    <optional>
+      <attribute name="edge">
+        <choice>
+          <value>left</value>
+          <value>right</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="att-actiontype">
+    <optional>
+      <attribute name="actiontype"/>
+    </optional>
+  </define>
+  <define name="att-selection">
+    <optional>
+      <attribute name="selection"/>
+    </optional>
+  </define>
+  <define name="att-name">
+    <optional>
+      <attribute name="name"/>
+    </optional>
+  </define>
+  <define name="att-alt">
+    <optional>
+      <attribute name="alt"/>
+    </optional>
+  </define>
+  <define name="att-index">
+    <optional>
+      <attribute name="index"/>
+    </optional>
+  </define>
+  <define name="att-bevelled">
+    <optional>
+      <attribute name="bevelled"/>
+    </optional>
+  </define>
+  <!-- Presentation schemata with content -->
+  <define name="ptoken">
+    <choice>
+      <ref name="mml.mi"/>
+      <ref name="mml.mn"/>
+      <ref name="mml.mo"/>
+      <ref name="mml.mtext"/>
+      <ref name="mml.ms"/>
+    </choice>
+  </define>
+  <define name="mml.mi-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-fontinfo"/>
+  </define>
+  <define name="mml.mn-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-fontinfo"/>
+  </define>
+  <define name="mml.mo-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-fontinfo"/>
+    <ref name="att-opinfo"/>
+  </define>
+  <define name="mml.mtext-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-fontinfo"/>
+  </define>
+  <define name="mml.ms-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-fontinfo"/>
+    <ref name="att-lquote"/>
+    <ref name="att-rquote"/>
+  </define>
+  <!-- Empty presentation schemata -->
+  <define name="petoken">
+    <ref name="mml.mspace"/>
+  </define>
+  <define name="mml.mspace">
+    <element name="mml:mspace">
+      <ref name="mml.mspace-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.mspace-attlist" combine="interleave">
+    <ref name="att-sizeinfo"/>
+    <ref name="att-linebreak"/>
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <!-- Presentation: general layout schemata -->
+  <define name="pgenschema">
+    <choice>
+      <ref name="mml.mrow"/>
+      <ref name="mml.mfrac"/>
+      <ref name="mml.msqrt"/>
+      <ref name="mml.mroot"/>
+      <ref name="mml.menclose"/>
+      <ref name="mml.mstyle"/>
+      <ref name="mml.merror"/>
+      <ref name="mml.mpadded"/>
+      <ref name="mml.mphantom"/>
+      <ref name="mml.mfenced"/>
+    </choice>
+  </define>
+  <define name="mml.mrow-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <define name="mml.mfrac-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-bevelled"/>
+    <ref name="att-numalign"/>
+    <ref name="att-denomalign"/>
+    <ref name="att-linethickness"/>
+  </define>
+  <define name="mml.msqrt-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <define name="mml.menclose-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <optional>
+      <attribute name="notation" a:defaultValue="longdiv"/>
+    </optional>
+  </define>
+  <define name="mml.mroot-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <define name="mml.mstyle-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-fontinfo"/>
+    <ref name="att-opinfo"/>
+    <ref name="att-lquote"/>
+    <ref name="att-rquote"/>
+    <ref name="att-linethickness"/>
+    <ref name="att-scriptlevel"/>
+    <ref name="att-scriptsizemultiplier"/>
+    <ref name="att-scriptminsize"/>
+    <ref name="att-background"/>
+    <ref name="att-veryverythinmathspace"/>
+    <ref name="att-verythinmathspace"/>
+    <ref name="att-thinmathspace"/>
+    <ref name="att-mediummathspace"/>
+    <ref name="att-thickmathspace"/>
+    <ref name="att-verythickmathspace"/>
+    <ref name="att-veryverythickmathspace"/>
+    <ref name="att-open"/>
+    <ref name="att-close"/>
+    <ref name="att-separators"/>
+    <ref name="att-subscriptshift"/>
+    <ref name="att-superscriptshift"/>
+    <ref name="att-accentunder"/>
+    <ref name="att-tableinfo"/>
+    <ref name="att-rowspan"/>
+    <ref name="att-columnspan"/>
+    <ref name="att-edge"/>
+    <ref name="att-selection"/>
+    <ref name="att-bevelled"/>
+    <ref name="att-height"/>
+    <ref name="att-depth"/>
+  </define>
+  <define name="mml.merror-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <define name="mml.mpadded-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-sizeinfo"/>
+    <ref name="att-lspace"/>
+  </define>
+  <define name="mml.mphantom-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <define name="mml.mfenced-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-open"/>
+    <ref name="att-close"/>
+    <ref name="att-separators"/>
+  </define>
+  <!-- Presentation layout schemata: scripts and limits -->
+  <define name="pscrschema">
+    <choice>
+      <ref name="mml.msub"/>
+      <ref name="mml.msup"/>
+      <ref name="mml.msubsup"/>
+      <ref name="mml.munder"/>
+      <ref name="mml.mover"/>
+      <ref name="mml.munderover"/>
+      <ref name="mml.mmultiscripts"/>
+    </choice>
+  </define>
+  <define name="mml.msub-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-subscriptshift"/>
+  </define>
+  <define name="mml.msup-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-superscriptshift"/>
+  </define>
+  <define name="mml.msubsup-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-subscriptshift"/>
+    <ref name="att-superscriptshift"/>
+  </define>
+  <define name="mml.munder-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-accentunder"/>
+  </define>
+  <define name="mml.mover-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-accent"/>
+  </define>
+  <define name="mml.munderover-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-accent"/>
+    <ref name="att-accentunder"/>
+  </define>
+  <define name="mml.mmultiscripts-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-subscriptshift"/>
+    <ref name="att-superscriptshift"/>
+  </define>
+  <!-- Presentation layout schemata: empty elements for scripts -->
+  <define name="pscreschema">
+    <choice>
+      <ref name="mml.mprescripts"/>
+      <ref name="mml.none"/>
+    </choice>
+  </define>
+  <define name="mml.mprescripts">
+    <element name="mml:mprescripts">
+      <ref name="mml.mprescripts-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.mprescripts-attlist" combine="interleave">
+    <ref name="MATHML.xmlns.attrib"/>
+  </define>
+  <define name="mml.none">
+    <element name="mml:none">
+      <ref name="mml.none-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.none-attlist" combine="interleave">
+    <ref name="MATHML.xmlns.attrib"/>
+  </define>
+  <!-- Presentation layout schemata: tables -->
+  <define name="ptabschema">
+    <choice>
+      <ref name="mml.mtable"/>
+      <ref name="mml.mtr"/>
+      <ref name="mml.mlabeledtr"/>
+      <ref name="mml.mtd"/>
+    </choice>
+  </define>
+  <define name="mml.mtable-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-tableinfo"/>
+  </define>
+  <define name="mml.mtr-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-rowalign"/>
+    <ref name="att-columnalign-list"/>
+    <ref name="att-groupalign-list"/>
+  </define>
+  <define name="mml.mlabeledtr-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-rowalign"/>
+    <ref name="att-columnalign-list"/>
+    <ref name="att-groupalign-list"/>
+  </define>
+  <define name="mml.mtd-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-rowalign"/>
+    <ref name="att-columnalign"/>
+    <ref name="att-groupalign-list"/>
+    <ref name="att-rowspan"/>
+    <ref name="att-columnspan"/>
+  </define>
+  <define name="plschema">
+    <choice>
+      <ref name="pgenschema"/>
+      <ref name="pscrschema"/>
+      <ref name="ptabschema"/>
+    </choice>
+  </define>
+  <!-- Empty presentation layout schemata -->
+  <define name="peschema">
+    <choice>
+      <ref name="mml.maligngroup"/>
+      <ref name="mml.malignmark"/>
+    </choice>
+  </define>
+  <define name="mml.malignmark">
+    <element name="mml:malignmark">
+      <ref name="mml.malignmark-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.malignmark-attlist" combine="interleave">
+    <ref name="att-edge"/>
+  </define>
+  <define name="mml.maligngroup">
+    <element name="mml:maligngroup">
+      <ref name="mml.maligngroup-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.maligngroup-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-groupalign"/>
+  </define>
+  <define name="mml.mglyph">
+    <element name="mml:mglyph">
+      <ref name="mml.mglyph-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.mglyph-attlist" combine="interleave">
+    <ref name="att-alt"/>
+    <ref name="att-fontfamily"/>
+    <ref name="att-index"/>
+  </define>
+  <!-- Presentation action schemata -->
+  <define name="pactions">
+    <ref name="mml.maction"/>
+  </define>
+  <define name="mml.maction-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-actiontype"/>
+    <ref name="att-selection"/>
+  </define>
+  <!--
+    The following entity for substitution into
+    content constructs excludes elements that
+    are not valid as expressions.
+  -->
+  <define name="PresInCont">
+    <choice>
+      <ref name="ptoken"/>
+      <ref name="petoken"/>
+      <ref name="plschema"/>
+      <ref name="peschema"/>
+      <ref name="pactions"/>
+    </choice>
+  </define>
+  <!-- Presentation entity: all presentation constructs -->
+  <define name="Presentation">
+    <choice>
+      <ref name="ptoken"/>
+      <ref name="petoken"/>
+      <ref name="pscreschema"/>
+      <ref name="plschema"/>
+      <ref name="peschema"/>
+      <ref name="pactions"/>
+    </choice>
+  </define>
+  <!-- Content element set  ........................................ -->
+  <!-- Attribute definitions -->
+  <define name="att-base">
+    <optional>
+      <attribute name="base" a:defaultValue="10"/>
+    </optional>
+  </define>
+  <define name="att-closure">
+    <optional>
+      <attribute name="closure" a:defaultValue="closed"/>
+    </optional>
+  </define>
+  <define name="att-definition">
+    <optional>
+      <attribute name="definitionURL" a:defaultValue=""/>
+    </optional>
+  </define>
+  <define name="att-encoding">
+    <optional>
+      <attribute name="encoding" a:defaultValue=""/>
+    </optional>
+  </define>
+  <define name="att-nargs">
+    <optional>
+      <attribute name="nargs" a:defaultValue="1"/>
+    </optional>
+  </define>
+  <define name="att-occurrence">
+    <optional>
+      <attribute name="occurrence" a:defaultValue="function-model"/>
+    </optional>
+  </define>
+  <define name="att-order">
+    <optional>
+      <attribute name="order" a:defaultValue="numeric"/>
+    </optional>
+  </define>
+  <define name="att-scope">
+    <optional>
+      <attribute name="scope" a:defaultValue="local"/>
+    </optional>
+  </define>
+  <define name="att-type">
+    <optional>
+      <attribute name="type"/>
+    </optional>
+  </define>
+  <!-- Content elements: leaf nodes -->
+  <define name="ctoken">
+    <choice>
+      <ref name="mml.csymbol"/>
+      <ref name="mml.ci"/>
+      <ref name="mml.cn"/>
+    </choice>
+  </define>
+  <define name="mml.ci-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-type"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.csymbol-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-encoding"/>
+    <ref name="att-type"/>
+    <ref name="att-definition"/>
+  </define>
+  <define name="mml.cn-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-type"/>
+    <ref name="att-base"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <!-- Content elements: specials -->
+  <define name="cspecial">
+    <choice>
+      <ref name="mml.apply"/>
+      <ref name="mml.reln"/>
+      <ref name="mml.lambda"/>
+    </choice>
+  </define>
+  <define name="mml.apply-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <define name="mml.reln-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <define name="mml.lambda-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <!-- Content elements: others -->
+  <define name="cother">
+    <choice>
+      <ref name="mml.condition"/>
+      <ref name="mml.declare"/>
+      <ref name="mml.sep"/>
+    </choice>
+  </define>
+  <define name="mml.condition-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <define name="mml.declare-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-type"/>
+    <ref name="att-scope"/>
+    <ref name="att-nargs"/>
+    <ref name="att-occurrence"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.sep">
+    <element name="mml:sep">
+      <ref name="mml.sep-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.sep-attlist" combine="interleave">
+    <ref name="MATHML.xmlns.attrib"/>
+  </define>
+  <!-- Content elements: semantic mapping -->
+  <define name="csemantics">
+    <choice>
+      <ref name="mml.semantics"/>
+      <ref name="mml.annotation"/>
+      <ref name="mml.annotation-xml"/>
+    </choice>
+  </define>
+  <define name="mml.semantics-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.annotation-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.annotation-xml-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-encoding"/>
+  </define>
+  <!-- Content elements: constructors -->
+  <define name="cconstructor">
+    <choice>
+      <ref name="mml.interval"/>
+      <ref name="mml.list"/>
+      <ref name="mml.matrix"/>
+      <ref name="mml.matrixrow"/>
+      <ref name="mml.set"/>
+      <ref name="mml.vector"/>
+      <ref name="mml.piecewise"/>
+    </choice>
+  </define>
+  <define name="mml.interval-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-closure"/>
+  </define>
+  <define name="mml.set-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-type"/>
+  </define>
+  <define name="mml.list-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-order"/>
+  </define>
+  <define name="mml.vector-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <define name="mml.matrix-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <define name="mml.matrixrow-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <define name="mml.piecewise-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <define name="mml.piece-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <define name="mml.otherwise-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <!-- Content elements: symbols -->
+  <define name="c0ary">
+    <choice>
+      <ref name="mml.integers"/>
+      <ref name="mml.reals"/>
+      <ref name="mml.rationals"/>
+      <ref name="mml.naturalnumbers"/>
+      <ref name="mml.complexes"/>
+      <ref name="mml.primes"/>
+      <ref name="mml.exponentiale"/>
+      <ref name="mml.imaginaryi"/>
+      <ref name="mml.notanumber"/>
+      <ref name="mml.true"/>
+      <ref name="mml.false"/>
+      <ref name="mml.emptyset"/>
+      <ref name="mml.pi"/>
+      <ref name="mml.eulergamma"/>
+      <ref name="mml.infinity"/>
+    </choice>
+  </define>
+  <define name="mml.integers">
+    <element name="mml:integers">
+      <ref name="mml.integers-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.integers-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.reals">
+    <element name="mml:reals">
+      <ref name="mml.reals-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.reals-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.rationals">
+    <element name="mml:rationals">
+      <ref name="mml.rationals-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.rationals-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.naturalnumbers">
+    <element name="mml:naturalnumbers">
+      <ref name="mml.naturalnumbers-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.naturalnumbers-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.complexes">
+    <element name="mml:complexes">
+      <ref name="mml.complexes-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.complexes-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.primes">
+    <element name="mml:primes">
+      <ref name="mml.primes-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.primes-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.exponentiale">
+    <element name="mml:exponentiale">
+      <ref name="mml.exponentiale-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.exponentiale-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.imaginaryi">
+    <element name="mml:imaginaryi">
+      <ref name="mml.imaginaryi-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.imaginaryi-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.notanumber">
+    <element name="mml:notanumber">
+      <ref name="mml.notanumber-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.notanumber-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.true">
+    <element name="mml:true">
+      <ref name="mml.true-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.true-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.false">
+    <element name="mml:false">
+      <ref name="mml.false-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.false-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.emptyset">
+    <element name="mml:emptyset">
+      <ref name="mml.emptyset-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.emptyset-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.pi">
+    <element name="mml:pi">
+      <ref name="mml.pi-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.pi-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.eulergamma">
+    <element name="mml:eulergamma">
+      <ref name="mml.eulergamma-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.eulergamma-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.infinity">
+    <element name="mml:infinity">
+      <ref name="mml.infinity-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.infinity-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <!-- Content elements: operators -->
+  <define name="cfuncop1ary">
+    <choice>
+      <ref name="mml.inverse"/>
+      <ref name="mml.ident"/>
+      <ref name="mml.domain"/>
+      <ref name="mml.codomain"/>
+      <ref name="mml.image"/>
+    </choice>
+  </define>
+  <define name="mml.inverse">
+    <element name="mml:inverse">
+      <ref name="mml.inverse-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.inverse-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.domain">
+    <element name="mml:domain">
+      <ref name="mml.domain-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.domain-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.codomain">
+    <element name="mml:codomain">
+      <ref name="mml.codomain-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.codomain-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.image">
+    <element name="mml:image">
+      <ref name="mml.image-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.image-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="cfuncopnary">
+    <choice>
+      <ref name="mml.fn"/>
+      <ref name="mml.compose"/>
+    </choice>
+  </define>
+  <define name="mml.fn-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.ident">
+    <element name="mml:ident">
+      <ref name="mml.ident-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.ident-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.compose">
+    <element name="mml:compose">
+      <ref name="mml.compose-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.compose-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="carithop1ary">
+    <choice>
+      <ref name="mml.abs"/>
+      <ref name="mml.conjugate"/>
+      <ref name="mml.exp"/>
+      <ref name="mml.factorial"/>
+      <ref name="mml.arg"/>
+      <ref name="mml.real"/>
+      <ref name="mml.imaginary"/>
+      <ref name="mml.floor"/>
+      <ref name="mml.ceiling"/>
+    </choice>
+  </define>
+  <define name="mml.exp">
+    <element name="mml:exp">
+      <ref name="mml.exp-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.exp-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.abs">
+    <element name="mml:abs">
+      <ref name="mml.abs-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.abs-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.arg">
+    <element name="mml:arg">
+      <ref name="mml.arg-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.arg-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.real">
+    <element name="mml:real">
+      <ref name="mml.real-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.real-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.imaginary">
+    <element name="mml:imaginary">
+      <ref name="mml.imaginary-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.imaginary-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.conjugate">
+    <element name="mml:conjugate">
+      <ref name="mml.conjugate-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.conjugate-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.factorial">
+    <element name="mml:factorial">
+      <ref name="mml.factorial-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.factorial-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.floor">
+    <element name="mml:floor">
+      <ref name="mml.floor-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.floor-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.ceiling">
+    <element name="mml:ceiling">
+      <ref name="mml.ceiling-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.ceiling-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="carithop1or2ary">
+    <ref name="mml.minus"/>
+  </define>
+  <define name="mml.minus">
+    <element name="mml:minus">
+      <ref name="mml.minus-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.minus-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="carithop2ary">
+    <choice>
+      <ref name="mml.quotient"/>
+      <ref name="mml.divide"/>
+      <ref name="mml.power"/>
+      <ref name="mml.rem"/>
+    </choice>
+  </define>
+  <define name="mml.quotient">
+    <element name="mml:quotient">
+      <ref name="mml.quotient-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.quotient-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.divide">
+    <element name="mml:divide">
+      <ref name="mml.divide-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.divide-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.power">
+    <element name="mml:power">
+      <ref name="mml.power-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.power-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.rem">
+    <element name="mml:rem">
+      <ref name="mml.rem-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.rem-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="carithopnary">
+    <choice>
+      <ref name="mml.plus"/>
+      <ref name="mml.times"/>
+      <ref name="mml.max"/>
+      <ref name="mml.min"/>
+      <ref name="mml.gcd"/>
+      <ref name="mml.lcm"/>
+    </choice>
+  </define>
+  <define name="mml.plus">
+    <element name="mml:plus">
+      <ref name="mml.plus-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.plus-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.max">
+    <element name="mml:max">
+      <ref name="mml.max-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.max-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.min">
+    <element name="mml:min">
+      <ref name="mml.min-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.min-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.times">
+    <element name="mml:times">
+      <ref name="mml.times-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.times-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.gcd">
+    <element name="mml:gcd">
+      <ref name="mml.gcd-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.gcd-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.lcm">
+    <element name="mml:lcm">
+      <ref name="mml.lcm-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.lcm-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="carithoproot">
+    <ref name="mml.root"/>
+  </define>
+  <define name="mml.root">
+    <element name="mml:root">
+      <ref name="mml.root-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.root-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="clogicopquant">
+    <choice>
+      <ref name="mml.exists"/>
+      <ref name="mml.forall"/>
+    </choice>
+  </define>
+  <define name="mml.exists">
+    <element name="mml:exists">
+      <ref name="mml.exists-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.exists-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.forall">
+    <element name="mml:forall">
+      <ref name="mml.forall-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.forall-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="clogicopnary">
+    <choice>
+      <ref name="mml.and"/>
+      <ref name="mml.or"/>
+      <ref name="mml.xor"/>
+    </choice>
+  </define>
+  <define name="mml.and">
+    <element name="mml:and">
+      <ref name="mml.and-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.and-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.or">
+    <element name="mml:or">
+      <ref name="mml.or-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.or-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.xor">
+    <element name="mml:xor">
+      <ref name="mml.xor-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.xor-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="clogicop1ary">
+    <ref name="mml.not"/>
+  </define>
+  <define name="mml.not">
+    <element name="mml:not">
+      <ref name="mml.not-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.not-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="clogicop2ary">
+    <ref name="mml.implies"/>
+  </define>
+  <define name="mml.implies">
+    <element name="mml:implies">
+      <ref name="mml.implies-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.implies-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="ccalcop">
+    <choice>
+      <ref name="mml.log"/>
+      <ref name="mml.int"/>
+      <ref name="mml.diff"/>
+      <ref name="mml.partialdiff"/>
+      <ref name="mml.divergence"/>
+      <ref name="mml.grad"/>
+      <ref name="mml.curl"/>
+      <ref name="mml.laplacian"/>
+    </choice>
+  </define>
+  <define name="mml.divergence">
+    <element name="mml:divergence">
+      <ref name="mml.divergence-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.divergence-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.grad">
+    <element name="mml:grad">
+      <ref name="mml.grad-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.grad-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.curl">
+    <element name="mml:curl">
+      <ref name="mml.curl-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.curl-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.laplacian">
+    <element name="mml:laplacian">
+      <ref name="mml.laplacian-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.laplacian-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.log">
+    <element name="mml:log">
+      <ref name="mml.log-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.log-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.int">
+    <element name="mml:int">
+      <ref name="mml.int-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.int-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.diff">
+    <element name="mml:diff">
+      <ref name="mml.diff-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.diff-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.partialdiff">
+    <element name="mml:partialdiff">
+      <ref name="mml.partialdiff-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.partialdiff-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="ccalcop1ary">
+    <ref name="mml.ln"/>
+  </define>
+  <define name="mml.ln">
+    <element name="mml:ln">
+      <ref name="mml.ln-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.ln-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="csetop1ary">
+    <ref name="mml.card"/>
+  </define>
+  <define name="mml.card">
+    <element name="mml:card">
+      <ref name="mml.card-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.card-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="csetop2ary">
+    <ref name="mml.setdiff"/>
+  </define>
+  <define name="mml.setdiff">
+    <element name="mml:setdiff">
+      <ref name="mml.setdiff-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.setdiff-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="csetopnary">
+    <choice>
+      <ref name="mml.union"/>
+      <ref name="mml.intersect"/>
+      <ref name="mml.cartesianproduct"/>
+    </choice>
+  </define>
+  <define name="mml.union">
+    <element name="mml:union">
+      <ref name="mml.union-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.union-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.intersect">
+    <element name="mml:intersect">
+      <ref name="mml.intersect-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.intersect-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.cartesianproduct">
+    <element name="mml:cartesianproduct">
+      <ref name="mml.cartesianproduct-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.cartesianproduct-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="cseqop">
+    <choice>
+      <ref name="mml.sum"/>
+      <ref name="mml.product"/>
+      <ref name="mml.limit"/>
+    </choice>
+  </define>
+  <define name="mml.sum">
+    <element name="mml:sum">
+      <ref name="mml.sum-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.sum-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.product">
+    <element name="mml:product">
+      <ref name="mml.product-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.product-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.limit">
+    <element name="mml:limit">
+      <ref name="mml.limit-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.limit-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="ctrigop">
+    <choice>
+      <ref name="mml.sin"/>
+      <ref name="mml.cos"/>
+      <ref name="mml.tan"/>
+      <ref name="mml.sec"/>
+      <ref name="mml.csc"/>
+      <ref name="mml.cot"/>
+      <ref name="mml.sinh"/>
+      <ref name="mml.cosh"/>
+      <ref name="mml.tanh"/>
+      <ref name="mml.sech"/>
+      <ref name="mml.csch"/>
+      <ref name="mml.coth"/>
+      <ref name="mml.arcsin"/>
+      <ref name="mml.arccos"/>
+      <ref name="mml.arctan"/>
+      <ref name="mml.arccosh"/>
+      <ref name="mml.arccot"/>
+      <ref name="mml.arccoth"/>
+      <ref name="mml.arccsc"/>
+      <ref name="mml.arccsch"/>
+      <ref name="mml.arcsec"/>
+      <ref name="mml.arcsech"/>
+      <ref name="mml.arcsinh"/>
+      <ref name="mml.arctanh"/>
+    </choice>
+  </define>
+  <define name="mml.sin">
+    <element name="mml:sin">
+      <ref name="mml.sin-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.sin-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.cos">
+    <element name="mml:cos">
+      <ref name="mml.cos-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.cos-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.tan">
+    <element name="mml:tan">
+      <ref name="mml.tan-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.tan-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.sec">
+    <element name="mml:sec">
+      <ref name="mml.sec-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.sec-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.csc">
+    <element name="mml:csc">
+      <ref name="mml.csc-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.csc-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.cot">
+    <element name="mml:cot">
+      <ref name="mml.cot-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.cot-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.sinh">
+    <element name="mml:sinh">
+      <ref name="mml.sinh-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.sinh-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.cosh">
+    <element name="mml:cosh">
+      <ref name="mml.cosh-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.cosh-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.tanh">
+    <element name="mml:tanh">
+      <ref name="mml.tanh-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.tanh-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.sech">
+    <element name="mml:sech">
+      <ref name="mml.sech-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.sech-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.csch">
+    <element name="mml:csch">
+      <ref name="mml.csch-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.csch-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.coth">
+    <element name="mml:coth">
+      <ref name="mml.coth-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.coth-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.arcsin">
+    <element name="mml:arcsin">
+      <ref name="mml.arcsin-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.arcsin-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.arccos">
+    <element name="mml:arccos">
+      <ref name="mml.arccos-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.arccos-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.arctan">
+    <element name="mml:arctan">
+      <ref name="mml.arctan-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.arctan-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.arccosh">
+    <element name="mml:arccosh">
+      <ref name="mml.arccosh-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.arccosh-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.arccot">
+    <element name="mml:arccot">
+      <ref name="mml.arccot-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.arccot-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.arccoth">
+    <element name="mml:arccoth">
+      <ref name="mml.arccoth-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.arccoth-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.arccsc">
+    <element name="mml:arccsc">
+      <ref name="mml.arccsc-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.arccsc-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.arccsch">
+    <element name="mml:arccsch">
+      <ref name="mml.arccsch-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.arccsch-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.arcsec">
+    <element name="mml:arcsec">
+      <ref name="mml.arcsec-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.arcsec-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.arcsech">
+    <element name="mml:arcsech">
+      <ref name="mml.arcsech-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.arcsech-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.arcsinh">
+    <element name="mml:arcsinh">
+      <ref name="mml.arcsinh-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.arcsinh-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.arctanh">
+    <element name="mml:arctanh">
+      <ref name="mml.arctanh-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.arctanh-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="cstatopnary">
+    <choice>
+      <ref name="mml.mean"/>
+      <ref name="mml.sdev"/>
+      <ref name="mml.variance"/>
+      <ref name="mml.median"/>
+      <ref name="mml.mode"/>
+    </choice>
+  </define>
+  <define name="mml.mean">
+    <element name="mml:mean">
+      <ref name="mml.mean-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.mean-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.sdev">
+    <element name="mml:sdev">
+      <ref name="mml.sdev-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.sdev-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.variance">
+    <element name="mml:variance">
+      <ref name="mml.variance-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.variance-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.median">
+    <element name="mml:median">
+      <ref name="mml.median-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.median-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.mode">
+    <element name="mml:mode">
+      <ref name="mml.mode-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.mode-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="cstatopmoment">
+    <ref name="mml.moment"/>
+  </define>
+  <define name="mml.moment">
+    <element name="mml:moment">
+      <ref name="mml.moment-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.moment-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="clalgop1ary">
+    <choice>
+      <ref name="mml.determinant"/>
+      <ref name="mml.transpose"/>
+    </choice>
+  </define>
+  <define name="mml.determinant">
+    <element name="mml:determinant">
+      <ref name="mml.determinant-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.determinant-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.transpose">
+    <element name="mml:transpose">
+      <ref name="mml.transpose-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.transpose-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="clalgop2ary">
+    <choice>
+      <ref name="mml.vectorproduct"/>
+      <ref name="mml.scalarproduct"/>
+      <ref name="mml.outerproduct"/>
+    </choice>
+  </define>
+  <define name="mml.vectorproduct">
+    <element name="mml:vectorproduct">
+      <ref name="mml.vectorproduct-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.vectorproduct-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.scalarproduct">
+    <element name="mml:scalarproduct">
+      <ref name="mml.scalarproduct-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.scalarproduct-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.outerproduct">
+    <element name="mml:outerproduct">
+      <ref name="mml.outerproduct-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.outerproduct-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="clalgopnary">
+    <ref name="mml.selector"/>
+  </define>
+  <define name="mml.selector">
+    <element name="mml:selector">
+      <ref name="mml.selector-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.selector-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <!-- Content elements: relations -->
+  <define name="cgenrel2ary">
+    <choice>
+      <ref name="mml.neq"/>
+      <ref name="mml.factorof"/>
+    </choice>
+  </define>
+  <define name="mml.neq">
+    <element name="mml:neq">
+      <ref name="mml.neq-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.neq-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.factorof">
+    <element name="mml:factorof">
+      <ref name="mml.factorof-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.factorof-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="cgenrelnary">
+    <choice>
+      <ref name="mml.eq"/>
+      <ref name="mml.leq"/>
+      <ref name="mml.lt"/>
+      <ref name="mml.geq"/>
+      <ref name="mml.gt"/>
+      <ref name="mml.equivalent"/>
+      <ref name="mml.approx"/>
+    </choice>
+  </define>
+  <define name="mml.eq">
+    <element name="mml:eq">
+      <ref name="mml.eq-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.eq-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.equivalent">
+    <element name="mml:equivalent">
+      <ref name="mml.equivalent-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.equivalent-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.approx">
+    <element name="mml:approx">
+      <ref name="mml.approx-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.approx-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.gt">
+    <element name="mml:gt">
+      <ref name="mml.gt-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.gt-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.lt">
+    <element name="mml:lt">
+      <ref name="mml.lt-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.lt-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.geq">
+    <element name="mml:geq">
+      <ref name="mml.geq-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.geq-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.leq">
+    <element name="mml:leq">
+      <ref name="mml.leq-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.leq-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="csetrel2ary">
+    <choice>
+      <ref name="mml.in"/>
+      <ref name="mml.notin"/>
+      <ref name="mml.notsubset"/>
+      <ref name="mml.notprsubset"/>
+    </choice>
+  </define>
+  <define name="mml.in">
+    <element name="mml:in">
+      <ref name="mml.in-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.in-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.notin">
+    <element name="mml:notin">
+      <ref name="mml.notin-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.notin-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.notsubset">
+    <element name="mml:notsubset">
+      <ref name="mml.notsubset-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.notsubset-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.notprsubset">
+    <element name="mml:notprsubset">
+      <ref name="mml.notprsubset-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.notprsubset-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="csetrelnary">
+    <choice>
+      <ref name="mml.subset"/>
+      <ref name="mml.prsubset"/>
+    </choice>
+  </define>
+  <define name="mml.subset">
+    <element name="mml:subset">
+      <ref name="mml.subset-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.subset-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="mml.prsubset">
+    <element name="mml:prsubset">
+      <ref name="mml.prsubset-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.prsubset-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+  </define>
+  <define name="cseqrel2ary">
+    <ref name="mml.tendsto"/>
+  </define>
+  <define name="mml.tendsto">
+    <element name="mml:tendsto">
+      <ref name="mml.tendsto-attlist"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mml.tendsto-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-definition"/>
+    <ref name="att-encoding"/>
+    <ref name="att-type"/>
+  </define>
+  <!-- Content elements: quantifiers -->
+  <define name="cquantifier">
+    <choice>
+      <ref name="mml.lowlimit"/>
+      <ref name="mml.uplimit"/>
+      <ref name="mml.bvar"/>
+      <ref name="mml.degree"/>
+      <ref name="mml.logbase"/>
+      <ref name="mml.momentabout"/>
+      <ref name="mml.domainofapplication"/>
+    </choice>
+  </define>
+  <define name="mml.lowlimit-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <define name="mml.uplimit-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <define name="mml.bvar-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <define name="mml.degree-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <define name="mml.logbase-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <define name="mml.momentabout-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <define name="mml.domainofapplication-attlist" combine="interleave">
+    <ref name="MATHML.Common.attrib"/>
+  </define>
+  <!-- Operator groups -->
+  <define name="cop1ary">
+    <choice>
+      <ref name="cfuncop1ary"/>
+      <ref name="carithop1ary"/>
+      <ref name="clogicop1ary"/>
+      <ref name="ccalcop1ary"/>
+      <ref name="ctrigop"/>
+      <ref name="clalgop1ary"/>
+      <ref name="csetop1ary"/>
+    </choice>
+  </define>
+  <define name="cop2ary">
+    <choice>
+      <ref name="carithop2ary"/>
+      <ref name="clogicop2ary"/>
+      <ref name="clalgop2ary"/>
+      <ref name="csetop2ary"/>
+    </choice>
+  </define>
+  <define name="copnary">
+    <choice>
+      <ref name="cfuncopnary"/>
+      <ref name="carithopnary"/>
+      <ref name="clogicopnary"/>
+      <ref name="csetopnary"/>
+      <ref name="cstatopnary"/>
+      <ref name="clalgopnary"/>
+    </choice>
+  </define>
+  <define name="copmisc">
+    <choice>
+      <ref name="carithoproot"/>
+      <ref name="carithop1or2ary"/>
+      <ref name="ccalcop"/>
+      <ref name="cseqop"/>
+      <ref name="cstatopmoment"/>
+      <ref name="clogicopquant"/>
+    </choice>
+  </define>
+  <!-- Relation groups -->
+  <define name="crel2ary">
+    <choice>
+      <ref name="cgenrel2ary"/>
+      <ref name="csetrel2ary"/>
+      <ref name="cseqrel2ary"/>
+    </choice>
+  </define>
+  <define name="crelnary">
+    <choice>
+      <ref name="cgenrelnary"/>
+      <ref name="csetrelnary"/>
+    </choice>
+  </define>
+  <!-- Content constructs: all -->
+  <define name="Content">
+    <choice>
+      <ref name="ctoken"/>
+      <ref name="cspecial"/>
+      <ref name="cother"/>
+      <ref name="csemantics"/>
+      <ref name="c0ary"/>
+      <ref name="cconstructor"/>
+      <ref name="cquantifier"/>
+      <ref name="cop1ary"/>
+      <ref name="cop2ary"/>
+      <ref name="copnary"/>
+      <ref name="copmisc"/>
+      <ref name="crel2ary"/>
+      <ref name="crelnary"/>
+    </choice>
+  </define>
+  <!-- Content constructs for substitution in presentation structures -->
+  <define name="ContInPres">
+    <choice>
+      <ref name="mml.ci"/>
+      <ref name="mml.csymbol"/>
+      <ref name="mml.cn"/>
+      <ref name="c0ary"/>
+      <ref name="mml.apply"/>
+      <ref name="mml.fn"/>
+      <ref name="mml.lambda"/>
+      <ref name="mml.reln"/>
+      <ref name="cconstructor"/>
+      <ref name="mml.semantics"/>
+      <ref name="mml.declare"/>
+    </choice>
+  </define>
+  <!-- ............................................................. -->
+  <!--
+    Recursive definition for content of expressions. Include
+    presentation constructs at lowest level so presentation
+    layout schemata hold presentation or content elements.
+    Include content constructs at lowest level so content
+    elements hold PCDATA or presentation elements at leaf
+    level (for permitted substitutable elements in context)
+  -->
+  <define name="ContentExpression">
+    <zeroOrMore>
+      <choice>
+        <ref name="Content"/>
+        <ref name="PresInCont"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="semanticsContentExpression">
+    <ref name="ContentExpression"/>
+  </define>
+  <define name="PresExpression">
+    <zeroOrMore>
+      <choice>
+        <ref name="Presentation"/>
+        <ref name="ContInPres"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="MathExpression">
+    <zeroOrMore>
+      <choice>
+        <ref name="PresInCont"/>
+        <ref name="ContInPres"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <!-- PCDATA or MathML character elements -->
+  <define name="MathMLCharacters">
+    <choice>
+      <text/>
+      <ref name="mml.mglyph"/>
+    </choice>
+  </define>
+  <!-- Content elements: tokens -->
+  <!-- (may contain embedded presentation constructs) -->
+  <define name="mml.ci">
+    <element name="mml:ci">
+      <ref name="mml.ci-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="MathMLCharacters"/>
+          <ref name="PresInCont"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mml.csymbol">
+    <element name="mml:csymbol">
+      <ref name="mml.csymbol-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="MathMLCharacters"/>
+          <ref name="PresInCont"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mml.cn">
+    <element name="mml:cn">
+      <ref name="mml.cn-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="MathMLCharacters"/>
+          <ref name="mml.sep"/>
+          <ref name="PresInCont"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <!-- Content elements: special -->
+  <define name="mml.apply">
+    <element name="mml:apply">
+      <ref name="mml.apply-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <define name="mml.reln">
+    <element name="mml:reln">
+      <ref name="mml.reln-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <define name="mml.lambda">
+    <element name="mml:lambda">
+      <ref name="mml.lambda-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <!-- Content elements: other -->
+  <define name="mml.condition">
+    <element name="mml:condition">
+      <ref name="mml.condition-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <define name="mml.declare">
+    <element name="mml:declare">
+      <ref name="mml.declare-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <!-- Content elements: semantics -->
+  <define name="mml.semantics">
+    <element name="mml:semantics">
+      <ref name="mml.semantics-attlist"/>
+      <ref name="semanticsContentExpression"/>
+    </element>
+  </define>
+  <define name="Annotation.content">
+    <text/>
+  </define>
+  <define name="mml.annotation">
+    <element name="mml:annotation">
+      <ref name="mml.annotation-attlist"/>
+      <ref name="Annotation.content"/>
+    </element>
+  </define>
+  <define name="mml.annotation-xml">
+    <element name="mml:annotation-xml">
+      <ref name="mml.annotation-xml-attlist"/>
+      <ref name="Annotation-xml.content"/>
+    </element>
+  </define>
+  <!-- Content elements: constructors -->
+  <define name="mml.interval">
+    <element name="mml:interval">
+      <ref name="mml.interval-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <define name="mml.set">
+    <element name="mml:set">
+      <ref name="mml.set-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <define name="mml.list">
+    <element name="mml:list">
+      <ref name="mml.list-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <define name="mml.vector">
+    <element name="mml:vector">
+      <ref name="mml.vector-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <define name="mml.matrix">
+    <element name="mml:matrix">
+      <ref name="mml.matrix-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <define name="mml.matrixrow">
+    <element name="mml:matrixrow">
+      <ref name="mml.matrixrow-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <define name="mml.piecewise">
+    <element name="mml:piecewise">
+      <ref name="mml.piecewise-attlist"/>
+      <zeroOrMore>
+        <ref name="mml.piece"/>
+      </zeroOrMore>
+      <optional>
+        <ref name="mml.otherwise"/>
+      </optional>
+    </element>
+  </define>
+  <define name="mml.piece">
+    <element name="mml:piece">
+      <ref name="mml.piece-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <define name="mml.otherwise">
+    <element name="mml:otherwise">
+      <ref name="mml.otherwise-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <!-- Content elements: operator (user-defined) -->
+  <define name="mml.fn">
+    <element name="mml:fn">
+      <ref name="mml.fn-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <!-- Content elements: quantifiers -->
+  <define name="mml.lowlimit">
+    <element name="mml:lowlimit">
+      <ref name="mml.lowlimit-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <define name="mml.uplimit">
+    <element name="mml:uplimit">
+      <ref name="mml.uplimit-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <define name="mml.bvar">
+    <element name="mml:bvar">
+      <ref name="mml.bvar-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <define name="mml.degree">
+    <element name="mml:degree">
+      <ref name="mml.degree-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <define name="mml.logbase">
+    <element name="mml:logbase">
+      <ref name="mml.logbase-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <define name="mml.momentabout">
+    <element name="mml:momentabout">
+      <ref name="mml.momentabout-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <define name="mml.domainofapplication">
+    <element name="mml:domainofapplication">
+      <ref name="mml.domainofapplication-attlist"/>
+      <ref name="ContentExpression"/>
+    </element>
+  </define>
+  <!-- ............................................................. -->
+  <!--
+    Presentation layout schemata contain tokens,
+    layout and content schemata.
+  -->
+  <!-- By default keep them as they were in MathML 2.0 -->
+  <define name="twoPresExpression">
+    <ref name="PresExpression"/>
+  </define>
+  <define name="threePresExpression">
+    <ref name="PresExpression"/>
+  </define>
+  <define name="mtrPresExpression">
+    <ref name="PresExpression"/>
+  </define>
+  <define name="mtdPresExpression">
+    <ref name="PresExpression"/>
+  </define>
+  <define name="prscrPresExpression">
+    <ref name="PresExpression"/>
+  </define>
+  <define name="mml.mstyle">
+    <element name="mml:mstyle">
+      <ref name="mml.mstyle-attlist"/>
+      <ref name="PresExpression"/>
+    </element>
+  </define>
+  <define name="mml.merror">
+    <element name="mml:merror">
+      <ref name="mml.merror-attlist"/>
+      <ref name="PresExpression"/>
+    </element>
+  </define>
+  <define name="mml.mphantom">
+    <element name="mml:mphantom">
+      <ref name="mml.mphantom-attlist"/>
+      <ref name="PresExpression"/>
+    </element>
+  </define>
+  <define name="mml.mrow">
+    <element name="mml:mrow">
+      <ref name="mml.mrow-attlist"/>
+      <ref name="PresExpression"/>
+    </element>
+  </define>
+  <define name="mml.mfrac">
+    <element name="mml:mfrac">
+      <ref name="mml.mfrac-attlist"/>
+      <ref name="twoPresExpression"/>
+    </element>
+  </define>
+  <define name="mml.msqrt">
+    <element name="mml:msqrt">
+      <ref name="mml.msqrt-attlist"/>
+      <ref name="PresExpression"/>
+    </element>
+  </define>
+  <define name="mml.menclose">
+    <element name="mml:menclose">
+      <ref name="mml.menclose-attlist"/>
+      <ref name="PresExpression"/>
+    </element>
+  </define>
+  <define name="mml.mroot">
+    <element name="mml:mroot">
+      <ref name="mml.mroot-attlist"/>
+      <ref name="twoPresExpression"/>
+    </element>
+  </define>
+  <define name="mml.msub">
+    <element name="mml:msub">
+      <ref name="mml.msub-attlist"/>
+      <ref name="twoPresExpression"/>
+    </element>
+  </define>
+  <define name="mml.msup">
+    <element name="mml:msup">
+      <ref name="mml.msup-attlist"/>
+      <ref name="twoPresExpression"/>
+    </element>
+  </define>
+  <define name="mml.msubsup">
+    <element name="mml:msubsup">
+      <ref name="mml.msubsup-attlist"/>
+      <ref name="threePresExpression"/>
+    </element>
+  </define>
+  <define name="mml.mmultiscripts">
+    <element name="mml:mmultiscripts">
+      <ref name="mml.mmultiscripts-attlist"/>
+      <ref name="prscrPresExpression"/>
+    </element>
+  </define>
+  <define name="mml.munder">
+    <element name="mml:munder">
+      <ref name="mml.munder-attlist"/>
+      <ref name="twoPresExpression"/>
+    </element>
+  </define>
+  <define name="mml.mover">
+    <element name="mml:mover">
+      <ref name="mml.mover-attlist"/>
+      <ref name="twoPresExpression"/>
+    </element>
+  </define>
+  <define name="mml.munderover">
+    <element name="mml:munderover">
+      <ref name="mml.munderover-attlist"/>
+      <ref name="threePresExpression"/>
+    </element>
+  </define>
+  <define name="mml.mtable">
+    <element name="mml:mtable">
+      <ref name="mml.mtable-attlist"/>
+      <ref name="mtrPresExpression"/>
+    </element>
+  </define>
+  <define name="mml.mtr">
+    <element name="mml:mtr">
+      <ref name="mml.mtr-attlist"/>
+      <ref name="mtdPresExpression"/>
+    </element>
+  </define>
+  <define name="mml.mlabeledtr">
+    <element name="mml:mlabeledtr">
+      <ref name="mml.mlabeledtr-attlist"/>
+      <ref name="mtdPresExpression"/>
+    </element>
+  </define>
+  <define name="mml.mtd">
+    <element name="mml:mtd">
+      <ref name="mml.mtd-attlist"/>
+      <ref name="PresExpression"/>
+    </element>
+  </define>
+  <define name="mml.maction">
+    <element name="mml:maction">
+      <ref name="mml.maction-attlist"/>
+      <ref name="PresExpression"/>
+    </element>
+  </define>
+  <define name="mml.mfenced">
+    <element name="mml:mfenced">
+      <ref name="mml.mfenced-attlist"/>
+      <ref name="PresExpression"/>
+    </element>
+  </define>
+  <define name="mml.mpadded">
+    <element name="mml:mpadded">
+      <ref name="mml.mpadded-attlist"/>
+      <ref name="PresExpression"/>
+    </element>
+  </define>
+  <!-- Presentation elements contain PCDATA or malignmark constructs. -->
+  <define name="mml.mi">
+    <element name="mml:mi">
+      <ref name="mml.mi-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="MathMLCharacters"/>
+          <ref name="mml.malignmark"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mml.mn">
+    <element name="mml:mn">
+      <ref name="mml.mn-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="MathMLCharacters"/>
+          <ref name="mml.malignmark"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mml.mo">
+    <element name="mml:mo">
+      <ref name="mml.mo-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="MathMLCharacters"/>
+          <ref name="mml.malignmark"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mml.mtext">
+    <element name="mml:mtext">
+      <ref name="mml.mtext-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="MathMLCharacters"/>
+          <ref name="mml.malignmark"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mml.ms">
+    <element name="mml:ms">
+      <ref name="mml.ms-attlist"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="MathMLCharacters"/>
+          <ref name="mml.malignmark"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <!-- Browser interface definition  ............................... -->
+  <!-- Attributes for top-level element "math" -->
+  <define name="att-macros">
+    <optional>
+      <attribute name="macros"/>
+    </optional>
+  </define>
+  <define name="att-mode">
+    <optional>
+      <attribute name="mode"/>
+    </optional>
+  </define>
+  <define name="att-display">
+    <optional>
+      <attribute name="display"/>
+    </optional>
+  </define>
+  <define name="att-schemalocation">
+    <optional>
+      <attribute name="xsi:schemaLocation"/>
+    </optional>
+  </define>
+  <define name="att-topinfo">
+    <ref name="MATHML.Common.attrib"/>
+    <ref name="att-schemalocation"/>
+    <ref name="att-macros"/>
+    <ref name="att-mode"/>
+    <ref name="att-display"/>
+  </define>
+  <!-- Attributes for browser interface element -->
+  <define name="att-baseline">
+    <optional>
+      <attribute name="baseline"/>
+    </optional>
+  </define>
+  <define name="att-overflow">
+    <optional>
+      <attribute name="overflow" a:defaultValue="scroll">
+        <choice>
+          <value>scroll</value>
+          <value>elide</value>
+          <value>truncate</value>
+          <value>scale</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="att-altimg">
+    <optional>
+      <attribute name="altimg"/>
+    </optional>
+  </define>
+  <define name="att-alttext">
+    <optional>
+      <attribute name="alttext"/>
+    </optional>
+  </define>
+  <define name="att-browif">
+    <ref name="att-type"/>
+    <ref name="att-name"/>
+    <ref name="att-height"/>
+    <ref name="att-width"/>
+    <ref name="att-baseline"/>
+    <ref name="att-overflow"/>
+    <ref name="att-altimg"/>
+    <ref name="att-alttext"/>
+  </define>
+  <!-- ............................................................. -->
+  <!--
+    The top-level element "math" contains MathML encoded
+    mathematics. The "math" element has the browser info
+    attributes iff it is also the browser interface element.
+  -->
+  <define name="mml.math">
+    <element name="mml:math">
+      <ref name="mml.math-attlist"/>
+      <ref name="MathExpression"/>
+    </element>
+  </define>
+  <define name="mml.math-attlist" combine="interleave">
+    <ref name="att-topinfo"/>
+    <ref name="att-browif"/>
+  </define>
+</grammar>
+<!-- MathML Character Entities .............................................. -->
+<!--
+  Revision History:
+  
+  Initial draft (syntax = XML) 1997-05-09
+     Stephen Buswell
+  Revised 1997-05-14
+     Robert Miner
+  Revised 1997-06-29 and 1997-07-02
+     Stephen Buswell
+  Revised 1997-12-15
+     Stephen Buswell
+  Revised 1998-02-08
+     Stephen Buswell
+  Revised 1998-04-04
+     Stephen Buswell
+  Entities and small revisions 1999-02-21
+     David Carlisle
+  Added attribute definitionURL to ci and cn 1999-10-11
+     Nico Poppelier
+  Additions for MathML 2  1999-12-16
+     David Carlisle
+  Namespace support 2000-01-14
+     David Carlisle
+  XHTML Compatibility 2000-02-23
+     Murray Altheim
+  New content elements 2000-03-26
+     David Carlisle
+  Further revisions for MathML2 CR draft 2000-07-11
+     David Carlisle
+  Further revisions for MathML2 CR draft 2000-10-31		
+     David Carlisle		
+  Revisions for Unicode 3.2  2002-05-21		
+     David Carlisle		
+  Add width and side attributes to mtable (to align with the specification)  2002-06-05		
+     David Carlisle		
+  Use %XLINK.prefix rather than hardwired xlink:, add xlink:type 2002-06-12		
+     David Carlisle		
+  Add missing numalign and denomalign attributes for mfrac 2002-07-05		
+     David Carlisle		
+  Add MathMLstrict entity and related extra constraints 2002-12-05		
+     David Carlisle		
+  Add support for xi:schemaLocation 2003-04-05		
+     David Carlisle		
+  Removed actiontype from mstyle (to match spec) 2003-04-07		
+     David Carlisle		
+  Additional constraints for MathMLstrict code (From Simon		
+     Pepping on www-math list) 2003-05-22		
+     David Carlisle		
+  Add missing minlabelspacing attribute (From Simon		
+     Pepping on www-math list) 2003-05-22		
+     David Carlisle		
+  Removed restricted menclose notation checking from MathMLstrict 2003-09-08		
+     David Carlisle		
+  
+-->
+<!-- end of MathML 2.0 DTD  ................................................ -->
+<!-- ....................................................................... -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/xhtml-inlstyle-1.mod.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/xhtml-inlstyle-1.mod.rng
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ...................................................................... -->
+<!-- XHTML Inline Style Module  ........................................... -->
+<!--
+  file: xhtml-inlstyle-1.mod
+  
+  This is XHTML, a reformulation of HTML as a modular XML application.
+  Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+  Revision: $Id: xhtml-inlstyle-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $
+  
+  This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+  
+    PUBLIC "-//W3C//ENTITIES XHTML Inline Style 1.0//EN"
+    SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-inlstyle-1.mod"
+  
+  Revisions:
+  (none)
+  .......................................................................
+-->
+<!--
+  Inline Style
+  
+  This module declares the 'style' attribute, used to support inline
+  style markup. This module must be instantiated prior to the XHTML
+  Common Attributes module in order to be included in %Core.attrib;.
+-->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <define name="style.attrib">
+    <optional>
+      <attribute name="style"/>
+    </optional>
+  </define>
+  <define name="Core.extra.attrib">
+    <ref name="style.attrib"/>
+  </define>
+</grammar>
+<!-- end of xhtml-inlstyle-1.mod -->

--- a/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/xhtml-table-1.mod.rng
+++ b/src/main/resources/dtd/archiving/1.2/rng/JATS-Archiving-1-2-MathML2-RNG/xhtml-table-1.mod.rng
@@ -1,0 +1,426 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ...................................................................... -->
+<!-- XHTML Table Module  .................................................. -->
+<!--
+  file: xhtml-table-1.mod
+  
+  This is XHTML, a reformulation of HTML as a modular XML application.
+  Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+  Revision: $Id: xhtml-table-1.mod,v 4.1 2001/04/10 09:42:30 altheim Exp $ SMI
+  
+  This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+  
+    PUBLIC "-//W3C//ELEMENTS XHTML Tables 1.0//EN"
+    SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-table-1.mod"
+  
+  Revisions:
+  (none)
+  .......................................................................
+-->
+<!--
+  Tables
+  
+     table, caption, thead, tfoot, tbody, colgroup, col, tr, th, td
+  
+  This module declares element types and attributes used to provide
+  table markup similar to HTML 4, including features that enable
+  better accessibility for non-visual user agents.
+-->
+<!-- declare qualified element type names: -->
+<!--
+  The frame attribute specifies which parts of the frame around
+  the table should be rendered. The values are not the same as
+  CALS to avoid a name clash with the valign attribute.
+-->
+<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="frame.attrib">
+    <optional>
+      <attribute name="frame">
+        <choice>
+          <value>void</value>
+          <value>above</value>
+          <value>below</value>
+          <value>hsides</value>
+          <value>lhs</value>
+          <value>rhs</value>
+          <value>vsides</value>
+          <value>box</value>
+          <value>border</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!--
+    The rules attribute defines which rules to draw between cells:
+    
+    If rules is absent then assume:
+    
+      "none" if border is absent or border="0" otherwise "all"
+  -->
+  <define name="rules.attrib">
+    <optional>
+      <attribute name="rules">
+        <choice>
+          <value>none</value>
+          <value>groups</value>
+          <value>rows</value>
+          <value>cols</value>
+          <value>all</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!-- horizontal alignment attributes for cell contents -->
+  <define name="CellHAlign.attrib">
+    <optional>
+      <attribute name="align">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>justify</value>
+          <value>char</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="char">
+        <ref name="Character.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="charoff">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- vertical alignment attribute for cell contents -->
+  <define name="CellVAlign.attrib">
+    <optional>
+      <attribute name="valign">
+        <choice>
+          <value>top</value>
+          <value>middle</value>
+          <value>bottom</value>
+          <value>baseline</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!-- scope is simpler than axes attribute for common tables -->
+  <define name="scope.attrib">
+    <optional>
+      <attribute name="scope">
+        <choice>
+          <value>row</value>
+          <value>col</value>
+          <value>rowgroup</value>
+          <value>colgroup</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!-- table: Table Element .............................. -->
+  <define name="table">
+    <element name="table">
+      <ref name="table-attlist"/>
+      <ref name="table.content"/>
+    </element>
+  </define>
+  <!-- end of table.element -->
+  <define name="table-attlist" combine="interleave">
+    <ref name="Common.attrib"/>
+    <optional>
+      <attribute name="summary">
+        <ref name="Text.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="width">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="border">
+        <ref name="Pixels.datatype"/>
+      </attribute>
+    </optional>
+    <ref name="frame.attrib"/>
+    <ref name="rules.attrib"/>
+    <optional>
+      <attribute name="cellspacing">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="cellpadding">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of table.attlist -->
+  <!-- caption: Table Caption ............................ -->
+  <!-- thead: Table Header ............................... -->
+  <!--
+    Use thead to duplicate headers when breaking table
+    across page boundaries, or for static headers when
+    tbody sections are rendered in scrolling panel.
+  -->
+  <define name="thead.content">
+    <oneOrMore>
+      <ref name="tr"/>
+    </oneOrMore>
+  </define>
+  <define name="thead">
+    <element name="thead">
+      <ref name="thead-attlist"/>
+      <ref name="thead.content"/>
+    </element>
+  </define>
+  <!-- end of thead.element -->
+  <define name="thead-attlist" combine="interleave">
+    <ref name="Common.attrib"/>
+    <ref name="CellHAlign.attrib"/>
+    <ref name="CellVAlign.attrib"/>
+  </define>
+  <!-- end of thead.attlist -->
+  <!-- tfoot: Table Footer ............................... -->
+  <!--
+    Use tfoot to duplicate footers when breaking table
+    across page boundaries, or for static footers when
+    tbody sections are rendered in scrolling panel.
+  -->
+  <define name="tfoot.content">
+    <oneOrMore>
+      <ref name="tr"/>
+    </oneOrMore>
+  </define>
+  <define name="tfoot">
+    <element name="tfoot">
+      <ref name="tfoot-attlist"/>
+      <ref name="tfoot.content"/>
+    </element>
+  </define>
+  <!-- end of tfoot.element -->
+  <define name="tfoot-attlist" combine="interleave">
+    <ref name="Common.attrib"/>
+    <ref name="CellHAlign.attrib"/>
+    <ref name="CellVAlign.attrib"/>
+  </define>
+  <!-- end of tfoot.attlist -->
+  <!-- tbody: Table Body ................................. -->
+  <!--
+    Use multiple tbody sections when rules are needed
+    between groups of table rows.
+  -->
+  <define name="tbody.content">
+    <oneOrMore>
+      <ref name="tr"/>
+    </oneOrMore>
+  </define>
+  <define name="tbody">
+    <element name="tbody">
+      <ref name="tbody-attlist"/>
+      <ref name="tbody.content"/>
+    </element>
+  </define>
+  <!-- end of tbody.element -->
+  <define name="tbody-attlist" combine="interleave">
+    <ref name="Common.attrib"/>
+    <ref name="CellHAlign.attrib"/>
+    <ref name="CellVAlign.attrib"/>
+  </define>
+  <!-- end of tbody.attlist -->
+  <!-- colgroup: Table Column Group ...................... -->
+  <!--
+    colgroup groups a set of col elements. It allows you
+    to group several semantically-related columns together.
+  -->
+  <define name="colgroup.content">
+    <zeroOrMore>
+      <ref name="col"/>
+    </zeroOrMore>
+  </define>
+  <define name="colgroup">
+    <element name="colgroup">
+      <ref name="colgroup-attlist"/>
+      <ref name="colgroup.content"/>
+    </element>
+  </define>
+  <!-- end of colgroup.element -->
+  <define name="colgroup-attlist" combine="interleave">
+    <ref name="Common.attrib"/>
+    <optional>
+      <attribute name="span" a:defaultValue="1">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="width">
+        <ref name="MultiLength.datatype"/>
+      </attribute>
+    </optional>
+    <ref name="CellHAlign.attrib"/>
+    <ref name="CellVAlign.attrib"/>
+  </define>
+  <!-- end of colgroup.attlist -->
+  <!-- col: Table Column ................................. -->
+  <!--
+    col elements define the alignment properties for
+    cells in one or more columns.
+    
+    The width attribute specifies the width of the
+    columns, e.g.
+    
+      width="64"        width in screen pixels
+      width="0.5*"      relative width of 0.5
+    
+    The span attribute causes the attributes of one
+    col element to apply to more than one column.
+  -->
+  <define name="col.content">
+    <empty/>
+  </define>
+  <define name="col">
+    <element name="col">
+      <ref name="col-attlist"/>
+      <ref name="col.content"/>
+    </element>
+  </define>
+  <!-- end of col.element -->
+  <define name="col-attlist" combine="interleave">
+    <ref name="Common.attrib"/>
+    <optional>
+      <attribute name="span" a:defaultValue="1">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="width">
+        <ref name="MultiLength.datatype"/>
+      </attribute>
+    </optional>
+    <ref name="CellHAlign.attrib"/>
+    <ref name="CellVAlign.attrib"/>
+  </define>
+  <!-- end of col.attlist -->
+  <!-- tr: Table Row ..................................... -->
+  <define name="tr.content">
+    <oneOrMore>
+      <choice>
+        <ref name="th"/>
+        <ref name="td"/>
+      </choice>
+    </oneOrMore>
+  </define>
+  <define name="tr">
+    <element name="tr">
+      <ref name="tr-attlist"/>
+      <ref name="tr.content"/>
+    </element>
+  </define>
+  <!-- end of tr.element -->
+  <define name="tr-attlist" combine="interleave">
+    <ref name="Common.attrib"/>
+    <ref name="CellHAlign.attrib"/>
+    <ref name="CellVAlign.attrib"/>
+  </define>
+  <!-- end of tr.attlist -->
+  <!-- th: Table Header Cell ............................. -->
+  <!--
+    th is for header cells, td for data,
+    but for cells acting as both use td
+  -->
+  <define name="th.content">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="Flow.mix"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="th">
+    <element name="th">
+      <ref name="th-attlist"/>
+      <ref name="th.content"/>
+    </element>
+  </define>
+  <!-- end of th.element -->
+  <define name="th-attlist" combine="interleave">
+    <ref name="Common.attrib"/>
+    <optional>
+      <attribute name="abbr">
+        <ref name="Text.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="axis"/>
+    </optional>
+    <optional>
+      <attribute name="headers">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <ref name="scope.attrib"/>
+    <optional>
+      <attribute name="rowspan" a:defaultValue="1">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="colspan" a:defaultValue="1">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <ref name="CellHAlign.attrib"/>
+    <ref name="CellVAlign.attrib"/>
+  </define>
+  <!-- end of th.attlist -->
+  <!-- td: Table Data Cell ............................... -->
+  <define name="td.content">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="Flow.mix"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="td">
+    <element name="td">
+      <ref name="td-attlist"/>
+      <ref name="td.content"/>
+    </element>
+  </define>
+  <!-- end of td.element -->
+  <define name="td-attlist" combine="interleave">
+    <ref name="Common.attrib"/>
+    <optional>
+      <attribute name="abbr">
+        <ref name="Text.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="axis"/>
+    </optional>
+    <optional>
+      <attribute name="headers">
+        <data type="IDREFS"/>
+      </attribute>
+    </optional>
+    <ref name="scope.attrib"/>
+    <optional>
+      <attribute name="rowspan" a:defaultValue="1">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="colspan" a:defaultValue="1">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <ref name="CellHAlign.attrib"/>
+    <ref name="CellVAlign.attrib"/>
+  </define>
+</grammar>
+<!-- end of td.attlist -->
+<!-- end of xhtml-table-1.mod -->

--- a/src/main/resources/dtd/archiving/1.2/xhtml-inlstyle-1.mod
+++ b/src/main/resources/dtd/archiving/1.2/xhtml-inlstyle-1.mod
@@ -1,0 +1,34 @@
+<!-- ...................................................................... -->
+<!-- XHTML Inline Style Module  ........................................... -->
+<!-- file: xhtml-inlstyle-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-inlstyle-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ENTITIES XHTML Inline Style 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-inlstyle-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Inline Style
+
+     This module declares the 'style' attribute, used to support inline
+     style markup. This module must be instantiated prior to the XHTML
+     Common Attributes module in order to be included in %Core.attrib;.
+-->
+
+<!ENTITY % style.attrib
+     "style        CDATA                    #IMPLIED"
+>
+
+
+<!ENTITY % Core.extra.attrib
+     "%style.attrib;"
+>
+
+<!-- end of xhtml-inlstyle-1.mod -->

--- a/src/main/resources/dtd/archiving/1.2/xhtml-table-1.mod
+++ b/src/main/resources/dtd/archiving/1.2/xhtml-table-1.mod
@@ -1,0 +1,333 @@
+<!-- ...................................................................... -->
+<!-- XHTML Table Module  .................................................. -->
+<!-- file: xhtml-table-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-table-1.mod,v 4.1 2001/04/10 09:42:30 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Tables 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-table-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Tables
+
+        table, caption, thead, tfoot, tbody, colgroup, col, tr, th, td
+
+     This module declares element types and attributes used to provide
+     table markup similar to HTML 4, including features that enable
+     better accessibility for non-visual user agents.
+-->
+
+<!-- declare qualified element type names:
+-->
+<!ENTITY % table.qname  "table" >
+<!ENTITY % caption.qname  "caption" >
+<!ENTITY % thead.qname  "thead" >
+<!ENTITY % tfoot.qname  "tfoot" >
+<!ENTITY % tbody.qname  "tbody" >
+<!ENTITY % colgroup.qname  "colgroup" >
+<!ENTITY % col.qname  "col" >
+<!ENTITY % tr.qname  "tr" >
+<!ENTITY % th.qname  "th" >
+<!ENTITY % td.qname  "td" >
+
+<!-- The frame attribute specifies which parts of the frame around
+     the table should be rendered. The values are not the same as
+     CALS to avoid a name clash with the valign attribute.
+-->
+<!ENTITY % frame.attrib
+     "frame        ( void
+                   | above
+                   | below
+                   | hsides
+                   | lhs
+                   | rhs
+                   | vsides
+                   | box
+                   | border )               #IMPLIED"
+>
+
+<!-- The rules attribute defines which rules to draw between cells:
+
+     If rules is absent then assume:
+
+       "none" if border is absent or border="0" otherwise "all"
+-->
+<!ENTITY % rules.attrib
+     "rules        ( none
+                   | groups
+                   | rows
+                   | cols
+                   | all )                  #IMPLIED"
+>
+
+<!-- horizontal alignment attributes for cell contents
+-->
+<!ENTITY % CellHAlign.attrib
+     "align        ( left
+                   | center
+                   | right
+                   | justify
+                   | char )                 #IMPLIED
+      char         %Character.datatype;     #IMPLIED
+      charoff      %Length.datatype;        #IMPLIED"
+>
+
+<!-- vertical alignment attribute for cell contents
+-->
+<!ENTITY % CellVAlign.attrib
+     "valign       ( top
+                   | middle
+                   | bottom
+                   | baseline )             #IMPLIED"
+>
+
+<!-- scope is simpler than axes attribute for common tables
+-->
+<!ENTITY % scope.attrib
+     "scope        ( row
+                   | col
+                   | rowgroup
+                   | colgroup )             #IMPLIED"
+>
+
+<!-- table: Table Element .............................. -->
+
+<!ENTITY % table.element  "INCLUDE" >
+<![%table.element;[
+<!ENTITY % table.content
+     "( %caption.qname;?, ( %col.qname;* | %colgroup.qname;* ),
+      (( %thead.qname;?, %tfoot.qname;?, %tbody.qname;+ ) | ( %tr.qname;+ )))"
+>
+<!ELEMENT %table.qname;  %table.content; >
+<!-- end of table.element -->]]>
+
+<!ENTITY % table.attlist  "INCLUDE" >
+<![%table.attlist;[
+<!ATTLIST %table.qname;
+      %Common.attrib;
+      summary      %Text.datatype;          #IMPLIED
+      width        %Length.datatype;        #IMPLIED
+      border       %Pixels.datatype;        #IMPLIED
+      %frame.attrib;
+      %rules.attrib;
+      cellspacing  %Length.datatype;        #IMPLIED
+      cellpadding  %Length.datatype;        #IMPLIED
+>
+<!-- end of table.attlist -->]]>
+
+<!-- caption: Table Caption ............................ -->
+
+<!ENTITY % caption.element  "INCLUDE" >
+<![%caption.element;[
+<!ENTITY % caption.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ELEMENT %caption.qname;  %caption.content; >
+<!-- end of caption.element -->]]>
+
+<!ENTITY % caption.attlist  "INCLUDE" >
+<![%caption.attlist;[
+<!ATTLIST %caption.qname;
+      %Common.attrib;
+>
+<!-- end of caption.attlist -->]]>
+
+<!-- thead: Table Header ............................... -->
+
+<!-- Use thead to duplicate headers when breaking table
+     across page boundaries, or for static headers when
+     tbody sections are rendered in scrolling panel.
+-->
+
+<!ENTITY % thead.element  "INCLUDE" >
+<![%thead.element;[
+<!ENTITY % thead.content  "( %tr.qname; )+" >
+<!ELEMENT %thead.qname;  %thead.content; >
+<!-- end of thead.element -->]]>
+
+<!ENTITY % thead.attlist  "INCLUDE" >
+<![%thead.attlist;[
+<!ATTLIST %thead.qname;
+      %Common.attrib;
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of thead.attlist -->]]>
+
+<!-- tfoot: Table Footer ............................... -->
+
+<!-- Use tfoot to duplicate footers when breaking table
+     across page boundaries, or for static footers when
+     tbody sections are rendered in scrolling panel.
+-->
+
+<!ENTITY % tfoot.element  "INCLUDE" >
+<![%tfoot.element;[
+<!ENTITY % tfoot.content  "( %tr.qname; )+" >
+<!ELEMENT %tfoot.qname;  %tfoot.content; >
+<!-- end of tfoot.element -->]]>
+
+<!ENTITY % tfoot.attlist  "INCLUDE" >
+<![%tfoot.attlist;[
+<!ATTLIST %tfoot.qname;
+      %Common.attrib;
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of tfoot.attlist -->]]>
+
+<!-- tbody: Table Body ................................. -->
+
+<!-- Use multiple tbody sections when rules are needed
+     between groups of table rows.
+-->
+
+<!ENTITY % tbody.element  "INCLUDE" >
+<![%tbody.element;[
+<!ENTITY % tbody.content  "( %tr.qname; )+" >
+<!ELEMENT %tbody.qname;  %tbody.content; >
+<!-- end of tbody.element -->]]>
+
+<!ENTITY % tbody.attlist  "INCLUDE" >
+<![%tbody.attlist;[
+<!ATTLIST %tbody.qname;
+      %Common.attrib;
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of tbody.attlist -->]]>
+
+<!-- colgroup: Table Column Group ...................... -->
+
+<!-- colgroup groups a set of col elements. It allows you
+     to group several semantically-related columns together.
+-->
+
+<!ENTITY % colgroup.element  "INCLUDE" >
+<![%colgroup.element;[
+<!ENTITY % colgroup.content  "( %col.qname; )*" >
+<!ELEMENT %colgroup.qname;  %colgroup.content; >
+<!-- end of colgroup.element -->]]>
+
+<!ENTITY % colgroup.attlist  "INCLUDE" >
+<![%colgroup.attlist;[
+<!ATTLIST %colgroup.qname;
+      %Common.attrib;
+      span         %Number.datatype;        '1'
+      width        %MultiLength.datatype;   #IMPLIED
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of colgroup.attlist -->]]>
+
+<!-- col: Table Column ................................. -->
+
+<!-- col elements define the alignment properties for
+     cells in one or more columns.
+
+     The width attribute specifies the width of the
+     columns, e.g.
+
+       width="64"        width in screen pixels
+       width="0.5*"      relative width of 0.5
+
+     The span attribute causes the attributes of one
+     col element to apply to more than one column.
+-->
+
+<!ENTITY % col.element  "INCLUDE" >
+<![%col.element;[
+<!ENTITY % col.content  "EMPTY" >
+<!ELEMENT %col.qname;  %col.content; >
+<!-- end of col.element -->]]>
+
+<!ENTITY % col.attlist  "INCLUDE" >
+<![%col.attlist;[
+<!ATTLIST %col.qname;
+      %Common.attrib;
+      span         %Number.datatype;        '1'
+      width        %MultiLength.datatype;   #IMPLIED
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of col.attlist -->]]>
+
+<!-- tr: Table Row ..................................... -->
+
+<!ENTITY % tr.element  "INCLUDE" >
+<![%tr.element;[
+<!ENTITY % tr.content  "( %th.qname; | %td.qname; )+" >
+<!ELEMENT %tr.qname;  %tr.content; >
+<!-- end of tr.element -->]]>
+
+<!ENTITY % tr.attlist  "INCLUDE" >
+<![%tr.attlist;[
+<!ATTLIST %tr.qname;
+      %Common.attrib;
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of tr.attlist -->]]>
+
+<!-- th: Table Header Cell ............................. -->
+
+<!-- th is for header cells, td for data,
+     but for cells acting as both use td
+-->
+
+<!ENTITY % th.element  "INCLUDE" >
+<![%th.element;[
+<!ENTITY % th.content
+     "( #PCDATA | %Flow.mix; )*"
+>
+<!ELEMENT %th.qname;  %th.content; >
+<!-- end of th.element -->]]>
+
+<!ENTITY % th.attlist  "INCLUDE" >
+<![%th.attlist;[
+<!ATTLIST %th.qname;
+      %Common.attrib;
+      abbr         %Text.datatype;          #IMPLIED
+      axis         CDATA                    #IMPLIED
+      headers      IDREFS                   #IMPLIED
+      %scope.attrib;
+      rowspan      %Number.datatype;        '1'
+      colspan      %Number.datatype;        '1'
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of th.attlist -->]]>
+
+<!-- td: Table Data Cell ............................... -->
+
+<!ENTITY % td.element  "INCLUDE" >
+<![%td.element;[
+<!ENTITY % td.content
+     "( #PCDATA | %Flow.mix; )*"
+>
+<!ELEMENT %td.qname;  %td.content; >
+<!-- end of td.element -->]]>
+
+<!ENTITY % td.attlist  "INCLUDE" >
+<![%td.attlist;[
+<!ATTLIST %td.qname;
+      %Common.attrib;
+      abbr         %Text.datatype;          #IMPLIED
+      axis         CDATA                    #IMPLIED
+      headers      IDREFS                   #IMPLIED
+      %scope.attrib;
+      rowspan      %Number.datatype;        '1'
+      colspan      %Number.datatype;        '1'
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of td.attlist -->]]>
+
+<!-- end of xhtml-table-1.mod -->

--- a/src/main/resources/dtd/archiving/1.2/xmlchars/isogrk1.ent
+++ b/src/main/resources/dtd/archiving/1.2/xmlchars/isogrk1.ent
@@ -1,0 +1,70 @@
+
+<!--
+     File isogrk1.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY Agr              "&#x00391;" ><!--=capital Alpha, Greek -->
+<!ENTITY agr              "&#x003B1;" ><!--=small alpha, Greek -->
+<!ENTITY Bgr              "&#x00392;" ><!--=capital Beta, Greek -->
+<!ENTITY bgr              "&#x003B2;" ><!--=small beta, Greek -->
+<!ENTITY Dgr              "&#x00394;" ><!--=capital Delta, Greek -->
+<!ENTITY dgr              "&#x003B4;" ><!--=small delta, Greek -->
+<!ENTITY EEgr             "&#x00397;" ><!--=capital Eta, Greek -->
+<!ENTITY eegr             "&#x003B7;" ><!--=small eta, Greek -->
+<!ENTITY Egr              "&#x00395;" ><!--=capital Epsilon, Greek -->
+<!ENTITY egr              "&#x003B5;" ><!--=small epsilon, Greek -->
+<!ENTITY Ggr              "&#x00393;" ><!--=capital Gamma, Greek -->
+<!ENTITY ggr              "&#x003B3;" ><!--=small gamma, Greek -->
+<!ENTITY Igr              "&#x00399;" ><!--=capital Iota, Greek -->
+<!ENTITY igr              "&#x003B9;" ><!--=small iota, Greek -->
+<!ENTITY Kgr              "&#x0039A;" ><!--=capital Kappa, Greek -->
+<!ENTITY kgr              "&#x003BA;" ><!--=small kappa, Greek -->
+<!ENTITY KHgr             "&#x003A7;" ><!--=capital Chi, Greek -->
+<!ENTITY khgr             "&#x003C7;" ><!--=small chi, Greek -->
+<!ENTITY Lgr              "&#x0039B;" ><!--=capital Lambda, Greek -->
+<!ENTITY lgr              "&#x003BB;" ><!--=small lambda, Greek -->
+<!ENTITY Mgr              "&#x0039C;" ><!--=capital Mu, Greek -->
+<!ENTITY mgr              "&#x003BC;" ><!--=small mu, Greek -->
+<!ENTITY Ngr              "&#x0039D;" ><!--=capital Nu, Greek -->
+<!ENTITY ngr              "&#x003BD;" ><!--=small nu, Greek -->
+<!ENTITY Ogr              "&#x0039F;" ><!--=capital Omicron, Greek -->
+<!ENTITY ogr              "&#x003BF;" ><!--=small omicron, Greek -->
+<!ENTITY OHgr             "&#x003A9;" ><!--=capital Omega, Greek -->
+<!ENTITY ohgr             "&#x003C9;" ><!--=small omega, Greek -->
+<!ENTITY Pgr              "&#x003A0;" ><!--=capital Pi, Greek -->
+<!ENTITY pgr              "&#x003C0;" ><!--=small pi, Greek -->
+<!ENTITY PHgr             "&#x003A6;" ><!--=capital Phi, Greek -->
+<!ENTITY phgr             "&#x003C6;" ><!--=small phi, Greek -->
+<!ENTITY PSgr             "&#x003A8;" ><!--=capital Psi, Greek -->
+<!ENTITY psgr             "&#x003C8;" ><!--=small psi, Greek -->
+<!ENTITY Rgr              "&#x003A1;" ><!--=capital Rho, Greek -->
+<!ENTITY rgr              "&#x003C1;" ><!--=small rho, Greek -->
+<!ENTITY sfgr             "&#x003C2;" ><!--=final small sigma, Greek -->
+<!ENTITY Sgr              "&#x003A3;" ><!--=capital Sigma, Greek -->
+<!ENTITY sgr              "&#x003C3;" ><!--=small sigma, Greek -->
+<!ENTITY Tgr              "&#x003A4;" ><!--=capital Tau, Greek -->
+<!ENTITY tgr              "&#x003C4;" ><!--=small tau, Greek -->
+<!ENTITY THgr             "&#x00398;" ><!--=capital Theta, Greek -->
+<!ENTITY thgr             "&#x003B8;" ><!--=small theta, Greek -->
+<!ENTITY Ugr              "&#x003A5;" ><!--=capital Upsilon, Greek -->
+<!ENTITY ugr              "&#x003C5;" ><!--=small upsilon, Greek -->
+<!ENTITY Xgr              "&#x0039E;" ><!--=capital Xi, Greek -->
+<!ENTITY xgr              "&#x003BE;" ><!--=small xi, Greek -->
+<!ENTITY Zgr              "&#x00396;" ><!--=capital Zeta, Greek -->
+<!ENTITY zgr              "&#x003B6;" ><!--=small zeta, Greek -->

--- a/src/main/resources/dtd/archiving/1.2/xmlchars/isogrk2.ent
+++ b/src/main/resources/dtd/archiving/1.2/xmlchars/isogrk2.ent
@@ -1,0 +1,41 @@
+
+<!--
+     File isogrk2.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY Aacgr            "&#x00386;" ><!--=capital Alpha, accent, Greek -->
+<!ENTITY aacgr            "&#x003AC;" ><!--=small alpha, accent, Greek -->
+<!ENTITY Eacgr            "&#x00388;" ><!--=capital Epsilon, accent, Greek -->
+<!ENTITY eacgr            "&#x003AD;" ><!--=small epsilon, accent, Greek -->
+<!ENTITY EEacgr           "&#x00389;" ><!--=capital Eta, accent, Greek -->
+<!ENTITY eeacgr           "&#x003AE;" ><!--=small eta, accent, Greek -->
+<!ENTITY Iacgr            "&#x0038A;" ><!--=capital Iota, accent, Greek -->
+<!ENTITY iacgr            "&#x003AF;" ><!--=small iota, accent, Greek -->
+<!ENTITY idiagr           "&#x00390;" ><!--=small iota, dieresis, accent, Greek -->
+<!ENTITY Idigr            "&#x003AA;" ><!--=capital Iota, dieresis, Greek -->
+<!ENTITY idigr            "&#x003CA;" ><!--=small iota, dieresis, Greek -->
+<!ENTITY Oacgr            "&#x0038C;" ><!--=capital Omicron, accent, Greek -->
+<!ENTITY oacgr            "&#x003CC;" ><!--=small omicron, accent, Greek -->
+<!ENTITY OHacgr           "&#x0038F;" ><!--=capital Omega, accent, Greek -->
+<!ENTITY ohacgr           "&#x003CE;" ><!--=small omega, accent, Greek -->
+<!ENTITY Uacgr            "&#x0038E;" ><!--=capital Upsilon, accent, Greek -->
+<!ENTITY uacgr            "&#x003CD;" ><!--=small upsilon, accent, Greek -->
+<!ENTITY udiagr           "&#x003B0;" ><!--=small upsilon, dieresis, accent, Greek -->
+<!ENTITY Udigr            "&#x003AB;" ><!--=capital Upsilon, dieresis, Greek -->
+<!ENTITY udigr            "&#x003CB;" ><!--=small upsilon, dieresis, Greek -->

--- a/src/main/resources/dtd/archiving/1.2/xmlchars/isogrk4.ent
+++ b/src/main/resources/dtd/archiving/1.2/xmlchars/isogrk4.ent
@@ -1,0 +1,66 @@
+
+<!--
+     File isogrk4.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY % plane1D  "&#38;#38;#x1D">
+
+<!ENTITY b.alpha          "%plane1D;6C2;" ><!--small alpha, Greek -->
+<!ENTITY b.beta           "%plane1D;6C3;" ><!--small beta, Greek -->
+<!ENTITY b.chi            "%plane1D;6D8;" ><!--small chi, Greek -->
+<!ENTITY b.Delta          "%plane1D;6AB;" ><!--capital delta, Greek -->
+<!ENTITY b.delta          "%plane1D;6C5;" ><!--small delta, Greek -->
+<!ENTITY b.epsi           "%plane1D;6C6;" ><!--small epsilon, Greek -->
+<!ENTITY b.epsiv          "%plane1D;6DC;" ><!--variant epsilon -->
+<!ENTITY b.eta            "%plane1D;6C8;" ><!--small eta, Greek -->
+<!ENTITY b.Gamma          "%plane1D;6AA;" ><!--capital gamma, Greek -->
+<!ENTITY b.gamma          "%plane1D;6C4;" ><!--small gamma, Greek -->
+<!ENTITY b.Gammad         "&#x003DC;" ><!--capital Digamma -->
+<!ENTITY b.gammad         "&#x003DD;" ><!--digamma -->
+<!ENTITY b.iota           "%plane1D;6CA;" ><!--small iota, Greek -->
+<!ENTITY b.kappa          "%plane1D;6CB;" ><!--small kappa, Greek -->
+<!ENTITY b.kappav         "%plane1D;6DE;" ><!--variant kappa -->
+<!ENTITY b.Lambda         "%plane1D;6B2;" ><!--capital Lambda, Greek -->
+<!ENTITY b.lambda         "%plane1D;6CC;" ><!--small lambda, Greek -->
+<!ENTITY b.mu             "%plane1D;6CD;" ><!--small mu, Greek -->
+<!ENTITY b.nu             "%plane1D;6CE;" ><!--small nu, Greek -->
+<!ENTITY b.Omega          "%plane1D;6C0;" ><!--capital Omega, Greek -->
+<!ENTITY b.omega          "%plane1D;6DA;" ><!--small omega, Greek -->
+<!ENTITY b.Phi            "%plane1D;6BD;" ><!--capital Phi, Greek -->
+<!ENTITY b.phi            "%plane1D;6D7;" ><!--small phi, Greek -->
+<!ENTITY b.phiv           "%plane1D;6DF;" ><!--variant phi -->
+<!ENTITY b.Pi             "%plane1D;6B7;" ><!--capital Pi, Greek -->
+<!ENTITY b.pi             "%plane1D;6D1;" ><!--small pi, Greek -->
+<!ENTITY b.piv            "%plane1D;6E1;" ><!--variant pi -->
+<!ENTITY b.Psi            "%plane1D;6BF;" ><!--capital Psi, Greek -->
+<!ENTITY b.psi            "%plane1D;6D9;" ><!--small psi, Greek -->
+<!ENTITY b.rho            "%plane1D;6D2;" ><!--small rho, Greek -->
+<!ENTITY b.rhov           "%plane1D;6E0;" ><!--variant rho -->
+<!ENTITY b.Sigma          "%plane1D;6BA;" ><!--capital Sigma, Greek -->
+<!ENTITY b.sigma          "%plane1D;6D4;" ><!--small sigma, Greek -->
+<!ENTITY b.sigmav         "%plane1D;6D3;" ><!--variant sigma -->
+<!ENTITY b.tau            "%plane1D;6D5;" ><!--small tau, Greek -->
+<!ENTITY b.Theta          "%plane1D;6AF;" ><!--capital Theta, Greek -->
+<!ENTITY b.thetas         "%plane1D;6C9;" ><!--straight theta, Greek -->
+<!ENTITY b.thetav         "%plane1D;6DD;" ><!--variant theta -->
+<!ENTITY b.Upsi           "%plane1D;6BC;" ><!--capital Upsilon, Greek -->
+<!ENTITY b.upsi           "%plane1D;6D6;" ><!--small upsilon, Greek -->
+<!ENTITY b.Xi             "%plane1D;6B5;" ><!--capital Xi, Greek -->
+<!ENTITY b.xi             "%plane1D;6CF;" ><!--small xi, Greek -->
+<!ENTITY b.zeta           "%plane1D;6C7;" ><!--small zeta, Greek -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/JATS-archivearticle1-elements.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/JATS-archivearticle1-elements.xsd
@@ -1,0 +1,9198 @@
+<?xml-stylesheet href="xsd.xsl" type="text/xsl"?>
+<xsd:schema xmlns:mtl="http://www.mulberrytech.com/taglib"
+            xmlns:c="http://www.w3.org/ns/xproc-step"
+            xmlns:mml="http://www.w3.org/1998/Math/MathML"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:ali="http://www.niso.org/schemas/ali/1.0/"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <xsd:annotation xmlns:dxdy="http://mulberrytech.com/2014/dxdy">
+          <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml" class="bodytext">
+              <h1>MODULE: JATS-archivearticle1 DTD in XSD form (declarations file)</h1>
+              <h2>MODEL: Journal Archiving and Interchange DTD (MathML 2.0)</h2>
+              <h2>VERSION:  1.2</h2>
+              <h2>DATE:  February 2019</h2>
+              <dl>
+                <dt>SYSTEM</dt>
+                <dd>
+                  <p>Journal Archiving and Interchange model of the JATS Suite</p>
+               </dd>
+                <dt>PURPOSE</dt>
+                <dd>
+                  <p>Declare elements with names which are not
+                  namespace-qualified</p>
+               </dd>
+                <dt>CREATED FOR</dt>
+                <dd>
+                  <p>NLM/NCBI</p> 
+               </dd>
+                
+              </dl>
+            </div>
+          </xsd:documentation>
+        </xsd:annotation>
+   <xsd:import namespace="http://www.w3.org/1999/xlink"/>
+   <xsd:import namespace="http://www.w3.org/1998/Math/MathML"/>
+   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+   <xsd:import namespace="http://www.niso.org/schemas/ali/1.0/"/>
+   <!--* Some imports may need to be added manually *-->
+   <xsd:element name="abbrev">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Abbreviation or Acronym</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="abbrev-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="alt" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="abbrev-journal-title">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Abbreviated Journal Title</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="abbrev-journal-title-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="abbrev-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="abstract">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Abstract</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="abstract-model"/>
+         <xsd:attribute name="abstract-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="access-date">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Access Date For Cited Work</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="access-date-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="calendar" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="iso-8601-date" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="ack">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Acknowledgments</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="ack-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="addr-line">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Address Line</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="addr-line-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="address">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Address/Contact Information</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="address-model" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="aff">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Affiliation</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="aff-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="aff-alternatives">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Affiliation Alternatives</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="aff-alternatives-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="alt-text">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Alternate Title Text For a Figure, Etc.</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="alt-title">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Alternate Title</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="alt-title-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="alt-title-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="alternatives">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Alternatives For Processing</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="alternatives-model" maxOccurs="unbounded"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="annotation">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Annotation in a Citation</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="annotation-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="anonymous">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Anonymous</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:group ref="anonymous-model" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="app">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Appendix</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="app-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="app-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Appendix Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="app-group-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="array">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Array (Simple Tabular Array)</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="array-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="orientation" use="optional" default="portrait">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="landscape"/>
+                  <xsd:enumeration value="portrait"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="article">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Article</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="article-full-model"/>
+         <xsd:attribute name="article-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="dtd-version" fixed="1.2" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional" default="en"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="article-categories">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Article Grouping Data</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="article-categories-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="article-id">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Article Identifier</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="assigning-authority" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="pub-id-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="article-meta">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Article Metadata</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="article-meta-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="article-title">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Article Title</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="article-title-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="article-version">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Article Version</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="article-version-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="designator" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="iso-8601-date" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="article-version-alternatives">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Article Version Alternatives</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:choice>
+            <xsd:element ref="article-version" maxOccurs="unbounded"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="attrib">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Attribution</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="attrib-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="author-comment">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Author Comment</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="author-comment-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="author-notes">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Author Note Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="author-notes-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="award-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Award Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="award-group-model"/>
+         <xsd:attribute name="award-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="award-id">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Award Identifier</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="award-id-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="award-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="back">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Back Matter</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="back-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="bio">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Biography</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="bio-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="body">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Body of the Article</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="body-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="bold">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Bold</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="emphasized-text"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="toggle" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="no"/>
+                  <xsd:enumeration value="yes"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="boxed-text">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Boxed Text</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="boxed-text-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="orientation" use="optional" default="portrait">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="landscape"/>
+                  <xsd:enumeration value="portrait"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="position" use="optional" default="float">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="anchor"/>
+                  <xsd:enumeration value="background"/>
+                  <xsd:enumeration value="float"/>
+                  <xsd:enumeration value="margin"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="break">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Line Break</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="caption">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Caption of a Figure, Table, Etc.</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="caption-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="style" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="chapter-title">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Chapter Title in a Citation</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="chapter-title-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="chem-struct">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Chemical Structure (Display)</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:group ref="chem-struct-model" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="chem-struct-wrap">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Chemical Structure Wrapper</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="chem-struct-wrap-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="orientation" use="optional" default="portrait">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="landscape"/>
+                  <xsd:enumeration value="portrait"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="position" use="optional" default="float">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="anchor"/>
+                  <xsd:enumeration value="background"/>
+                  <xsd:enumeration value="float"/>
+                  <xsd:enumeration value="margin"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="citation-alternatives">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Citation Alternatives</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="citation-alternatives-model" maxOccurs="unbounded"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="city">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>City: in an Address</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="city-elements"/>
+         </xsd:sequence>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="code">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Code Text</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="code-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="code-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="code-version" use="optional" type="xsd:string"/>
+         <xsd:attribute name="executable" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="no"/>
+                  <xsd:enumeration value="yes"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="language" use="optional" type="xsd:string"/>
+         <xsd:attribute name="language-version" use="optional" type="xsd:string"/>
+         <xsd:attribute name="orientation" use="optional" default="portrait">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="landscape"/>
+                  <xsd:enumeration value="portrait"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="platforms" use="optional" type="xsd:string"/>
+         <xsd:attribute name="position" use="optional" default="float">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="anchor"/>
+                  <xsd:enumeration value="background"/>
+                  <xsd:enumeration value="float"/>
+                  <xsd:enumeration value="margin"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+         <xsd:attribute ref="xml:space" fixed="preserve"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="col">
+      <xsd:annotation>
+         <xsd:documentation/>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="align" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="center"/>
+                  <xsd:enumeration value="char"/>
+                  <xsd:enumeration value="justify"/>
+                  <xsd:enumeration value="left"/>
+                  <xsd:enumeration value="right"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="char" use="optional" type="xsd:string"/>
+         <xsd:attribute name="charoff" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="span" use="optional" default="1" type="xsd:string"/>
+         <xsd:attribute name="style" use="optional" type="xsd:string"/>
+         <xsd:attribute name="valign" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="baseline"/>
+                  <xsd:enumeration value="bottom"/>
+                  <xsd:enumeration value="middle"/>
+                  <xsd:enumeration value="top"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="width" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="colgroup">
+      <xsd:annotation>
+         <xsd:documentation/>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="colgroup.content" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="align" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="center"/>
+                  <xsd:enumeration value="char"/>
+                  <xsd:enumeration value="justify"/>
+                  <xsd:enumeration value="left"/>
+                  <xsd:enumeration value="right"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="char" use="optional" type="xsd:string"/>
+         <xsd:attribute name="charoff" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="span" use="optional" default="1" type="xsd:string"/>
+         <xsd:attribute name="style" use="optional" type="xsd:string"/>
+         <xsd:attribute name="valign" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="baseline"/>
+                  <xsd:enumeration value="bottom"/>
+                  <xsd:enumeration value="middle"/>
+                  <xsd:enumeration value="top"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="width" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="collab">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Collaborative (Group) Author</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="collab-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="collab-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="symbol" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="collab-alternatives">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Collaboration Alternatives</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="collab-alternatives-model" maxOccurs="unbounded"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="comment">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Comment in a Citation</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="comment-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="compound-kwd">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Compound Keyword</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="compound-kwd-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="vocab" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="compound-kwd-part">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Compound Keyword Part</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="compound-kwd-part-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="compound-subject">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Compound Subject Name</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="compound-subject-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="vocab" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="compound-subject-part">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Compound Subject Part Name</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="compound-subject-part-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="conf-acronym">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Conference Acronym</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="conf-acronym-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="conf-date">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Conference Date</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="conf-date-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="calendar" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="iso-8601-date" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="conf-loc">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Conference Location</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="conf-loc-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="conf-name">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Conference Name</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="conf-name-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="conf-num">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Conference Number</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="conf-num-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="conf-sponsor">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Conference Sponsor</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="conf-sponsor-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="conf-theme">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Conference Theme</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="conf-theme-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="conference">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Conference Information</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="conference-model" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="contrib">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Contributor</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="contrib-model" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="contrib-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="corresp" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="no"/>
+                  <xsd:enumeration value="yes"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="deceased" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="no"/>
+                  <xsd:enumeration value="yes"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="equal-contrib" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="no"/>
+                  <xsd:enumeration value="yes"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="contrib-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Contributor Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="contrib-group-model" maxOccurs="unbounded"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="contrib-id">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Contributor Identifier</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:group ref="contrib-id-model" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="assigning-authority" use="optional" type="xsd:string"/>
+         <xsd:attribute name="authenticated" use="optional" default="false">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="false"/>
+                  <xsd:enumeration value="true"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="contrib-id-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="contributed-resource-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Contributed Resource Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="contributed-resource-group-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="resource-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="copyright-holder">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Copyright Holder</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="copyright-holder-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="copyright-statement">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Copyright Statement</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="copyright-statement-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="copyright-year">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Copyright Year</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="corresp">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Correspondence Information</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="corresp-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="count">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Count</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="count" use="required" type="xsd:NMTOKEN"/>
+         <xsd:attribute name="count-type" use="required" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="country">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Country: in an Address</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="country-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="country" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="counts">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Counts</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="counts-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="custom-meta">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Custom Metadata</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="custom-meta-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="custom-meta-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Custom Metadata Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="custom-meta-group-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="data-title">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Data Title in a Citation</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="data-title-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="date">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Date</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="date-model"/>
+         <xsd:attribute name="calendar" use="optional" type="xsd:string"/>
+         <xsd:attribute name="date-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="iso-8601-date" use="optional" type="xsd:string"/>
+         <xsd:attribute name="publication-format" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="date-in-citation">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Date Inside Citation</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="date-in-citation-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="calendar" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="iso-8601-date" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="day">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Day</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="def">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Definition List: Definition</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="def-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="def-head">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Definition List: Definition Head</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="def-head-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="def-item">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Definition List: Definition Item</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="def-item-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="def-list">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Definition List</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="def-list-model"/>
+         <xsd:attribute name="continued-from" use="optional" type="xsd:IDREF"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="list-content" use="optional" type="xsd:string"/>
+         <xsd:attribute name="list-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="prefix-word" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="degrees">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Degree(s)</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="degrees-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="disp-formula">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Formula, Display</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:group ref="disp-formula-model" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="disp-formula-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Formula, Display Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="disp-formula-group-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="disp-quote">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Quote, Displayed</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="disp-quote-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="edition">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Edition Statement, Cited</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="edition-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="designator" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="element-citation">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Element Citation</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="citation-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="publication-format" use="optional" type="xsd:string"/>
+         <xsd:attribute name="publication-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="publisher-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="use-type" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="elocation-id">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Electronic Location Identifier</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="seq" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="email">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Email Address</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="email-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="equation-count">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Equation Count</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="count" use="required" type="xsd:NMTOKEN"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="era">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Era</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="etal">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Et Al</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:group ref="etal-model" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="event">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Event in Publishing History</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="event-model"/>
+         <xsd:attribute name="event-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="event-desc">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Event Description</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="event-desc-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="ext-link">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>External Link</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="ext-link-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="assigning-authority" use="optional" type="xsd:string"/>
+         <xsd:attribute name="ext-link-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="fax">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Fax Number: in an Address</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="fax-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="fig">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Figure</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="fig-model"/>
+         <xsd:attribute name="fig-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="orientation" use="optional" default="portrait">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="landscape"/>
+                  <xsd:enumeration value="portrait"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="position" use="optional" default="float">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="anchor"/>
+                  <xsd:enumeration value="background"/>
+                  <xsd:enumeration value="float"/>
+                  <xsd:enumeration value="margin"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="fig-count">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Figure Count</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="count" use="required" type="xsd:NMTOKEN"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="fig-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Figure Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="fig-group-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="orientation" use="optional" default="portrait">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="landscape"/>
+                  <xsd:enumeration value="portrait"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="position" use="optional" default="float">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="anchor"/>
+                  <xsd:enumeration value="background"/>
+                  <xsd:enumeration value="float"/>
+                  <xsd:enumeration value="margin"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="fixed-case">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Fixed Case</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="emphasized-text"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="floats-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Floats Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="floats-group-model" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="fn">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Footnote</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="fn-model"/>
+         <xsd:attribute name="fn-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="symbol" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="fn-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Footnote Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="fn-group-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="fpage">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>First Page</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="seq" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="front">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Front Matter</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="front-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="front-stub">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Stub Front Metadata</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="front-stub-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="funding-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Funding Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="funding-group-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="funding-source">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Funding Source</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="funding-source-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="country" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="source-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="funding-statement">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Funding Statement</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="funding-statement-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="given-names">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Given (First) Names</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="given-names-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="initials" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="glossary">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Glossary Elements</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="glossary-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="glyph-data">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Glyph Data For a Private Character</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="fontchar" use="optional" type="xsd:string">
+            <xsd:annotation/>
+         </xsd:attribute>
+         <xsd:attribute name="fontname" use="optional" type="xsd:string">
+            <xsd:annotation/>
+         </xsd:attribute>
+         <xsd:attribute name="format" use="optional" type="xsd:NMTOKEN">
+            <xsd:annotation/>
+         </xsd:attribute>
+         <xsd:attribute name="id" use="optional" type="xsd:ID">
+            <xsd:annotation/>
+         </xsd:attribute>
+         <xsd:attribute name="resolution" use="optional" type="xsd:string">
+            <xsd:annotation/>
+         </xsd:attribute>
+         <xsd:attribute name="x-size" use="optional" type="xsd:string">
+            <xsd:annotation/>
+         </xsd:attribute>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:space" fixed="preserve"/>
+         <xsd:attribute name="y-size" use="optional" type="xsd:string">
+            <xsd:annotation/>
+         </xsd:attribute>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="glyph-ref">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Glyph Reference For a Private Character</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="glyph-data" use="optional" type="xsd:IDREF">
+            <xsd:annotation/>
+         </xsd:attribute>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="gov">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Government Report, Cited</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="gov-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="graphic">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Graphic</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="graphic-model" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="mime-subtype" use="optional" type="xsd:string"/>
+         <xsd:attribute name="mimetype" use="optional" type="xsd:string"/>
+         <xsd:attribute name="orientation" use="optional" default="portrait">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="landscape"/>
+                  <xsd:enumeration value="portrait"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="position" use="optional" default="float">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="anchor"/>
+                  <xsd:enumeration value="background"/>
+                  <xsd:enumeration value="float"/>
+                  <xsd:enumeration value="margin"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="required"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="history">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>History: Document History</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:group ref="history-model" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="hr">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Horizontal Rule</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="index-term">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Index Term</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="index-term-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="index-type" use="optional" type="xsd:NMTOKENS"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="index-term-range-end">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Index Term Range End</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="required" type="xsd:IDREF"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="inline-formula">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Formula, Inline</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:group ref="inline-formula-model" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="inline-graphic">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Inline Graphic</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="inline-graphic-model"/>
+         <xsd:attribute name="baseline-shift" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="mime-subtype" use="optional" type="xsd:string"/>
+         <xsd:attribute name="mimetype" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="required"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="inline-media">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Inline Media Object</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="inline-media-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="mime-subtype" use="optional" type="xsd:string"/>
+         <xsd:attribute name="mimetype" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="required"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="inline-supplementary-material">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Inline Supplementary Material</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="inline-supplementary-material-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="mime-subtype" use="optional" type="xsd:string"/>
+         <xsd:attribute name="mimetype" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="institution">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Institution Name: in an Address</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="institution-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="institution-id">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Institution Identifier</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:group ref="institution-id-model" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="assigning-authority" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="institution-id-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="institution-wrap">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Institution Wrapper</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="institution-wrap-model" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="isbn">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Isbn</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="isbn-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="publication-format" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="issn">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Issn</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="issn-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="pub-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="publication-format" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="issn-l">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Issn Linking</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="issn-l-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="issue">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Issue Number</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="issue-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="seq" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="issue-id">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Issue Identifier</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="assigning-authority" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="pub-id-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="issue-part">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Issue Part</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="issue-part-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="issue-sponsor">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Issue Title</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="issue-sponsor-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="issue-title">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Issue Title</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="issue-title-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="italic">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Italic</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="emphasized-text"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="toggle" use="optional" default="yes">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="no"/>
+                  <xsd:enumeration value="yes"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="journal-id">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Journal Identifier</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="assigning-authority" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="journal-id-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="journal-meta">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Journal Metadata</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="journal-meta-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="journal-subtitle">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Journal Subtitle</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="journal-subtitle-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="journal-title">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Journal Title (Full)</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="journal-title-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="journal-title-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Journal Title Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="journal-title-group-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="kwd">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Keyword</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="kwd-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="vocab" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="kwd-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Keyword Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="kwd-group-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="kwd-group-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="label">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Label of a Figure, Reference, Etc.</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="label-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="alt" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="license">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>License Information</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="license-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="license-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="license-p">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>License Paragraph</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="license-p-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="list">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>List</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="list-model"/>
+         <xsd:attribute name="continued-from" use="optional" type="xsd:IDREF"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="list-content" use="optional" type="xsd:string"/>
+         <xsd:attribute name="list-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="prefix-word" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="list-item">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>List Item</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="list-item-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="long-desc">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Long Description</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="long-desc-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="lpage">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Last Page</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="media">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Media Object</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="media-model" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="mime-subtype" use="optional" type="xsd:string"/>
+         <xsd:attribute name="mimetype" use="optional" type="xsd:string"/>
+         <xsd:attribute name="orientation" use="optional" default="portrait">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="landscape"/>
+                  <xsd:enumeration value="portrait"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="position" use="optional" default="float">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="anchor"/>
+                  <xsd:enumeration value="background"/>
+                  <xsd:enumeration value="float"/>
+                  <xsd:enumeration value="margin"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="required"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="meta-name">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Metadata Data Name For Custom Metadata</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="meta-name-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="meta-value">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Metadata Data Value For Custom Metadata</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="meta-value-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="milestone-end">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Milestone End</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rationale" use="optional" type="xsd:string"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREF"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="milestone-start">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Milestone Start</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rationale" use="optional" type="xsd:string"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREF"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="mixed-citation">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Mixed Citation</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="citation-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="publication-format" use="optional" type="xsd:string"/>
+         <xsd:attribute name="publication-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="publisher-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="use-type" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="monospace">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Monospace Text (Typewriter Text)</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="emphasized-text"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="toggle" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="no"/>
+                  <xsd:enumeration value="yes"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="month">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Month</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="name">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Name of Person (Structured)</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:sequence>
+            <xsd:choice>
+               <xsd:sequence>
+                  <xsd:element ref="surname"/>
+                  <xsd:element ref="given-names" minOccurs="0"/>
+               </xsd:sequence>
+               <xsd:element ref="given-names"/>
+            </xsd:choice>
+            <xsd:element ref="prefix" minOccurs="0"/>
+            <xsd:element ref="suffix" minOccurs="0"/>
+         </xsd:sequence>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="name-style" use="optional" default="western">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="eastern"/>
+                  <xsd:enumeration value="given-only"/>
+                  <xsd:enumeration value="islensk"/>
+                  <xsd:enumeration value="western"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="name-alternatives">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Name Alternatives</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="name-alternatives-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="named-content">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Named Special (Subject) Content</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="named-content-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="alt" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="required" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="nested-kwd">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Nested Keyword</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="nested-kwd-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="vocab" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="nlm-citation">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Nlm Citation Model</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:sequence>
+            <xsd:choice minOccurs="0" maxOccurs="unbounded">
+               <xsd:element ref="person-group"/>
+               <xsd:element ref="collab"/>
+            </xsd:choice>
+            <xsd:choice minOccurs="0" maxOccurs="unbounded">
+               <xsd:element ref="article-title"/>
+               <xsd:element ref="trans-title"/>
+            </xsd:choice>
+            <xsd:element ref="source" minOccurs="0"/>
+            <xsd:element ref="patent" minOccurs="0"/>
+            <xsd:element ref="trans-source" minOccurs="0"/>
+            <xsd:element ref="year" minOccurs="0"/>
+            <xsd:choice>
+               <xsd:sequence>
+                  <xsd:element ref="month" minOccurs="0"/>
+                  <xsd:element ref="day" minOccurs="0"/>
+                  <xsd:element ref="time-stamp" minOccurs="0"/>
+               </xsd:sequence>
+               <xsd:element ref="season" minOccurs="0"/>
+            </xsd:choice>
+            <xsd:element ref="access-date" minOccurs="0"/>
+            <xsd:element ref="volume" minOccurs="0"/>
+            <xsd:element ref="edition" minOccurs="0"/>
+            <xsd:element ref="conf-name" minOccurs="0"/>
+            <xsd:element ref="conf-date" minOccurs="0"/>
+            <xsd:element ref="conf-loc" minOccurs="0"/>
+            <xsd:choice minOccurs="0" maxOccurs="unbounded">
+               <xsd:element ref="issue"/>
+               <xsd:element ref="supplement"/>
+            </xsd:choice>
+            <xsd:element ref="publisher-loc" minOccurs="0"/>
+            <xsd:element ref="publisher-name" minOccurs="0"/>
+            <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+               <xsd:element ref="fpage" minOccurs="0"/>
+               <xsd:element ref="lpage" minOccurs="0"/>
+            </xsd:sequence>
+            <xsd:element ref="page-count" minOccurs="0"/>
+            <xsd:element ref="series" minOccurs="0"/>
+            <xsd:element ref="comment" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element ref="pub-id" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element ref="annotation" minOccurs="0"/>
+         </xsd:sequence>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="publication-format" use="optional" type="xsd:string"/>
+         <xsd:attribute name="publication-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="publisher-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="note">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Note in a Reference List</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="note-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="notes">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Notes</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="notes-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="notes-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="object-id">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Object Identifier</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="assigning-authority" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="pub-id-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="on-behalf-of">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>On Behalf of</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="on-behalf-of-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="open-access">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Open Access</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="open-access-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="overline">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Overline</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="emphasized-text"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="toggle" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="no"/>
+                  <xsd:enumeration value="yes"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="overline-end">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Overline End</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="required" type="xsd:IDREF"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="overline-start">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Overline Start</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="id" use="required" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="p">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Paragraph</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="p-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="page-count">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Page Count</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="count" use="required" type="xsd:NMTOKEN"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="page-range">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Page Ranges</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="part-title">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Part Title in a Citation</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="part-title-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="patent">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Patent Number, Cited</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="patent-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="country" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="permissions">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Permissions</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="permissions-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="person-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Person Group For a Cited Publication</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:group ref="person-group-model" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="person-group-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="phone">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Phone Number: in an Address</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="phone-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="postal-code">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Postal Code: in an Address</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="postal-code-elements"/>
+         </xsd:sequence>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="prefix">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Prefix</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="prefix-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="preformat">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Preformatted Text</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:group ref="preformat-model" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="orientation" use="optional" default="portrait">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="landscape"/>
+                  <xsd:enumeration value="portrait"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="position" use="optional" default="float">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="anchor"/>
+                  <xsd:enumeration value="background"/>
+                  <xsd:enumeration value="float"/>
+                  <xsd:enumeration value="margin"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="preformat-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+         <xsd:attribute ref="xml:space" fixed="preserve"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="price">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Price</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="price-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="currency" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="principal-award-recipient">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Principal Award Recipient</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="principal-award-recipient-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="principal-investigator">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Principal Investigator Recipient</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="principal-investigator-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="private-char">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Private Character (Custom or Unicode)</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="private-char-model"/>
+         <xsd:attribute name="description" use="optional" type="xsd:string">
+            <xsd:annotation/>
+         </xsd:attribute>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="name" use="optional" type="xsd:string">
+            <xsd:annotation/>
+         </xsd:attribute>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="product">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Product Information</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="product-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="product-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="pub-date">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Publication Date</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="pub-date-model" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="calendar" use="optional" type="xsd:string"/>
+         <xsd:attribute name="date-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="iso-8601-date" use="optional" type="xsd:string"/>
+         <xsd:attribute name="pub-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="publication-format" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="pub-date-not-available">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Date Not Available Flag</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="pub-history">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Publication History</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="pub-history-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="pub-id">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Publication Identifier For a Cited Publication</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="assigning-authority" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="pub-id-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="publisher">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Publisher</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="publisher-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="publisher-loc">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Publisher's Location</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="publisher-loc-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="publisher-name">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Publisher's Name</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="publisher-name-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="rb">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Ruby Base</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="rb-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="ref">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Reference Item</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="ref-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="ref-count">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Reference Count</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="count" use="required" type="xsd:NMTOKEN"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="ref-list">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Reference List (Bibliographic Reference List)</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="ref-list-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="related-article">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Related Article Information</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="related-article-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="elocation-id" use="optional" type="xsd:string"/>
+         <xsd:attribute name="ext-link-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="issue" use="optional" type="xsd:string"/>
+         <xsd:attribute name="journal-id" use="optional" type="xsd:string"/>
+         <xsd:attribute name="journal-id-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="page" use="optional" type="xsd:string"/>
+         <xsd:attribute name="related-article-type" use="required" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vol" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="related-object">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Related Object Information</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="related-object-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="document-id" use="optional" type="xsd:string"/>
+         <xsd:attribute name="document-id-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="document-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="ext-link-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="link-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="object-id" use="optional" type="xsd:string"/>
+         <xsd:attribute name="object-id-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="object-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="source-id" use="optional" type="xsd:string"/>
+         <xsd:attribute name="source-id-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="source-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="resource-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Resource Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="resource-group-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="resource-id">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Resource Identifier</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="resource-id-elements"/>
+         </xsd:sequence>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="resource-id-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="resource-name">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Resource Name</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="resource-name-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="resource-wrap">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Resource Wrap</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="resource-wrap-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="response">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Response</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="article-short-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="response-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="role">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Role or Function Title of Contributor</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="role-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="degree-contribution" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="roman">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Roman</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="emphasized-text"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="toggle" use="optional" default="no">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="no"/>
+                  <xsd:enumeration value="yes"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="rp">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Ruby Parenthesis</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="rt">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Ruby Textual Annotation</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="rt-elements"/>
+         </xsd:sequence>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="ruby">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Ruby Wrapper</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="ruby-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="sans-serif">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Sans Serif</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="emphasized-text"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="toggle" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="no"/>
+                  <xsd:enumeration value="yes"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="sc">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Small Caps</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="emphasized-text"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="toggle" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="no"/>
+                  <xsd:enumeration value="yes"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="season">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Season</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="sec">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Section</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="sec-model"/>
+         <xsd:attribute name="disp-level" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="sec-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="sec-meta">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Section Metadata</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="sec-meta-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="see">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>See</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="see-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="see-also">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>See-Also Term</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="see-also-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="self-uri">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Uri For This Same Article Online</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="self-uri-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="series">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Series</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="series-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="series-text">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Series Text: Header Text to Describe</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="series-text-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="series-title">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Series Title</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="series-title-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="sig">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Signature</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="sig-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="sig-block">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Signature Block</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="sig-block-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="size">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Size</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="size-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="units" use="required" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="source">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Source</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="source-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="speaker">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Speaker</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="speaker-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="speech">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Speech</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="speech-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="state">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>State or Province: in an Address</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="state-elements"/>
+         </xsd:sequence>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="statement">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Statement, Formal</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="statement-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="std">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Standard, Cited</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="std-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="std-organization">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Standards Organization</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="std-organization-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="strike">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Strike Through</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="emphasized-text"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="toggle" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="no"/>
+                  <xsd:enumeration value="yes"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="string-conf">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>String Conference Name</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="string-conf-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="string-date">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Date As a String</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="string-date-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="calendar" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="iso-8601-date" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="string-name">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Name of Person (Unstructured)</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="string-name-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="name-style" use="optional" default="western">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="eastern"/>
+                  <xsd:enumeration value="given-only"/>
+                  <xsd:enumeration value="islensk"/>
+                  <xsd:enumeration value="western"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="styled-content">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Styled Special (Subject) Content</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="styled-content-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="alt" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="style" use="optional" type="xsd:string"/>
+         <xsd:attribute name="style-detail" use="optional" type="xsd:string"/>
+         <xsd:attribute name="style-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="toggle" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="no"/>
+                  <xsd:enumeration value="yes"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="sub">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Subscript</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="emphasized-text"/>
+         </xsd:choice>
+         <xsd:attribute name="arrange" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="stack"/>
+                  <xsd:enumeration value="stagger"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="sub-article">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Sub-Article</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="sub-article-model"/>
+         <xsd:attribute name="article-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="subj-group">
+      <xsd:annotation>
+         <xsd:documentation/>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="subj-group-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="subj-group-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="subject">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Subject Name</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="subject-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="vocab" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="subtitle">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Article Subtitle</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="subtitle-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="suffix">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Suffix</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="suffix-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="sup">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Superscript</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="emphasized-text"/>
+         </xsd:choice>
+         <xsd:attribute name="arrange" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="stack"/>
+                  <xsd:enumeration value="stagger"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="supplement">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Supplement</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="supplement-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="supplement-type" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="supplementary-material">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Supplementary Material</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="supplementary-material-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="mime-subtype" use="optional" type="xsd:string"/>
+         <xsd:attribute name="mimetype" use="optional" type="xsd:string"/>
+         <xsd:attribute name="orientation" use="optional" default="portrait">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="landscape"/>
+                  <xsd:enumeration value="portrait"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="position" use="optional" default="float">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="anchor"/>
+                  <xsd:enumeration value="background"/>
+                  <xsd:enumeration value="float"/>
+                  <xsd:enumeration value="margin"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="support-description">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Support Description</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:choice>
+            <xsd:group ref="support-description-model"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="support-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Support Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="support-group-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="support-source">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Support Source</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="support-source-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="country" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="support-type" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="surname">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Surname</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="surname-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="initials" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="table">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Table: Table Element ..............................</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="table.content"/>
+         <xsd:attribute name="border" use="optional" type="xsd:string"/>
+         <xsd:attribute name="cellpadding" use="optional" type="xsd:string"/>
+         <xsd:attribute name="cellspacing" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="frame" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="above"/>
+                  <xsd:enumeration value="below"/>
+                  <xsd:enumeration value="border"/>
+                  <xsd:enumeration value="box"/>
+                  <xsd:enumeration value="hsides"/>
+                  <xsd:enumeration value="lhs"/>
+                  <xsd:enumeration value="rhs"/>
+                  <xsd:enumeration value="void"/>
+                  <xsd:enumeration value="vsides"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rules" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="all"/>
+                  <xsd:enumeration value="cols"/>
+                  <xsd:enumeration value="groups"/>
+                  <xsd:enumeration value="none"/>
+                  <xsd:enumeration value="rows"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="style" use="optional" type="xsd:string"/>
+         <xsd:attribute name="summary" use="optional" type="xsd:string"/>
+         <xsd:attribute name="width" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="table-count">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Table Count</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="count" use="required" type="xsd:NMTOKEN"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="table-wrap">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Table Wrapper</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="table-wrap-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="orientation" use="optional" default="portrait">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="landscape"/>
+                  <xsd:enumeration value="portrait"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="position" use="optional" default="float">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="anchor"/>
+                  <xsd:enumeration value="background"/>
+                  <xsd:enumeration value="float"/>
+                  <xsd:enumeration value="margin"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="table-wrap-foot">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Table Wrap Footer</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="table-wrap-foot-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="table-wrap-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Table Wrapper Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="table-wrap-group-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="orientation" use="optional" default="portrait">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="landscape"/>
+                  <xsd:enumeration value="portrait"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="position" use="optional" default="float">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="anchor"/>
+                  <xsd:enumeration value="background"/>
+                  <xsd:enumeration value="float"/>
+                  <xsd:enumeration value="margin"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="target">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Target of an Internal Link</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="target-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="required" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="target-type" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="tbody">
+      <xsd:annotation>
+         <xsd:documentation/>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="tbody.content" maxOccurs="unbounded"/>
+         <xsd:attribute name="align" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="center"/>
+                  <xsd:enumeration value="char"/>
+                  <xsd:enumeration value="justify"/>
+                  <xsd:enumeration value="left"/>
+                  <xsd:enumeration value="right"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="char" use="optional" type="xsd:string"/>
+         <xsd:attribute name="charoff" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="style" use="optional" type="xsd:string"/>
+         <xsd:attribute name="valign" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="baseline"/>
+                  <xsd:enumeration value="bottom"/>
+                  <xsd:enumeration value="middle"/>
+                  <xsd:enumeration value="top"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="td">
+      <xsd:annotation>
+         <xsd:documentation/>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:group ref="td.content" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="abbr" use="optional" type="xsd:string"/>
+         <xsd:attribute name="align" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="center"/>
+                  <xsd:enumeration value="char"/>
+                  <xsd:enumeration value="justify"/>
+                  <xsd:enumeration value="left"/>
+                  <xsd:enumeration value="right"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="axis" use="optional" type="xsd:string"/>
+         <xsd:attribute name="char" use="optional" type="xsd:string"/>
+         <xsd:attribute name="charoff" use="optional" type="xsd:string"/>
+         <xsd:attribute name="colspan" use="optional" default="1" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="headers" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rowspan" use="optional" default="1" type="xsd:string"/>
+         <xsd:attribute name="scope" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="col"/>
+                  <xsd:enumeration value="colgroup"/>
+                  <xsd:enumeration value="row"/>
+                  <xsd:enumeration value="rowgroup"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="style" use="optional" type="xsd:string"/>
+         <xsd:attribute name="valign" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="baseline"/>
+                  <xsd:enumeration value="bottom"/>
+                  <xsd:enumeration value="middle"/>
+                  <xsd:enumeration value="top"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="term">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Definition List: Term</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="term-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="term-status" use="optional" type="xsd:string"/>
+         <xsd:attribute name="term-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-term-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="term-head">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Definition List: Term Head</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="term-head-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="tex-math">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Tex Math Equation</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="notation" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="LaTeX"/>
+                  <xsd:enumeration value="TEX"/>
+                  <xsd:enumeration value="TeX"/>
+                  <xsd:enumeration value="tex"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="version" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="textual-form">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Textual Form</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="textual-form-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="tfoot">
+      <xsd:annotation>
+         <xsd:documentation/>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="tfoot.content" maxOccurs="unbounded"/>
+         <xsd:attribute name="align" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="center"/>
+                  <xsd:enumeration value="char"/>
+                  <xsd:enumeration value="justify"/>
+                  <xsd:enumeration value="left"/>
+                  <xsd:enumeration value="right"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="char" use="optional" type="xsd:string"/>
+         <xsd:attribute name="charoff" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="style" use="optional" type="xsd:string"/>
+         <xsd:attribute name="valign" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="baseline"/>
+                  <xsd:enumeration value="bottom"/>
+                  <xsd:enumeration value="middle"/>
+                  <xsd:enumeration value="top"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="th">
+      <xsd:annotation>
+         <xsd:documentation/>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:group ref="th.content" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="abbr" use="optional" type="xsd:string"/>
+         <xsd:attribute name="align" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="center"/>
+                  <xsd:enumeration value="char"/>
+                  <xsd:enumeration value="justify"/>
+                  <xsd:enumeration value="left"/>
+                  <xsd:enumeration value="right"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="axis" use="optional" type="xsd:string"/>
+         <xsd:attribute name="char" use="optional" type="xsd:string"/>
+         <xsd:attribute name="charoff" use="optional" type="xsd:string"/>
+         <xsd:attribute name="colspan" use="optional" default="1" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="headers" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rowspan" use="optional" default="1" type="xsd:string"/>
+         <xsd:attribute name="scope" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="col"/>
+                  <xsd:enumeration value="colgroup"/>
+                  <xsd:enumeration value="row"/>
+                  <xsd:enumeration value="rowgroup"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="style" use="optional" type="xsd:string"/>
+         <xsd:attribute name="valign" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="baseline"/>
+                  <xsd:enumeration value="bottom"/>
+                  <xsd:enumeration value="middle"/>
+                  <xsd:enumeration value="top"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="thead">
+      <xsd:annotation>
+         <xsd:documentation/>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="thead.content" maxOccurs="unbounded"/>
+         <xsd:attribute name="align" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="center"/>
+                  <xsd:enumeration value="char"/>
+                  <xsd:enumeration value="justify"/>
+                  <xsd:enumeration value="left"/>
+                  <xsd:enumeration value="right"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="char" use="optional" type="xsd:string"/>
+         <xsd:attribute name="charoff" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="style" use="optional" type="xsd:string"/>
+         <xsd:attribute name="valign" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="baseline"/>
+                  <xsd:enumeration value="bottom"/>
+                  <xsd:enumeration value="middle"/>
+                  <xsd:enumeration value="top"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="time-stamp">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Time Stamp For Cited Work</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="time-stamp-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="title">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Title</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="struct-title-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="title-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Title Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="title-group-model"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="tr">
+      <xsd:annotation>
+         <xsd:documentation/>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="tr.content" maxOccurs="unbounded"/>
+         <xsd:attribute name="align" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="center"/>
+                  <xsd:enumeration value="char"/>
+                  <xsd:enumeration value="justify"/>
+                  <xsd:enumeration value="left"/>
+                  <xsd:enumeration value="right"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="char" use="optional" type="xsd:string"/>
+         <xsd:attribute name="charoff" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="style" use="optional" type="xsd:string"/>
+         <xsd:attribute name="valign" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="baseline"/>
+                  <xsd:enumeration value="bottom"/>
+                  <xsd:enumeration value="middle"/>
+                  <xsd:enumeration value="top"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="trans-abstract">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Translated Abstract</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="trans-abstract-model"/>
+         <xsd:attribute name="abstract-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="trans-source">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Translated Source</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="source-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="trans-subtitle">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Translated Subtitle</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="trans-subtitle-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="trans-title">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Translated Title</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="trans-title-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="trans-title-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Translated Title Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="trans-title-group-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="underline">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Underline</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="emphasized-text"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="toggle" use="optional">
+            <xsd:simpleType>
+               <xsd:annotation>
+                  <xsd:documentation/>
+               </xsd:annotation>
+               <xsd:restriction base="xsd:NMTOKEN">
+                  <xsd:enumeration value="no"/>
+                  <xsd:enumeration value="yes"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:attribute>
+         <xsd:attribute name="underline-style" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="underline-end">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Underline End</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="rid" use="required" type="xsd:IDREF"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="underline-start">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Underline Start</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="id" use="required" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="unstructured-kwd-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Unstructured Keyword Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="unstructured-kwd-group-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="kwd-group-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab" use="optional" type="xsd:string"/>
+         <xsd:attribute name="vocab-identifier" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="uri">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Uri</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="uri-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="verse-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Verse Form For Poetry</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="verse-group-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="style" use="optional" type="xsd:string"/>
+         <xsd:attribute name="style-detail" use="optional" type="xsd:string"/>
+         <xsd:attribute name="style-type" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="verse-line">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Line of a Verse</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="verse-line-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="indent-level" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="style" use="optional" type="xsd:string"/>
+         <xsd:attribute name="style-detail" use="optional" type="xsd:string"/>
+         <xsd:attribute name="style-type" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="version">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Version Statement, Cited</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="version-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="designator" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="volume">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Volume Number</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="volume-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="seq" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="volume-id">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Volume Identifier</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="volume-id-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="assigning-authority" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="pub-id-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xlink:actuate" use="optional"/>
+         <xsd:attribute ref="xlink:href" use="optional"/>
+         <xsd:attribute ref="xlink:role" use="optional"/>
+         <xsd:attribute ref="xlink:show" use="optional"/>
+         <xsd:attribute ref="xlink:title" use="optional"/>
+         <xsd:attribute ref="xlink:type" use="optional" fixed="simple"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="volume-issue-group">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Translated Title Group</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:group ref="volume-issue-group-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="volume-series">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Volume Series</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="volume-series-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="word-count">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Word Count</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="count" use="required" type="xsd:NMTOKEN"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="x">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>X - Generated Text and Punctuation</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="x-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+         <xsd:attribute ref="xml:space" fixed="preserve"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="xref">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>X(cross) Reference</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="xref-elements"/>
+         </xsd:choice>
+         <xsd:attribute name="alt" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="ref-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="rid" use="optional" type="xsd:IDREFS"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="year">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Year</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:choice minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:attribute name="calendar" use="optional" type="xsd:string"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="iso-8601-date" use="optional" type="xsd:string"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+         <xsd:attribute ref="xml:lang" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:notation name="cgmchar" public="ISO 8632/2//NOTATION Character encoding//EN"/>
+   <xsd:notation name="cgmclear" public="ISO 8632/4//NOTATION Clear text encoding//EN"/>
+   <xsd:notation name="eps"
+                 public="+//ISBN 0-201-18127-4::Adobe//NOTATION PostScript Language Reference Manual//EN"/>
+   <xsd:notation name="gif"
+                 public="-//ISBN 0-7923-9432-1::Graphic Notation//NOTATION CompuServe Graphic Interchange Format//EN"/>
+   <xsd:notation name="jpeg"
+                 public="+//ISBN 0-7923-9432-1::Graphic Notation//NOTATION Joint Photographic Experts Group raster//EN"/>
+   <xsd:notation name="LaTeX"
+                 public="+//ISBN 3-893-196463::Goosens//NOTATION Der LaTeX Begleiter//DE"/>
+   <xsd:notation name="TEX"
+                 public="+//ISBN 0-201-13448-9::Knuth//NOTATION The TeXbook//EN"/>
+   <xsd:notation name="TeX"
+                 public="+//ISBN 0-201-13448-9::Knuth//NOTATION The TeXbook//EN"/>
+   <xsd:notation name="tex"
+                 public="+//ISBN 0-201-13448-9::Knuth//NOTATION The TeXbook//EN"/>
+   <xsd:notation name="tiff"
+                 public="+//ISBN 0-7923-9432-1::Graphic Notation//NOTATION Aldus/Microsoft Tagged Interchange File Format//EN"/>
+   <xsd:annotation/>
+   <xsd:group name="abbrev-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="def.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="all-phrase">
+      <xsd:choice>
+         <xsd:group ref="address-link.class"/>
+         <xsd:group ref="article-link.class"/>
+         <xsd:group ref="appearance.class"/>
+         <xsd:group ref="emphasis.class"/>
+         <xsd:group ref="inline-display.class"/>
+         <xsd:group ref="inline-math.class"/>
+         <xsd:group ref="math.class"/>
+         <xsd:group ref="phrase.class"/>
+         <xsd:group ref="simple-link.class"/>
+         <xsd:group ref="subsup.class"/>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="address-link.class">
+      <xsd:choice>
+         <xsd:element ref="email"/>
+         <xsd:element ref="ext-link"/>
+         <xsd:element ref="uri"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="article-link.class">
+      <xsd:choice>
+         <xsd:element ref="inline-supplementary-material"/>
+         <xsd:element ref="related-article"/>
+         <xsd:element ref="related-object"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="appearance.class">
+      <xsd:choice>
+         <xsd:element ref="hr"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="emphasis.class">
+      <xsd:choice>
+         <xsd:element ref="bold"/>
+         <xsd:element ref="fixed-case"/>
+         <xsd:element ref="italic"/>
+         <xsd:element ref="monospace"/>
+         <xsd:element ref="overline"/>
+         <xsd:element ref="overline-start"/>
+         <xsd:element ref="overline-end"/>
+         <xsd:element ref="roman"/>
+         <xsd:element ref="sans-serif"/>
+         <xsd:element ref="sc"/>
+         <xsd:element ref="strike"/>
+         <xsd:element ref="underline"/>
+         <xsd:element ref="underline-start"/>
+         <xsd:element ref="underline-end"/>
+         <xsd:element ref="ruby"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="inline-display.class">
+      <xsd:choice>
+         <xsd:element ref="alternatives"/>
+         <xsd:element ref="inline-graphic"/>
+         <xsd:element ref="inline-media"/>
+         <xsd:element ref="private-char"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="inline-math.class">
+      <xsd:choice>
+         <xsd:element ref="chem-struct"/>
+         <xsd:element ref="inline-formula"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="math.class">
+      <xsd:choice>
+         <xsd:element ref="tex-math"/>
+         <xsd:element ref="mml:math"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="phrase.class">
+      <xsd:choice>
+         <xsd:element ref="abbrev"/>
+         <xsd:element ref="index-term"/>
+         <xsd:element ref="index-term-range-end"/>
+         <xsd:element ref="milestone-end"/>
+         <xsd:element ref="milestone-start"/>
+         <xsd:element ref="named-content"/>
+         <xsd:element ref="styled-content"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="simple-link.class">
+      <xsd:choice>
+         <xsd:element ref="fn"/>
+         <xsd:element ref="target"/>
+         <xsd:element ref="xref"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="subsup.class">
+      <xsd:choice>
+         <xsd:element ref="sub"/>
+         <xsd:element ref="sup"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="x.class">
+      <xsd:choice>
+         <xsd:element ref="x"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="def.class">
+      <xsd:choice>
+         <xsd:element ref="def"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="abbrev-journal-title-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="just-rendition">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="abstract-model">
+      <xsd:sequence>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="id.class"/>
+         </xsd:choice>
+         <xsd:group ref="sec-opt-title-model"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="id.class">
+      <xsd:choice>
+         <xsd:element ref="object-id"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="sec-opt-title-model">
+      <xsd:sequence>
+         <xsd:element ref="sec-meta" minOccurs="0"/>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:element ref="title" minOccurs="0"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="para-level"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="sec-level"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="sec-back-matter-mix"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="para-level">
+      <xsd:choice>
+         <xsd:group ref="block-display.class"/>
+         <xsd:group ref="block-math.class"/>
+         <xsd:group ref="list.class"/>
+         <xsd:group ref="math.class"/>
+         <xsd:group ref="nothing-but-para.class"/>
+         <xsd:group ref="related-article.class"/>
+         <xsd:group ref="rest-of-para.class"/>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="block-display.class">
+      <xsd:choice>
+         <xsd:element ref="address"/>
+         <xsd:element ref="alternatives"/>
+         <xsd:element ref="array"/>
+         <xsd:element ref="boxed-text"/>
+         <xsd:element ref="chem-struct-wrap"/>
+         <xsd:element ref="code"/>
+         <xsd:element ref="fig"/>
+         <xsd:element ref="fig-group"/>
+         <xsd:element ref="graphic"/>
+         <xsd:element ref="media"/>
+         <xsd:element ref="preformat"/>
+         <xsd:element ref="supplementary-material"/>
+         <xsd:element ref="table-wrap"/>
+         <xsd:element ref="table-wrap-group"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="block-math.class">
+      <xsd:choice>
+         <xsd:element ref="disp-formula"/>
+         <xsd:element ref="disp-formula-group"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="list.class">
+      <xsd:choice>
+         <xsd:element ref="def-list"/>
+         <xsd:element ref="list"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="nothing-but-para.class">
+      <xsd:choice>
+         <xsd:element ref="p"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="related-article.class">
+      <xsd:choice>
+         <xsd:element ref="related-article"/>
+         <xsd:element ref="related-object"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="rest-of-para.class">
+      <xsd:choice>
+         <xsd:element ref="ack"/>
+         <xsd:element ref="disp-quote"/>
+         <xsd:element ref="speech"/>
+         <xsd:element ref="statement"/>
+         <xsd:element ref="verse-group"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="sec-level">
+      <xsd:choice>
+         <xsd:group ref="sec.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="sec.class">
+      <xsd:choice>
+         <xsd:element ref="sec"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="sec-back-matter-mix">
+      <xsd:choice>
+         <xsd:group ref="front-back.class"/>
+         <xsd:group ref="sec-back.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="front-back.class">
+      <xsd:choice>
+         <xsd:element ref="notes"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="sec-back.class">
+      <xsd:choice>
+         <xsd:element ref="fn-group"/>
+         <xsd:element ref="glossary"/>
+         <xsd:element ref="ref-list"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="access-date-elements">
+      <xsd:choice>
+         <xsd:group ref="date-parts.class"/>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="date-parts.class">
+      <xsd:choice>
+         <xsd:element ref="day"/>
+         <xsd:element ref="era"/>
+         <xsd:element ref="month"/>
+         <xsd:element ref="season"/>
+         <xsd:element ref="year"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="ack-model">
+      <xsd:sequence>
+         <xsd:group ref="sec-opt-title-model"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="addr-line-elements">
+      <xsd:choice>
+         <xsd:group ref="simple-text"/>
+         <xsd:group ref="address-line.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="simple-text">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="address-line.class">
+      <xsd:choice>
+         <xsd:element ref="city"/>
+         <xsd:element ref="country"/>
+         <xsd:element ref="fax"/>
+         <xsd:element ref="institution"/>
+         <xsd:element ref="institution-wrap"/>
+         <xsd:element ref="phone"/>
+         <xsd:element ref="postal-code"/>
+         <xsd:element ref="state"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="address-model">
+      <xsd:choice>
+         <xsd:group ref="address.class"/>
+         <xsd:group ref="address-link.class"/>
+         <xsd:group ref="label.class"/>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="address.class">
+      <xsd:choice>
+         <xsd:element ref="addr-line"/>
+         <xsd:element ref="city"/>
+         <xsd:element ref="country"/>
+         <xsd:element ref="fax"/>
+         <xsd:element ref="institution"/>
+         <xsd:element ref="institution-wrap"/>
+         <xsd:element ref="phone"/>
+         <xsd:element ref="postal-code"/>
+         <xsd:element ref="state"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="label.class">
+      <xsd:choice>
+         <xsd:element ref="label"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="aff-elements">
+      <xsd:choice>
+         <xsd:group ref="address.class"/>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="break.class"/>
+         <xsd:group ref="label.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="break.class">
+      <xsd:choice>
+         <xsd:element ref="break"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="aff-alternatives-model">
+      <xsd:choice>
+         <xsd:element ref="aff" maxOccurs="unbounded"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="license-ref-model">
+      <xsd:choice>
+         <xsd:group ref="anyURI" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="anyURI">
+      <xsd:choice/>
+   </xsd:group>
+   <xsd:group name="alt-title-elements">
+      <xsd:choice>
+         <xsd:group ref="title-elements"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="title-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="break.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="alternatives-model">
+      <xsd:choice>
+         <xsd:group ref="alternatives-display.class"/>
+         <xsd:group ref="math.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="alternatives-display.class">
+      <xsd:choice>
+         <xsd:element ref="array"/>
+         <xsd:element ref="chem-struct"/>
+         <xsd:element ref="code"/>
+         <xsd:element ref="graphic"/>
+         <xsd:element ref="inline-graphic"/>
+         <xsd:element ref="inline-media"/>
+         <xsd:element ref="inline-supplementary-material"/>
+         <xsd:element ref="media"/>
+         <xsd:element ref="preformat"/>
+         <xsd:element ref="private-char"/>
+         <xsd:element ref="supplementary-material"/>
+         <xsd:element ref="table"/>
+         <xsd:element ref="textual-form"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="annotation-model">
+      <xsd:choice>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="just-para.class"/>
+         </xsd:choice>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="just-para.class">
+      <xsd:choice>
+         <xsd:element ref="p"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="anonymous-model">
+      <xsd:choice>
+         <xsd:group ref="anonymous-elements"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="anonymous-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="app-model">
+      <xsd:sequence>
+         <xsd:group ref="sec-opt-title-model"/>
+         <xsd:element ref="permissions" minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="app-group-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:element ref="title" minOccurs="0"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="abstract.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="kwd-group.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="para-level"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="app.class"/>
+            <xsd:group ref="ref-list.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="abstract.class">
+      <xsd:choice>
+         <xsd:element ref="abstract"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="kwd-group.class">
+      <xsd:choice>
+         <xsd:element ref="kwd-group"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="app.class">
+      <xsd:choice>
+         <xsd:element ref="app"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="ref-list.class">
+      <xsd:choice>
+         <xsd:element ref="ref-list"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="array-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="access.class"/>
+            <xsd:group ref="address-link.class"/>
+         </xsd:choice>
+         <xsd:choice>
+            <xsd:choice minOccurs="0" maxOccurs="unbounded">
+               <xsd:group ref="just-base-display.class"/>
+            </xsd:choice>
+            <xsd:group ref="tbody.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="display-back-matter.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="access.class">
+      <xsd:choice>
+         <xsd:element ref="alt-text"/>
+         <xsd:element ref="long-desc"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="just-base-display.class">
+      <xsd:choice>
+         <xsd:element ref="alternatives"/>
+         <xsd:element ref="graphic"/>
+         <xsd:element ref="media"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="tbody.class">
+      <xsd:choice>
+         <xsd:element ref="tbody"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="display-back-matter.class">
+      <xsd:choice>
+         <xsd:element ref="attrib"/>
+         <xsd:element ref="permissions"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="article-full-model">
+      <xsd:sequence>
+         <xsd:element ref="front"/>
+         <xsd:element ref="body" minOccurs="0"/>
+         <xsd:element ref="back" minOccurs="0"/>
+         <xsd:element ref="floats-group" minOccurs="0"/>
+         <xsd:choice>
+            <xsd:element ref="sub-article" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element ref="response" minOccurs="0" maxOccurs="unbounded"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="article-categories-model">
+      <xsd:sequence>
+         <xsd:element ref="subj-group" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="series-title" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="series-text" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="article-meta-model">
+      <xsd:sequence>
+         <xsd:element ref="article-id" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:choice minOccurs="0">
+            <xsd:group ref="article-version.class"/>
+         </xsd:choice>
+         <xsd:element ref="article-categories" minOccurs="0"/>
+         <xsd:element ref="title-group" minOccurs="0"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="contrib-group.class"/>
+            <xsd:group ref="aff-alternatives.class"/>
+            <xsd:group ref="x.class"/>
+         </xsd:choice>
+         <xsd:element ref="author-notes" minOccurs="0"/>
+         <xsd:choice>
+            <xsd:choice minOccurs="0" maxOccurs="unbounded">
+               <xsd:group ref="pub-date.class"/>
+            </xsd:choice>
+            <xsd:element ref="pub-date-not-available" minOccurs="0"/>
+         </xsd:choice>
+         <xsd:element ref="volume" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="volume-id" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="volume-series" minOccurs="0"/>
+         <xsd:element ref="issue" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="issue-id" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="issue-title" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="issue-sponsor" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="issue-part" minOccurs="0"/>
+         <xsd:element ref="volume-issue-group" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="isbn" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="supplement" minOccurs="0"/>
+         <xsd:choice minOccurs="0">
+            <xsd:sequence>
+               <xsd:sequence minOccurs="0">
+                  <xsd:element ref="fpage"/>
+                  <xsd:element ref="lpage" minOccurs="0"/>
+               </xsd:sequence>
+               <xsd:element ref="page-range" minOccurs="0"/>
+            </xsd:sequence>
+            <xsd:element ref="elocation-id"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="address-link.class"/>
+            <xsd:element ref="product"/>
+            <xsd:element ref="supplementary-material"/>
+         </xsd:choice>
+         <xsd:element ref="history" minOccurs="0"/>
+         <xsd:element ref="pub-history" minOccurs="0"/>
+         <xsd:element ref="permissions" minOccurs="0"/>
+         <xsd:element ref="self-uri" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="related-article.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="abstract.class"/>
+         </xsd:choice>
+         <xsd:element ref="trans-abstract" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="kwd-group.class"/>
+         </xsd:choice>
+         <xsd:element ref="funding-group" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="support-group" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="conference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="counts" minOccurs="0"/>
+         <xsd:element ref="custom-meta-group" minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="article-version.class">
+      <xsd:choice>
+         <xsd:element ref="article-version"/>
+         <xsd:element ref="article-version-alternatives"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="contrib-group.class">
+      <xsd:choice>
+         <xsd:element ref="contrib-group"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="aff-alternatives.class">
+      <xsd:choice>
+         <xsd:element ref="aff"/>
+         <xsd:element ref="aff-alternatives"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="pub-date.class">
+      <xsd:choice>
+         <xsd:element ref="pub-date"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="article-title-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="break.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="attrib-elements">
+      <xsd:choice>
+         <xsd:group ref="emphasized-text"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="emphasized-text">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="break.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="author-comment-model">
+      <xsd:sequence>
+         <xsd:element ref="title" minOccurs="0"/>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="just-para.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="author-notes-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:element ref="title" minOccurs="0"/>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="corresp.class"/>
+            <xsd:group ref="fn-link.class"/>
+            <xsd:group ref="just-para.class"/>
+            <xsd:group ref="x.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="corresp.class">
+      <xsd:choice>
+         <xsd:element ref="corresp"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="fn-link.class">
+      <xsd:choice>
+         <xsd:element ref="fn"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="award-group-model">
+      <xsd:sequence>
+         <xsd:choice>
+            <xsd:element ref="funding-source" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element ref="support-source" minOccurs="0" maxOccurs="unbounded"/>
+         </xsd:choice>
+         <xsd:element ref="award-id" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="principal-award-recipient" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="principal-investigator" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="award-id-elements">
+      <xsd:choice>
+         <xsd:group ref="simple-text"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="back-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:element ref="title" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="doc-back-matter-mix"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="doc-back-matter-mix">
+      <xsd:choice>
+         <xsd:group ref="back.class"/>
+         <xsd:group ref="front-back.class"/>
+         <xsd:group ref="sec.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="back.class">
+      <xsd:choice>
+         <xsd:element ref="ack"/>
+         <xsd:element ref="app-group"/>
+         <xsd:element ref="bio"/>
+         <xsd:element ref="fn-group"/>
+         <xsd:element ref="glossary"/>
+         <xsd:element ref="ref-list"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="bio-model">
+      <xsd:sequence>
+         <xsd:group ref="sec-opt-title-model"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="body-model">
+      <xsd:sequence>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="para-level"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="sec-level"/>
+         </xsd:choice>
+         <xsd:element ref="sig-block" minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="boxed-text-model">
+      <xsd:sequence>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="id.class"/>
+         </xsd:choice>
+         <xsd:element ref="sec-meta" minOccurs="0"/>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:element ref="caption" minOccurs="0"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="para-level"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="sec-level"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="sec-back-matter-mix"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="display-back-matter.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="caption-model">
+      <xsd:sequence>
+         <xsd:element ref="title" minOccurs="0"/>
+         <xsd:group ref="caption-body-parts" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="caption-body-parts">
+      <xsd:choice>
+         <xsd:group ref="just-para.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="chapter-title-elements">
+      <xsd:choice>
+         <xsd:group ref="source-elements"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="source-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="break.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="chem-struct-model">
+      <xsd:choice>
+         <xsd:group ref="chem-struct-elements"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="chem-struct-elements">
+      <xsd:choice>
+         <xsd:group ref="access.class"/>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="break.class"/>
+         <xsd:group ref="id.class"/>
+         <xsd:group ref="label.class"/>
+         <xsd:group ref="list.class"/>
+         <xsd:group ref="simple-display-noalt.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="simple-display-noalt.class">
+      <xsd:choice>
+         <xsd:element ref="array"/>
+         <xsd:element ref="code"/>
+         <xsd:element ref="graphic"/>
+         <xsd:element ref="media"/>
+         <xsd:element ref="preformat"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="chem-struct-wrap-model">
+      <xsd:sequence>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="id.class"/>
+         </xsd:choice>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:choice minOccurs="0">
+            <xsd:group ref="caption.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="abstract.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="kwd-group.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="access.class"/>
+            <xsd:group ref="address-link.class"/>
+         </xsd:choice>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="inside-chem-struct-wrap.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="display-back-matter.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="caption.class">
+      <xsd:choice>
+         <xsd:element ref="caption"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="inside-chem-struct-wrap.class">
+      <xsd:choice>
+         <xsd:element ref="alternatives"/>
+         <xsd:element ref="chem-struct"/>
+         <xsd:element ref="code"/>
+         <xsd:element ref="graphic"/>
+         <xsd:element ref="media"/>
+         <xsd:element ref="preformat"/>
+         <xsd:element ref="textual-form"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="citation-alternatives-model">
+      <xsd:choice>
+         <xsd:group ref="citation-minus-alt.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="citation-minus-alt.class">
+      <xsd:choice>
+         <xsd:element ref="element-citation"/>
+         <xsd:element ref="mixed-citation"/>
+         <xsd:element ref="nlm-citation"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="city-elements">
+      <xsd:choice/>
+   </xsd:group>
+   <xsd:group name="code-elements">
+      <xsd:choice>
+         <xsd:group ref="address-link.class"/>
+         <xsd:group ref="emphasis.class"/>
+         <xsd:group ref="inline-display-noalt.class"/>
+         <xsd:group ref="phrase.class"/>
+         <xsd:group ref="simple-link.class"/>
+         <xsd:group ref="subsup.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="inline-display-noalt.class">
+      <xsd:choice>
+         <xsd:element ref="inline-graphic"/>
+         <xsd:element ref="inline-media"/>
+         <xsd:element ref="private-char"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="colgroup.content">
+      <xsd:choice>
+         <xsd:element ref="col"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="collab-elements">
+      <xsd:choice>
+         <xsd:group ref="article-link.class"/>
+         <xsd:group ref="address.class"/>
+         <xsd:group ref="appearance.class"/>
+         <xsd:group ref="break.class"/>
+         <xsd:group ref="contrib-group.class"/>
+         <xsd:group ref="contrib-info.class"/>
+         <xsd:group ref="emphasis.class"/>
+         <xsd:group ref="inline-display.class"/>
+         <xsd:group ref="inline-math.class"/>
+         <xsd:group ref="math.class"/>
+         <xsd:group ref="phrase.class"/>
+         <xsd:group ref="subsup.class"/>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="contrib-info.class">
+      <xsd:choice>
+         <xsd:element ref="address"/>
+         <xsd:element ref="aff"/>
+         <xsd:element ref="aff-alternatives"/>
+         <xsd:element ref="author-comment"/>
+         <xsd:element ref="bio"/>
+         <xsd:element ref="email"/>
+         <xsd:element ref="etal"/>
+         <xsd:element ref="ext-link"/>
+         <xsd:element ref="fn"/>
+         <xsd:element ref="on-behalf-of"/>
+         <xsd:element ref="role"/>
+         <xsd:element ref="uri"/>
+         <xsd:element ref="xref"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="collab-alternatives-model">
+      <xsd:choice>
+         <xsd:group ref="collab.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="collab.class">
+      <xsd:choice>
+         <xsd:element ref="collab"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="comment-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="compound-kwd-model">
+      <xsd:choice>
+         <xsd:element ref="compound-kwd-part" maxOccurs="unbounded"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="compound-kwd-part-elements">
+      <xsd:choice>
+         <xsd:group ref="break.class"/>
+         <xsd:group ref="all-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="compound-subject-model">
+      <xsd:choice>
+         <xsd:element ref="compound-subject-part" maxOccurs="unbounded"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="compound-subject-part-elements">
+      <xsd:choice>
+         <xsd:group ref="emphasis.class"/>
+         <xsd:group ref="inline-display.class"/>
+         <xsd:group ref="inline-math.class"/>
+         <xsd:group ref="phrase-content.class"/>
+         <xsd:group ref="subsup.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="phrase-content.class">
+      <xsd:choice>
+         <xsd:element ref="named-content"/>
+         <xsd:element ref="styled-content"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="conf-acronym-elements">
+      <xsd:choice>
+         <xsd:group ref="simple-text"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="conf-date-elements">
+      <xsd:choice>
+         <xsd:group ref="date-parts.class"/>
+         <xsd:group ref="face-markup.class"/>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="face-markup.class">
+      <xsd:choice>
+         <xsd:element ref="bold"/>
+         <xsd:element ref="fixed-case"/>
+         <xsd:element ref="italic"/>
+         <xsd:element ref="monospace"/>
+         <xsd:element ref="overline"/>
+         <xsd:element ref="overline-start"/>
+         <xsd:element ref="overline-end"/>
+         <xsd:element ref="roman"/>
+         <xsd:element ref="sans-serif"/>
+         <xsd:element ref="sc"/>
+         <xsd:element ref="strike"/>
+         <xsd:element ref="underline"/>
+         <xsd:element ref="underline-start"/>
+         <xsd:element ref="underline-end"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="conf-loc-elements">
+      <xsd:choice>
+         <xsd:group ref="simple-text"/>
+         <xsd:group ref="address.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="conf-name-elements">
+      <xsd:choice>
+         <xsd:group ref="simple-text"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="conf-num-elements">
+      <xsd:choice>
+         <xsd:group ref="simple-text"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="conf-sponsor-elements">
+      <xsd:choice>
+         <xsd:group ref="simple-text"/>
+         <xsd:group ref="institution-wrap.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="institution-wrap.class">
+      <xsd:choice>
+         <xsd:element ref="institution"/>
+         <xsd:element ref="institution-wrap"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="conf-theme-elements">
+      <xsd:choice>
+         <xsd:group ref="simple-text"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="conference-model">
+      <xsd:choice>
+         <xsd:group ref="conference.class"/>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="conference.class">
+      <xsd:choice>
+         <xsd:element ref="conf-date"/>
+         <xsd:element ref="conf-name"/>
+         <xsd:element ref="conf-num"/>
+         <xsd:element ref="conf-loc"/>
+         <xsd:element ref="conf-sponsor"/>
+         <xsd:element ref="conf-theme"/>
+         <xsd:element ref="conf-acronym"/>
+         <xsd:element ref="string-conf"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="contrib-model">
+      <xsd:choice>
+         <xsd:group ref="contrib-id.class"/>
+         <xsd:group ref="name.class"/>
+         <xsd:group ref="degree.class"/>
+         <xsd:group ref="contrib-info.class"/>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="contrib-id.class">
+      <xsd:choice>
+         <xsd:element ref="contrib-id"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="name.class">
+      <xsd:choice>
+         <xsd:element ref="anonymous"/>
+         <xsd:element ref="collab"/>
+         <xsd:element ref="collab-alternatives"/>
+         <xsd:element ref="name"/>
+         <xsd:element ref="name-alternatives"/>
+         <xsd:element ref="string-name"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="degree.class">
+      <xsd:choice>
+         <xsd:element ref="degrees"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="contrib-group-model">
+      <xsd:choice>
+         <xsd:group ref="contrib.class"/>
+         <xsd:group ref="contrib-info.class"/>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="contrib.class">
+      <xsd:choice>
+         <xsd:element ref="contrib"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="contrib-id-model">
+      <xsd:choice/>
+   </xsd:group>
+   <xsd:group name="contributed-resource-group-model">
+      <xsd:sequence>
+         <xsd:element ref="award-group" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="support-description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="resource-group" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="copyright-holder-elements">
+      <xsd:choice>
+         <xsd:group ref="institution-wrap.class"/>
+         <xsd:group ref="subsup.class"/>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="copyright-statement-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="corresp-elements">
+      <xsd:choice>
+         <xsd:group ref="address.class"/>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="break.class"/>
+         <xsd:group ref="label.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="country-elements">
+      <xsd:choice>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="counts-model">
+      <xsd:sequence>
+         <xsd:element ref="count" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="fig-count" minOccurs="0"/>
+         <xsd:element ref="table-count" minOccurs="0"/>
+         <xsd:element ref="equation-count" minOccurs="0"/>
+         <xsd:element ref="ref-count" minOccurs="0"/>
+         <xsd:element ref="page-count" minOccurs="0"/>
+         <xsd:element ref="word-count" minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="custom-meta-model">
+      <xsd:sequence>
+         <xsd:element ref="meta-name"/>
+         <xsd:element ref="meta-value"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="custom-meta-group-model">
+      <xsd:choice>
+         <xsd:element ref="custom-meta" maxOccurs="unbounded"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="data-title-elements">
+      <xsd:choice>
+         <xsd:group ref="address-link.class"/>
+         <xsd:group ref="inline-display-noalt.class"/>
+         <xsd:group ref="emphasis.class"/>
+         <xsd:group ref="phrase-content.class"/>
+         <xsd:group ref="subsup.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="date-model">
+      <xsd:sequence>
+         <xsd:choice minOccurs="0">
+            <xsd:sequence>
+               <xsd:element ref="day" minOccurs="0"/>
+               <xsd:element ref="month" minOccurs="0"/>
+            </xsd:sequence>
+            <xsd:element ref="season"/>
+         </xsd:choice>
+         <xsd:element ref="year" minOccurs="0"/>
+         <xsd:element ref="era" minOccurs="0"/>
+         <xsd:element ref="string-date" minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="date-in-citation-elements">
+      <xsd:choice>
+         <xsd:group ref="date-parts.class"/>
+         <xsd:group ref="emphasis.class"/>
+         <xsd:group ref="subsup.class"/>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="def-model">
+      <xsd:choice>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="just-para.class"/>
+         </xsd:choice>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="def-head-elements">
+      <xsd:choice>
+         <xsd:group ref="def-list-head-elements"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="def-list-head-elements">
+      <xsd:choice>
+         <xsd:group ref="simple-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="simple-phrase">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="def-item-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:element ref="term" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="def.class"/>
+            <xsd:group ref="x.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="def-list-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:element ref="title" minOccurs="0"/>
+         <xsd:element ref="term-head" minOccurs="0"/>
+         <xsd:element ref="def-head" minOccurs="0"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="def-item.class"/>
+            <xsd:group ref="x.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="def-list.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="def-item.class">
+      <xsd:choice>
+         <xsd:element ref="def-item"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="def-list.class">
+      <xsd:choice>
+         <xsd:element ref="def-list"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="degrees-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="disp-formula-model">
+      <xsd:choice>
+         <xsd:group ref="disp-formula-elements"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="disp-formula-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="abstract.class"/>
+         <xsd:group ref="access.class"/>
+         <xsd:group ref="break.class"/>
+         <xsd:group ref="display-back-matter.class"/>
+         <xsd:group ref="kwd-group.class"/>
+         <xsd:group ref="label.class"/>
+         <xsd:group ref="simple-display-noalt.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="disp-formula-group-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:choice minOccurs="0">
+            <xsd:group ref="caption.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="abstract.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="kwd-group.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="access.class"/>
+            <xsd:group ref="address-link.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="block-math.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="disp-quote-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:element ref="title" minOccurs="0"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="para-level"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="display-back-matter.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="edition-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="citation-elements">
+      <xsd:choice>
+         <xsd:group ref="article-link.class"/>
+         <xsd:group ref="appearance.class"/>
+         <xsd:group ref="citation-additions.class"/>
+         <xsd:group ref="emphasis.class"/>
+         <xsd:group ref="inline-display.class"/>
+         <xsd:group ref="inline-math.class"/>
+         <xsd:group ref="label.class"/>
+         <xsd:group ref="math.class"/>
+         <xsd:group ref="phrase.class"/>
+         <xsd:group ref="references.class"/>
+         <xsd:group ref="simple-link.class"/>
+         <xsd:group ref="subsup.class"/>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="citation-additions.class">
+      <xsd:choice>
+         <xsd:element ref="string-date"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="references.class">
+      <xsd:choice>
+         <xsd:element ref="annotation"/>
+         <xsd:element ref="article-title"/>
+         <xsd:element ref="chapter-title"/>
+         <xsd:element ref="collab"/>
+         <xsd:element ref="collab-alternatives"/>
+         <xsd:element ref="comment"/>
+         <xsd:element ref="conf-acronym"/>
+         <xsd:element ref="conf-date"/>
+         <xsd:element ref="conf-loc"/>
+         <xsd:element ref="conf-name"/>
+         <xsd:element ref="conf-sponsor"/>
+         <xsd:element ref="data-title"/>
+         <xsd:element ref="date"/>
+         <xsd:element ref="date-in-citation"/>
+         <xsd:element ref="day"/>
+         <xsd:element ref="edition"/>
+         <xsd:element ref="email"/>
+         <xsd:element ref="elocation-id"/>
+         <xsd:element ref="etal"/>
+         <xsd:element ref="ext-link"/>
+         <xsd:element ref="fpage"/>
+         <xsd:element ref="gov"/>
+         <xsd:element ref="institution"/>
+         <xsd:element ref="institution-wrap"/>
+         <xsd:element ref="isbn"/>
+         <xsd:element ref="issn"/>
+         <xsd:element ref="issn-l"/>
+         <xsd:element ref="issue"/>
+         <xsd:element ref="issue-id"/>
+         <xsd:element ref="issue-part"/>
+         <xsd:element ref="issue-title"/>
+         <xsd:element ref="lpage"/>
+         <xsd:element ref="month"/>
+         <xsd:element ref="name"/>
+         <xsd:element ref="name-alternatives"/>
+         <xsd:element ref="object-id"/>
+         <xsd:element ref="page-range"/>
+         <xsd:element ref="part-title"/>
+         <xsd:element ref="patent"/>
+         <xsd:element ref="person-group"/>
+         <xsd:element ref="pub-id"/>
+         <xsd:element ref="publisher-loc"/>
+         <xsd:element ref="publisher-name"/>
+         <xsd:element ref="role"/>
+         <xsd:element ref="season"/>
+         <xsd:element ref="series"/>
+         <xsd:element ref="size"/>
+         <xsd:element ref="source"/>
+         <xsd:element ref="std"/>
+         <xsd:element ref="string-name"/>
+         <xsd:element ref="supplement"/>
+         <xsd:element ref="trans-source"/>
+         <xsd:element ref="trans-title"/>
+         <xsd:element ref="uri"/>
+         <xsd:element ref="version"/>
+         <xsd:element ref="volume"/>
+         <xsd:element ref="volume-id"/>
+         <xsd:element ref="volume-series"/>
+         <xsd:element ref="year"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="email-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="etal-model">
+      <xsd:choice>
+         <xsd:group ref="etal-elements"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="etal-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="event-model">
+      <xsd:sequence>
+         <xsd:element ref="event-desc" minOccurs="0"/>
+         <xsd:element ref="article-id" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:choice minOccurs="0">
+            <xsd:group ref="article-version.class"/>
+         </xsd:choice>
+         <xsd:choice>
+            <xsd:choice minOccurs="0" maxOccurs="unbounded">
+               <xsd:group ref="pub-date.class"/>
+            </xsd:choice>
+            <xsd:element ref="pub-date-not-available" minOccurs="0"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="date.class"/>
+         </xsd:choice>
+         <xsd:element ref="issn" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="issn-l" minOccurs="0"/>
+         <xsd:element ref="isbn" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="permissions" minOccurs="0"/>
+         <xsd:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="self-uri" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="date.class">
+      <xsd:choice>
+         <xsd:element ref="date"/>
+         <xsd:element ref="string-date"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="event-desc-elements">
+      <xsd:choice>
+         <xsd:group ref="address-link.class"/>
+         <xsd:group ref="article-identifier.class"/>
+         <xsd:group ref="article-version.class"/>
+         <xsd:group ref="date.class"/>
+         <xsd:group ref="pub-date.class"/>
+         <xsd:element ref="pub-date-not-available"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="article-identifier.class">
+      <xsd:choice>
+         <xsd:element ref="article-id"/>
+         <xsd:element ref="issn"/>
+         <xsd:element ref="issn-l"/>
+         <xsd:element ref="isbn"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="ext-link-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="fax-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="fig-model">
+      <xsd:sequence>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="id.class"/>
+         </xsd:choice>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="caption.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="abstract.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="kwd-group.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="access.class"/>
+            <xsd:group ref="address-link.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="block-math.class"/>
+            <xsd:group ref="chem-struct-wrap.class"/>
+            <xsd:group ref="intable-para.class"/>
+            <xsd:group ref="just-table.class"/>
+            <xsd:group ref="just-para.class"/>
+            <xsd:group ref="list.class"/>
+            <xsd:group ref="simple-display.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="display-back-matter.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="chem-struct-wrap.class">
+      <xsd:choice>
+         <xsd:element ref="chem-struct-wrap"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="intable-para.class">
+      <xsd:choice>
+         <xsd:element ref="disp-quote"/>
+         <xsd:element ref="speech"/>
+         <xsd:element ref="statement"/>
+         <xsd:element ref="verse-group"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="just-table.class">
+      <xsd:choice>
+         <xsd:element ref="table-wrap"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="simple-display.class">
+      <xsd:choice>
+         <xsd:element ref="alternatives"/>
+         <xsd:element ref="array"/>
+         <xsd:element ref="code"/>
+         <xsd:element ref="graphic"/>
+         <xsd:element ref="media"/>
+         <xsd:element ref="preformat"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="fig-group-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:choice minOccurs="0">
+            <xsd:group ref="caption.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="abstract.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="kwd-group.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="access.class"/>
+            <xsd:group ref="address-link.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="fig-display.class"/>
+            <xsd:group ref="just-base-display.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="fig-display.class">
+      <xsd:choice>
+         <xsd:element ref="fig"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="floats-group-model">
+      <xsd:choice>
+         <xsd:group ref="floats-display.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="floats-display.class">
+      <xsd:choice>
+         <xsd:element ref="alternatives"/>
+         <xsd:element ref="boxed-text"/>
+         <xsd:element ref="chem-struct-wrap"/>
+         <xsd:element ref="code"/>
+         <xsd:element ref="fig"/>
+         <xsd:element ref="fig-group"/>
+         <xsd:element ref="graphic"/>
+         <xsd:element ref="media"/>
+         <xsd:element ref="preformat"/>
+         <xsd:element ref="supplementary-material"/>
+         <xsd:element ref="table-wrap"/>
+         <xsd:element ref="table-wrap-group"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="fn-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="just-para.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="fn-group-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:element ref="title" minOccurs="0"/>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="fn-link.class"/>
+            <xsd:group ref="x.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="front-model">
+      <xsd:sequence>
+         <xsd:element ref="journal-meta" minOccurs="0"/>
+         <xsd:element ref="article-meta"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="list.class"/>
+            <xsd:group ref="front.class"/>
+            <xsd:group ref="front-back.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="front.class">
+      <xsd:choice>
+         <xsd:element ref="ack"/>
+         <xsd:element ref="bio"/>
+         <xsd:element ref="fn-group"/>
+         <xsd:element ref="glossary"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="front-stub-model">
+      <xsd:sequence>
+         <xsd:element ref="article-id" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:choice minOccurs="0">
+            <xsd:group ref="article-version.class"/>
+         </xsd:choice>
+         <xsd:element ref="article-categories" minOccurs="0"/>
+         <xsd:element ref="title-group" minOccurs="0"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="contrib-group.class"/>
+            <xsd:group ref="aff-alternatives.class"/>
+            <xsd:group ref="x.class"/>
+         </xsd:choice>
+         <xsd:element ref="author-notes" minOccurs="0"/>
+         <xsd:choice>
+            <xsd:choice minOccurs="0" maxOccurs="unbounded">
+               <xsd:group ref="pub-date.class"/>
+            </xsd:choice>
+            <xsd:element ref="pub-date-not-available" minOccurs="0"/>
+         </xsd:choice>
+         <xsd:element ref="volume" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="volume-id" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="volume-series" minOccurs="0"/>
+         <xsd:element ref="issue" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="issue-id" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="issue-title" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="issue-sponsor" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="issue-part" minOccurs="0"/>
+         <xsd:element ref="volume-issue-group" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="isbn" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="supplement" minOccurs="0"/>
+         <xsd:choice minOccurs="0">
+            <xsd:sequence>
+               <xsd:sequence minOccurs="0">
+                  <xsd:element ref="fpage"/>
+                  <xsd:element ref="lpage" minOccurs="0"/>
+               </xsd:sequence>
+               <xsd:element ref="page-range" minOccurs="0"/>
+            </xsd:sequence>
+            <xsd:element ref="elocation-id"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="address-link.class"/>
+            <xsd:element ref="product"/>
+            <xsd:element ref="supplementary-material"/>
+         </xsd:choice>
+         <xsd:element ref="history" minOccurs="0"/>
+         <xsd:element ref="pub-history" minOccurs="0"/>
+         <xsd:element ref="permissions" minOccurs="0"/>
+         <xsd:element ref="self-uri" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="related-article.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="abstract.class"/>
+         </xsd:choice>
+         <xsd:element ref="trans-abstract" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="kwd-group.class"/>
+         </xsd:choice>
+         <xsd:element ref="funding-group" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="support-group" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="conference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="counts" minOccurs="0"/>
+         <xsd:element ref="custom-meta-group" minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="funding-group-model">
+      <xsd:sequence>
+         <xsd:element ref="award-group" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="funding-statement" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="open-access" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="funding-source-elements">
+      <xsd:choice>
+         <xsd:group ref="simple-text"/>
+         <xsd:group ref="institution-wrap.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="funding-statement-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="funding.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="funding.class">
+      <xsd:choice>
+         <xsd:element ref="award-id"/>
+         <xsd:element ref="funding-source"/>
+         <xsd:element ref="open-access"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="given-names-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="glossary-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:element ref="title" minOccurs="0"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="para-level"/>
+         </xsd:choice>
+         <xsd:element ref="glossary" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="gov-elements">
+      <xsd:choice>
+         <xsd:group ref="rendition-plus"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="rendition-plus">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="graphic-model">
+      <xsd:choice>
+         <xsd:group ref="access.class"/>
+         <xsd:group ref="abstract.class"/>
+         <xsd:group ref="address-link.class"/>
+         <xsd:group ref="caption.class"/>
+         <xsd:group ref="id.class"/>
+         <xsd:group ref="kwd-group.class"/>
+         <xsd:group ref="label.class"/>
+         <xsd:group ref="display-back-matter.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="history-model">
+      <xsd:choice>
+         <xsd:group ref="history-elements"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="history-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="break.class"/>
+         <xsd:group ref="date.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="index-term-model">
+      <xsd:sequence>
+         <xsd:element ref="term"/>
+         <xsd:choice>
+            <xsd:element ref="index-term"/>
+            <xsd:choice minOccurs="0" maxOccurs="unbounded">
+               <xsd:element ref="see"/>
+               <xsd:element ref="see-also"/>
+            </xsd:choice>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="inline-formula-model">
+      <xsd:choice>
+         <xsd:group ref="inline-formula-elements"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="inline-formula-elements">
+      <xsd:choice>
+         <xsd:group ref="access.class"/>
+         <xsd:group ref="all-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="inline-graphic-model">
+      <xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="access.class"/>
+         </xsd:choice>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="inline-media-elements">
+      <xsd:choice>
+         <xsd:group ref="access.class"/>
+         <xsd:group ref="address-link.class"/>
+         <xsd:group ref="emphasis.class"/>
+         <xsd:group ref="phrase-content.class"/>
+         <xsd:group ref="subsup.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="inline-supplementary-material-elements">
+      <xsd:choice>
+         <xsd:group ref="access.class"/>
+         <xsd:group ref="all-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="institution-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="break.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="institution-id-model">
+      <xsd:choice/>
+   </xsd:group>
+   <xsd:group name="institution-wrap-model">
+      <xsd:choice>
+         <xsd:group ref="institution.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="institution.class">
+      <xsd:choice>
+         <xsd:element ref="institution"/>
+         <xsd:element ref="institution-id"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="isbn-elements">
+      <xsd:choice>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="issn-elements">
+      <xsd:choice>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="issn-l-elements">
+      <xsd:choice>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="issue-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="issue-part-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="issue-sponsor-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="issue-title-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="journal-meta-model">
+      <xsd:sequence>
+         <xsd:element ref="journal-id" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="journal-title-group" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="contrib-group.class"/>
+            <xsd:group ref="aff-alternatives.class"/>
+         </xsd:choice>
+         <xsd:element ref="issn" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="issn-l" minOccurs="0"/>
+         <xsd:element ref="isbn" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="publisher" minOccurs="0"/>
+         <xsd:element ref="notes" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="self-uri" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="custom-meta-group" minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="journal-subtitle-elements">
+      <xsd:choice>
+         <xsd:group ref="journal-title-elements"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="journal-title-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="journal-title-group-model">
+      <xsd:sequence>
+         <xsd:element ref="journal-title" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="journal-subtitle" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="trans-title-group" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="abbrev-journal-title" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="kwd-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="break.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="kwd-group-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:element ref="title" minOccurs="0"/>
+         <xsd:choice>
+            <xsd:choice maxOccurs="unbounded">
+               <xsd:group ref="kwd.class"/>
+               <xsd:group ref="x.class"/>
+            </xsd:choice>
+            <xsd:choice minOccurs="0" maxOccurs="unbounded">
+               <xsd:group ref="unstructured-kwd-group.class"/>
+            </xsd:choice>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="kwd.class">
+      <xsd:choice>
+         <xsd:element ref="kwd"/>
+         <xsd:element ref="compound-kwd"/>
+         <xsd:element ref="nested-kwd"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="unstructured-kwd-group.class">
+      <xsd:choice>
+         <xsd:element ref="unstructured-kwd-group"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="label-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="break.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="license-model">
+      <xsd:choice>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="license-p.class"/>
+         </xsd:choice>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="license-p.class">
+      <xsd:choice>
+         <xsd:element ref="ali:license_ref"/>
+         <xsd:element ref="license-p"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="license-p-elements">
+      <xsd:choice>
+         <xsd:group ref="p-elements"/>
+         <xsd:group ref="price.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="p-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="block-display-noalt.class"/>
+         <xsd:group ref="block-math.class"/>
+         <xsd:group ref="citation.class"/>
+         <xsd:group ref="funding.class"/>
+         <xsd:group ref="list.class"/>
+         <xsd:group ref="rest-of-para.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="block-display-noalt.class">
+      <xsd:choice>
+         <xsd:element ref="address"/>
+         <xsd:element ref="array"/>
+         <xsd:element ref="boxed-text"/>
+         <xsd:element ref="chem-struct-wrap"/>
+         <xsd:element ref="code"/>
+         <xsd:element ref="fig"/>
+         <xsd:element ref="fig-group"/>
+         <xsd:element ref="graphic"/>
+         <xsd:element ref="media"/>
+         <xsd:element ref="preformat"/>
+         <xsd:element ref="supplementary-material"/>
+         <xsd:element ref="table-wrap"/>
+         <xsd:element ref="table-wrap-group"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="citation.class">
+      <xsd:choice>
+         <xsd:element ref="citation-alternatives"/>
+         <xsd:element ref="element-citation"/>
+         <xsd:element ref="mixed-citation"/>
+         <xsd:element ref="nlm-citation"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="price.class">
+      <xsd:choice>
+         <xsd:element ref="price"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="list-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:element ref="title" minOccurs="0"/>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="list-item.class"/>
+            <xsd:group ref="x.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="list-item.class">
+      <xsd:choice>
+         <xsd:element ref="list-item"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="list-item-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:element ref="title" minOccurs="0"/>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="just-para.class"/>
+            <xsd:group ref="list.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="long-desc-elements">
+      <xsd:choice>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="media-model">
+      <xsd:choice>
+         <xsd:group ref="access.class"/>
+         <xsd:group ref="abstract.class"/>
+         <xsd:group ref="address-link.class"/>
+         <xsd:group ref="caption.class"/>
+         <xsd:group ref="id.class"/>
+         <xsd:group ref="kwd-group.class"/>
+         <xsd:group ref="label.class"/>
+         <xsd:group ref="display-back-matter.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="meta-name-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="meta-value-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="name-alternatives-model">
+      <xsd:choice>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="name-alternatives.class"/>
+         </xsd:choice>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="name-alternatives.class">
+      <xsd:choice>
+         <xsd:element ref="name"/>
+         <xsd:element ref="string-name"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="named-content-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="block-display-noalt.class"/>
+         <xsd:group ref="block-math.class"/>
+         <xsd:group ref="list.class"/>
+         <xsd:group ref="rest-of-para.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="nested-kwd-model">
+      <xsd:sequence>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="nested-kwd.class"/>
+         </xsd:choice>
+         <xsd:element ref="nested-kwd" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="nested-kwd.class">
+      <xsd:choice>
+         <xsd:element ref="kwd"/>
+         <xsd:element ref="compound-kwd"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="note-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="just-para.class"/>
+            <xsd:group ref="product.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="product.class">
+      <xsd:choice>
+         <xsd:element ref="product"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="notes-model">
+      <xsd:sequence>
+         <xsd:group ref="sec-opt-title-model"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="on-behalf-of-elements">
+      <xsd:choice>
+         <xsd:group ref="rendition-plus"/>
+         <xsd:group ref="institution-wrap.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="open-access-model">
+      <xsd:choice>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="just-para.class"/>
+         </xsd:choice>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="part-title-elements">
+      <xsd:choice>
+         <xsd:group ref="source-elements"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="patent-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="permissions-model">
+      <xsd:sequence>
+         <xsd:element ref="copyright-statement" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="copyright-year" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="copyright-holder" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="license.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="license.class">
+      <xsd:choice>
+         <xsd:element ref="ali:free_to_read"/>
+         <xsd:element ref="license"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="person-group-model">
+      <xsd:choice>
+         <xsd:group ref="person-group-elements"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="person-group-elements">
+      <xsd:choice>
+         <xsd:group ref="name.class"/>
+         <xsd:group ref="person-group-info.class"/>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="person-group-info.class">
+      <xsd:choice>
+         <xsd:element ref="aff"/>
+         <xsd:element ref="aff-alternatives"/>
+         <xsd:element ref="etal"/>
+         <xsd:element ref="role"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="phone-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="postal-code-elements">
+      <xsd:choice/>
+   </xsd:group>
+   <xsd:group name="prefix-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="preformat-model">
+      <xsd:choice>
+         <xsd:group ref="preformat-elements"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="preformat-elements">
+      <xsd:choice>
+         <xsd:group ref="access.class"/>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="display-back-matter.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="price-elements">
+      <xsd:choice>
+         <xsd:group ref="emphasis.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="principal-award-recipient-elements">
+      <xsd:choice>
+         <xsd:group ref="contrib-id.class"/>
+         <xsd:group ref="recipient-name.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="recipient-name.class">
+      <xsd:choice>
+         <xsd:element ref="name"/>
+         <xsd:element ref="name-alternatives"/>
+         <xsd:element ref="institution"/>
+         <xsd:element ref="institution-wrap"/>
+         <xsd:element ref="string-name"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="principal-investigator-elements">
+      <xsd:choice>
+         <xsd:group ref="contrib-id.class"/>
+         <xsd:group ref="investigator-name.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="investigator-name.class">
+      <xsd:choice>
+         <xsd:element ref="name"/>
+         <xsd:element ref="name-alternatives"/>
+         <xsd:element ref="string-name"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="private-char-model">
+      <xsd:choice>
+         <xsd:choice>
+            <xsd:element ref="glyph-data"/>
+            <xsd:element ref="glyph-ref"/>
+         </xsd:choice>
+         <xsd:element ref="inline-graphic" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="product-elements">
+      <xsd:choice>
+         <xsd:group ref="article-link.class"/>
+         <xsd:group ref="appearance.class"/>
+         <xsd:group ref="break.class"/>
+         <xsd:group ref="citation-additions.class"/>
+         <xsd:group ref="emphasis.class"/>
+         <xsd:group ref="inline-display.class"/>
+         <xsd:group ref="inline-math.class"/>
+         <xsd:group ref="label.class"/>
+         <xsd:group ref="math.class"/>
+         <xsd:group ref="phrase.class"/>
+         <xsd:group ref="price.class"/>
+         <xsd:group ref="references.class"/>
+         <xsd:group ref="simple-link.class"/>
+         <xsd:group ref="subsup.class"/>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="pub-date-model">
+      <xsd:choice>
+         <xsd:group ref="date-parts.class"/>
+         <xsd:group ref="string-date.class"/>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="string-date.class">
+      <xsd:choice>
+         <xsd:element ref="string-date"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="pub-history-model">
+      <xsd:choice>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="event.class"/>
+         </xsd:choice>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="event.class">
+      <xsd:choice>
+         <xsd:element ref="event"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="publisher-model">
+      <xsd:choice>
+         <xsd:sequence maxOccurs="unbounded">
+            <xsd:element ref="publisher-name"/>
+            <xsd:element ref="publisher-loc" minOccurs="0"/>
+         </xsd:sequence>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="publisher-loc-elements">
+      <xsd:choice>
+         <xsd:group ref="address.class"/>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="break.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="publisher-name-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+         <xsd:group ref="institution-wrap.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="rb-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="ref-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="citation.class"/>
+            <xsd:group ref="note.class"/>
+            <xsd:group ref="x.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="note.class">
+      <xsd:choice>
+         <xsd:element ref="note"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="ref-list-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:element ref="title" minOccurs="0"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="para-level"/>
+            <xsd:group ref="ref.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="ref-list.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="ref.class">
+      <xsd:choice>
+         <xsd:element ref="ref"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="related-article-elements">
+      <xsd:choice>
+         <xsd:group ref="article-link.class"/>
+         <xsd:group ref="appearance.class"/>
+         <xsd:group ref="break.class"/>
+         <xsd:group ref="citation-additions.class"/>
+         <xsd:group ref="emphasis.class"/>
+         <xsd:group ref="inline-display.class"/>
+         <xsd:group ref="inline-math.class"/>
+         <xsd:group ref="journal-id.class"/>
+         <xsd:group ref="label.class"/>
+         <xsd:group ref="math.class"/>
+         <xsd:group ref="phrase.class"/>
+         <xsd:group ref="references.class"/>
+         <xsd:group ref="simple-link.class"/>
+         <xsd:group ref="subsup.class"/>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="journal-id.class">
+      <xsd:choice>
+         <xsd:element ref="journal-id"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="related-object-elements">
+      <xsd:choice>
+         <xsd:group ref="article-link.class"/>
+         <xsd:group ref="appearance.class"/>
+         <xsd:group ref="break.class"/>
+         <xsd:group ref="citation-additions.class"/>
+         <xsd:group ref="emphasis.class"/>
+         <xsd:group ref="inline-display.class"/>
+         <xsd:group ref="inline-math.class"/>
+         <xsd:group ref="label.class"/>
+         <xsd:group ref="math.class"/>
+         <xsd:group ref="phrase.class"/>
+         <xsd:group ref="references.class"/>
+         <xsd:group ref="simple-link.class"/>
+         <xsd:group ref="subsup.class"/>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="resource-group-model">
+      <xsd:choice>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:element ref="resource-name"/>
+            <xsd:element ref="resource-wrap"/>
+         </xsd:choice>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="resource-id-elements">
+      <xsd:choice/>
+   </xsd:group>
+   <xsd:group name="resource-name-elements">
+      <xsd:choice>
+         <xsd:group ref="face-markup.class"/>
+         <xsd:group ref="subsup.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="resource-wrap-model">
+      <xsd:sequence>
+         <xsd:element ref="resource-name"/>
+         <xsd:element ref="resource-id" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="article-short-model">
+      <xsd:sequence>
+         <xsd:choice>
+            <xsd:element ref="front"/>
+            <xsd:element ref="front-stub"/>
+         </xsd:choice>
+         <xsd:element ref="body" minOccurs="0"/>
+         <xsd:element ref="back" minOccurs="0"/>
+         <xsd:element ref="floats-group" minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="role-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="rt-elements">
+      <xsd:choice/>
+   </xsd:group>
+   <xsd:group name="ruby-model">
+      <xsd:sequence>
+         <xsd:element ref="rb"/>
+         <xsd:choice>
+            <xsd:element ref="rt"/>
+            <xsd:sequence>
+               <xsd:element ref="rp"/>
+               <xsd:element ref="rt"/>
+               <xsd:element ref="rp"/>
+            </xsd:sequence>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="sec-model">
+      <xsd:sequence>
+         <xsd:element ref="sec-meta" minOccurs="0"/>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:element ref="title" minOccurs="0"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="para-level"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="sec-level"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="sec-back-matter-mix"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="sec-meta-model">
+      <xsd:sequence>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="contrib-group.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="abstract.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="kwd-group.class"/>
+         </xsd:choice>
+         <xsd:element ref="permissions" minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="see-elements">
+      <xsd:choice>
+         <xsd:group ref="simple-phrase"/>
+         <xsd:group ref="block-math.class"/>
+         <xsd:group ref="simple-display-noalt.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="see-also-elements">
+      <xsd:choice>
+         <xsd:group ref="simple-phrase"/>
+         <xsd:group ref="block-math.class"/>
+         <xsd:group ref="simple-display-noalt.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="self-uri-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="series-elements">
+      <xsd:choice>
+         <xsd:group ref="rendition-plus"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="series-text-elements">
+      <xsd:choice>
+         <xsd:group ref="rendition-plus"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="series-title-elements">
+      <xsd:choice>
+         <xsd:group ref="rendition-plus"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="sig-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="break.class"/>
+         <xsd:group ref="just-base-display-noalt.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="just-base-display-noalt.class">
+      <xsd:choice>
+         <xsd:element ref="graphic"/>
+         <xsd:element ref="media"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="sig-block-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="break.class"/>
+         <xsd:group ref="contrib.class"/>
+         <xsd:group ref="just-base-display-noalt.class"/>
+         <xsd:group ref="person-group-info.class"/>
+         <xsd:group ref="sig.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="sig.class">
+      <xsd:choice>
+         <xsd:element ref="sig"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="size-elements">
+      <xsd:choice>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="speaker-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="person-name.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="person-name.class">
+      <xsd:choice>
+         <xsd:element ref="degrees"/>
+         <xsd:element ref="given-names"/>
+         <xsd:element ref="prefix"/>
+         <xsd:element ref="surname"/>
+         <xsd:element ref="suffix"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="speech-model">
+      <xsd:sequence>
+         <xsd:element ref="speaker"/>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="just-para.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="state-elements">
+      <xsd:choice/>
+   </xsd:group>
+   <xsd:group name="statement-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:element ref="title" minOccurs="0"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="abstract.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="kwd-group.class"/>
+         </xsd:choice>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="just-para.class"/>
+            <xsd:group ref="statement.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="display-back-matter.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="statement.class">
+      <xsd:choice>
+         <xsd:element ref="statement"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="std-elements">
+      <xsd:choice>
+         <xsd:group ref="emphasis.class"/>
+         <xsd:group ref="inline-display-noalt.class"/>
+         <xsd:group ref="phrase-content.class"/>
+         <xsd:group ref="std.class"/>
+         <xsd:group ref="subsup.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="std.class">
+      <xsd:choice>
+         <xsd:element ref="day"/>
+         <xsd:element ref="month"/>
+         <xsd:element ref="pub-id"/>
+         <xsd:element ref="source"/>
+         <xsd:element ref="std-organization"/>
+         <xsd:element ref="year"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="std-organization-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="institution-wrap.class"/>
+         <xsd:group ref="break.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="string-conf-elements">
+      <xsd:choice>
+         <xsd:group ref="simple-text"/>
+         <xsd:group ref="conference.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="string-date-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="date-parts.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="string-name-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="person-name.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="styled-content-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="block-display-noalt.class"/>
+         <xsd:group ref="block-math.class"/>
+         <xsd:group ref="list.class"/>
+         <xsd:group ref="rest-of-para.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="sub-article-model">
+      <xsd:sequence>
+         <xsd:choice>
+            <xsd:element ref="front"/>
+            <xsd:element ref="front-stub"/>
+         </xsd:choice>
+         <xsd:element ref="body" minOccurs="0"/>
+         <xsd:element ref="back" minOccurs="0"/>
+         <xsd:element ref="floats-group" minOccurs="0"/>
+         <xsd:choice>
+            <xsd:element ref="sub-article" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element ref="response" minOccurs="0" maxOccurs="unbounded"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="subj-group-model">
+      <xsd:sequence>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:element ref="subject"/>
+            <xsd:element ref="compound-subject"/>
+         </xsd:choice>
+         <xsd:element ref="subj-group" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="subject-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="break.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="subtitle-elements">
+      <xsd:choice>
+         <xsd:group ref="title-elements"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="suffix-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="supplement-elements">
+      <xsd:choice>
+         <xsd:group ref="simple-text"/>
+         <xsd:group ref="contrib-group.class"/>
+         <xsd:group ref="title.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="title.class">
+      <xsd:choice>
+         <xsd:element ref="title"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="supplementary-material-model">
+      <xsd:sequence>
+         <xsd:group ref="fig-model"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="support-description-model">
+      <xsd:choice>
+         <xsd:element ref="p" maxOccurs="unbounded"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="support-group-model">
+      <xsd:sequence>
+         <xsd:element ref="funding-group" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="contributed-resource-group"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="support-source-elements">
+      <xsd:choice>
+         <xsd:group ref="simple-text"/>
+         <xsd:group ref="institution-wrap.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="surname-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="table.content">
+      <xsd:sequence>
+         <xsd:choice>
+            <xsd:element ref="col" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element ref="colgroup" minOccurs="0" maxOccurs="unbounded"/>
+         </xsd:choice>
+         <xsd:choice>
+            <xsd:sequence>
+               <xsd:element ref="thead" minOccurs="0"/>
+               <xsd:element ref="tfoot" minOccurs="0"/>
+               <xsd:element ref="tbody" maxOccurs="unbounded"/>
+            </xsd:sequence>
+            <xsd:choice>
+               <xsd:element ref="tr" maxOccurs="unbounded"/>
+            </xsd:choice>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="table-wrap-model">
+      <xsd:sequence>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="id.class"/>
+         </xsd:choice>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:choice minOccurs="0">
+            <xsd:group ref="caption.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="abstract.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="kwd-group.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="access.class"/>
+            <xsd:group ref="address-link.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="inside-table-wrap"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="table-foot.class"/>
+            <xsd:group ref="display-back-matter.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="inside-table-wrap">
+      <xsd:choice>
+         <xsd:group ref="intable-para.class"/>
+         <xsd:group ref="list.class"/>
+         <xsd:group ref="simple-intable-display.class"/>
+         <xsd:group ref="table.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="simple-intable-display.class">
+      <xsd:choice>
+         <xsd:element ref="alternatives"/>
+         <xsd:element ref="chem-struct-wrap"/>
+         <xsd:element ref="code"/>
+         <xsd:element ref="disp-formula"/>
+         <xsd:element ref="graphic"/>
+         <xsd:element ref="media"/>
+         <xsd:element ref="preformat"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="table.class">
+      <xsd:choice>
+         <xsd:element ref="table"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="table-foot.class">
+      <xsd:choice>
+         <xsd:element ref="table-wrap-foot"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="table-wrap-foot-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:element ref="title" minOccurs="0"/>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="just-para.class"/>
+            <xsd:group ref="fn-group.class"/>
+            <xsd:group ref="fn-link.class"/>
+            <xsd:group ref="display-back-matter.class"/>
+            <xsd:group ref="x.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="fn-group.class">
+      <xsd:choice>
+         <xsd:element ref="fn-group"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="table-wrap-group-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:element ref="caption" minOccurs="0"/>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="abstract.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="kwd-group.class"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="access.class"/>
+            <xsd:group ref="address-link.class"/>
+         </xsd:choice>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:group ref="just-table.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="target-elements">
+      <xsd:choice>
+         <xsd:group ref="link-elements"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="link-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="break.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="tbody.content">
+      <xsd:choice>
+         <xsd:element ref="tr"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="td.content">
+      <xsd:choice>
+         <xsd:group ref="Flow.mix"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="Flow.mix">
+      <xsd:choice>
+         <xsd:group ref="inside-cell"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="inside-cell">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="block-math.class"/>
+         <xsd:group ref="break.class"/>
+         <xsd:group ref="chem-struct-wrap.class"/>
+         <xsd:group ref="citation.class"/>
+         <xsd:group ref="list.class"/>
+         <xsd:group ref="nothing-but-para.class"/>
+         <xsd:group ref="simple-display-noalt.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="term-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="block-math.class"/>
+         <xsd:group ref="chem-struct-wrap.class"/>
+         <xsd:group ref="simple-display-noalt.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="term-head-elements">
+      <xsd:choice>
+         <xsd:group ref="def-list-head-elements"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="textual-form-elements">
+      <xsd:choice>
+         <xsd:group ref="emphasis.class"/>
+         <xsd:group ref="inline-display-noalt.class"/>
+         <xsd:group ref="label.class"/>
+         <xsd:group ref="math.class"/>
+         <xsd:group ref="phrase-content.class"/>
+         <xsd:group ref="subsup.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="tfoot.content">
+      <xsd:choice>
+         <xsd:element ref="tr"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="th.content">
+      <xsd:choice>
+         <xsd:group ref="Flow.mix"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="thead.content">
+      <xsd:choice>
+         <xsd:element ref="tr"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="time-stamp-elements">
+      <xsd:choice>
+         <xsd:group ref="date-parts.class"/>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="struct-title-elements">
+      <xsd:choice>
+         <xsd:group ref="all-phrase"/>
+         <xsd:group ref="break.class"/>
+         <xsd:group ref="citation.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="title-group-model">
+      <xsd:sequence>
+         <xsd:element ref="article-title"/>
+         <xsd:element ref="subtitle" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="trans-title-group" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="alt-title" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="fn-group" minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="tr.content">
+      <xsd:choice>
+         <xsd:element ref="th"/>
+         <xsd:element ref="td"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="trans-abstract-model">
+      <xsd:sequence>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="id.class"/>
+         </xsd:choice>
+         <xsd:group ref="sec-opt-title-model"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="trans-subtitle-elements">
+      <xsd:choice>
+         <xsd:group ref="title-elements"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="trans-title-elements">
+      <xsd:choice>
+         <xsd:group ref="title-elements"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="trans-title-group-model">
+      <xsd:sequence>
+         <xsd:element ref="trans-title"/>
+         <xsd:element ref="trans-subtitle" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="unstructured-kwd-group-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="uri-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="verse-group-model">
+      <xsd:sequence>
+         <xsd:element ref="label" minOccurs="0"/>
+         <xsd:element ref="title" minOccurs="0"/>
+         <xsd:element ref="subtitle" minOccurs="0"/>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:element ref="verse-line"/>
+            <xsd:element ref="verse-group"/>
+         </xsd:choice>
+         <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:group ref="display-back-matter.class"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="verse-line-elements">
+      <xsd:choice>
+         <xsd:group ref="simple-text"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="version-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="volume-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="volume-id-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="volume-issue-group-model">
+      <xsd:sequence>
+         <xsd:element ref="volume" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="volume-id" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="volume-series" minOccurs="0"/>
+         <xsd:element ref="issue" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="issue-id" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="issue-title" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="issue-sponsor" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="issue-part" minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="volume-series-elements">
+      <xsd:choice>
+         <xsd:group ref="just-rendition"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="x-elements">
+      <xsd:choice>
+         <xsd:group ref="emphasis.class"/>
+         <xsd:group ref="inline-display-noalt.class"/>
+         <xsd:group ref="phrase-content.class"/>
+         <xsd:group ref="subsup.class"/>
+         <xsd:group ref="x.class"/>
+      </xsd:choice>
+   </xsd:group>
+   <xsd:group name="xref-elements">
+      <xsd:choice>
+         <xsd:group ref="link-elements"/>
+      </xsd:choice>
+   </xsd:group>
+</xsd:schema>
+

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/JATS-archivearticle1.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/JATS-archivearticle1.xsd
@@ -1,0 +1,58 @@
+<?xml-stylesheet href="xsd.xsl" type="text/xsl"?>
+<xsd:schema xmlns:mtl="http://www.mulberrytech.com/taglib"
+            xmlns:c="http://www.w3.org/ns/xproc-step"
+            xmlns:mml="http://www.w3.org/1998/Math/MathML"
+            xmlns:ali="http://www.niso.org/schemas/ali/1.0/"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <xsd:annotation>
+      <xsd:documentation>
+         <div xmlns="http://www.w3.org/1999/xhtml"
+              xmlns:dxdy="http://mulberrytech.com/2014/dxdy"
+              xmlns:xsd="http://www.w3.org/2000/10/XMLSchema"
+              class="bodytext">
+              <h1>MODULE: JATS-archivearticle1 DTD in XSD form (driver file)</h1>
+              <h2>MODEL: Journal Archiving and Interchange DTD (MathML 2.0)</h2>
+              <h2>VERSION:  1.2</h2>
+              <h2>DATE:  February 2019</h2>
+              
+              <dl>
+                <dt>SYSTEM</dt>
+                <dd>
+                  <p>Journal Archiving and Interchange model of the JATS Suite</p>
+               </dd>
+                <dt>PURPOSE</dt>
+                <dd>
+                  <p>Driver file: include and import all other schema documents</p>
+               </dd>
+                <dt>CREATED FOR</dt>
+                <dd>
+                  <p>NLM/NCBI</p> 
+               </dd>
+                
+              </dl>
+            </div>
+      </xsd:documentation>
+   </xsd:annotation>
+   <xsd:import namespace="http://www.w3.org/1999/xlink"
+               schemaLocation="standard-modules/xlink.xsd"/>
+   <xsd:import namespace="http://www.w3.org/1998/Math/MathML"
+               schemaLocation="standard-modules/mathml2/mathml2.xsd">
+        <xsd:annotation xmlns:dxdy="http://mulberrytech.com/2014/dxdy">
+          <xsd:documentation>
+            This is a modified copy of the MathML 2 schema documents
+            at http://www.w3.org/Math/XMLSchema/mathml2.tgz
+            -- an explicit reference to an incomplete copy of the
+            XLink schema document has been suppressed to avoid
+            conflicts with the full XLink schema document.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:import>
+   <xsd:import namespace="http://www.niso.org/schemas/ali/1.0/"
+               schemaLocation="standard-modules/module-ali.xsd"/>
+   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
+               schemaLocation="standard-modules/xml.xsd"/>
+   <xsd:include schemaLocation="JATS-archivearticle1-elements.xsd"/>
+</xsd:schema>
+

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/common/common-attribs.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/common/common-attribs.xsd
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+>
+
+<xs:annotation>
+  <xs:documentation>
+  This is the common attributes module for MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!--* Modified 2014-01-21 by CMSMcQ:  suppress schemaLocation hint.
+    * It interferes with the use of the full XLink schema.
+    *-->
+<!--* <xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink-href.xsd"/> *-->
+<xs:import namespace="http://www.w3.org/1999/xlink"/>
+<xs:import/> <!-- import any foreign namespace -->
+
+
+<!-- The type of "class" is from the XHTML modularization with Schema
+     document -->
+<xs:attributeGroup name="Common.attrib">
+  <xs:attribute name="class" type="xs:NMTOKENS"/>
+  <xs:attribute name="style" type="xs:string"/>
+  <xs:attribute name="xref" type="xs:IDREF"/>
+  <xs:attribute name="id" type="xs:ID"/>
+  <xs:attribute ref="xlink:href"/>
+  <!-- allow attributes from foreign namespaces, and don't check them -->
+  <xs:anyAttribute namespace="##other" processContents="skip"/>
+</xs:attributeGroup>
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/common/math.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/common/math.xsd
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is an XML Schema module defining the "math" element of MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- The four groups that govern a lot of things -->
+
+<!-- currently very lax. Should be tightened from Chapter 5 -->
+
+<xs:group name="Presentation-expr.class">
+  <xs:choice>
+    <xs:group ref="PresExpr.class"/>
+    <xs:group ref="ContExpr.class"/>
+  </xs:choice>
+</xs:group>
+
+<xs:group name="Content-expr.class">
+  <xs:choice>
+    <xs:group ref="ContExpr.class"/>
+    <xs:group ref="PresExpr.class"/>
+  </xs:choice>
+</xs:group>
+
+<xs:group name="PresExpr.class">
+  <xs:choice>
+    <xs:group ref="Presentation-token.class"/>
+    <xs:group ref="Presentation-layout.class"/>
+    <xs:group ref="Presentation-script.class"/>
+    <xs:group ref="Presentation-table.class"/>
+    <xs:element ref="mspace"/>
+    <xs:element ref="maction"/>
+    <xs:element ref="merror"/>
+    <xs:element ref="mstyle"/>
+  </xs:choice>
+</xs:group>
+
+<xs:group name="ContExpr.class">
+  <xs:choice>
+    <xs:group ref="Content-tokens.class"/>
+    <xs:group ref="Content-arith.class"/>
+    <xs:group ref="Content-functions.class"/>
+    <xs:group ref="Content-logic.class"/>
+    <xs:group ref="Content-constants.class"/>
+    <xs:group ref="Content-sets.class"/>
+    <xs:group ref="Content-relations.class"/>
+    <xs:group ref="Content-elementary-functions.class"/>
+    <xs:group ref="Content-calculus.class"/>
+    <xs:group ref="Content-linear-algebra.class"/>
+    <xs:group ref="Content-vector-calculus.class"/>
+    <xs:group ref="Content-statistics.class"/>
+    <xs:group ref="Content-constructs.class"/>
+    <xs:element ref="semantics"/>
+  </xs:choice>
+</xs:group>
+
+<!-- "math" -->
+
+<xs:attributeGroup name="Browser-interface.attrib">
+  <xs:attribute name="baseline" type="xs:string"/>
+  <xs:attribute name="overflow" default="scroll">
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="scroll"/>
+        <xs:enumeration value="elide"/>
+        <xs:enumeration value="truncate"/>
+        <xs:enumeration value="scale"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="altimg" type="xs:anyURI"/>
+  <xs:attribute name="alttext" type="xs:string"/>
+  <xs:attribute name="type" type="xs:string"/>
+  <xs:attribute name="name" type="xs:string"/>
+  <xs:attribute name="height" type="xs:string"/>
+  <xs:attribute name="width" type="xs:string"/>
+</xs:attributeGroup>
+
+<xs:attributeGroup name="math.attlist">
+  <xs:attributeGroup ref="Browser-interface.attrib"/>
+  <xs:attribute name="macros" type="xs:string"/>
+<!-- deprecated
+  <xs:attribute name="mode" type="xs:string"/>
+-->
+  <xs:attribute name="display" default="inline">
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="block"/>
+        <xs:enumeration value="inline"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="math.content">
+  <xs:choice>
+    <xs:group ref="PresExpr.class"/>
+    <xs:group ref="ContExpr.class"/>
+  </xs:choice>
+</xs:group>
+
+<xs:complexType name="math.type">
+  <xs:group ref="math.content" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="math.attlist"/>
+</xs:complexType>
+
+<xs:element name="math" type="math.type"/>
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/common/xlink-href.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/common/xlink-href.xsd
@@ -1,0 +1,20 @@
+<schema targetNamespace="http://www.w3.org/1999/xlink" 
+        xmlns:xlink="http://www.w3.org/1999/xlink" 
+        xmlns="http://www.w3.org/2001/XMLSchema">
+  <annotation>
+    <documentation xml:lang="en">
+      This schema provides the XLink href attribute for use in the MathML2 
+      schema. Written by Max Froumentin, W3C.
+    </documentation>
+  </annotation>
+
+  <attribute name="href" type="anyURI"/>
+</schema>
+
+     
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/arith.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/arith.xsd
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+>
+
+<xs:annotation>
+  <xs:documentation>
+  This is an XML Schema module for the "arithmetic" operators of content
+  MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- a common type for all this -->
+
+<xs:complexType name="Arith.type">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:complexType>
+
+<!-- The elements -->
+
+<xs:element name="abs" type="Arith.type"/>
+<xs:element name="conjugate" type="Arith.type"/>
+<xs:element name="arg" type="Arith.type"/>
+<xs:element name="real" type="Arith.type"/>
+<xs:element name="imaginary" type="Arith.type"/>
+
+<xs:element name="floor" type="Arith.type"/>
+<xs:element name="ceiling" type="Arith.type"/>
+
+<xs:element name="power" type="Arith.type"/>
+<xs:element name="root" type="Arith.type"/>
+
+<xs:element name="minus" type="Arith.type"/>
+<xs:element name="plus" type="Arith.type"/>
+<xs:element name="sum" type="Arith.type"/>
+<xs:element name="times" type="Arith.type"/>
+<xs:element name="product" type="Arith.type"/>
+
+<xs:element name="max" type="Arith.type"/>
+<xs:element name="min" type="Arith.type"/>
+
+<xs:element name="factorial" type="Arith.type"/>
+<xs:element name="quotient" type="Arith.type"/>
+<xs:element name="divide" type="Arith.type"/>
+<xs:element name="rem" type="Arith.type"/>
+<xs:element name="gcd" type="Arith.type"/>
+<xs:element name="lcm" type="Arith.type"/>
+
+<!-- And the group of everything -->
+
+<xs:group name="Content-arith.class">
+  <xs:choice>
+    <xs:element ref="abs"/>
+    <xs:element ref="conjugate"/>
+    <xs:element ref="factorial"/>
+    <xs:element ref="arg"/>
+    <xs:element ref="real"/>
+    <xs:element ref="imaginary"/>
+    <xs:element ref="floor"/>
+    <xs:element ref="ceiling"/>
+    <xs:element ref="quotient"/>
+    <xs:element ref="divide"/>
+    <xs:element ref="rem"/>
+    <xs:element ref="minus"/>
+    <xs:element ref="plus"/>
+    <xs:element ref="times"/>
+    <xs:element ref="power"/>
+    <xs:element ref="root"/>
+    <xs:element ref="max"/>
+    <xs:element ref="min"/>
+    <xs:element ref="gcd"/>
+    <xs:element ref="lcm"/>
+    <xs:element ref="sum"/>
+    <xs:element ref="product"/>
+  </xs:choice>
+</xs:group>
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/calculus.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/calculus.xsd
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is an XML Schema module for the calculs operators of content
+  MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- "int" -->
+
+<xs:attributeGroup name="int.attlist">  
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="int.type">
+  <xs:attributeGroup ref="int.attlist"/>
+</xs:complexType>
+
+<xs:element name="int" type="int.type"/>
+
+<!-- "diff" -->
+
+<xs:attributeGroup name="diff.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="diff.type">
+  <xs:attributeGroup ref="diff.attlist"/>
+</xs:complexType>
+
+<xs:element name="diff" type="diff.type"/>
+
+<!-- "partialdiff" -->
+
+<xs:attributeGroup name="partialdiff.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="partialdiff.type">
+  <xs:attributeGroup ref="partialdiff.attlist"/>
+</xs:complexType>
+
+<xs:element name="partialdiff" type="partialdiff.type"/>
+
+<!-- "limit" -->
+
+<xs:attributeGroup name="limit.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+
+<xs:complexType name="limit.type">
+  <xs:attributeGroup ref="limit.attlist"/>
+</xs:complexType>
+
+<xs:element name="limit" type="limit.type"/>
+
+<!-- "lowlimit" -->
+
+<xs:attributeGroup name="lowlimit.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="lowlimit.content">
+  <xs:sequence>
+    <xs:group ref="Content-expr.class"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="lowlimit.type">
+  <xs:group ref="lowlimit.content"  minOccurs="1" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="lowlimit.attlist"/>
+</xs:complexType>
+
+<xs:element name="lowlimit" type="lowlimit.type"/>
+
+<!-- "uplimit" -->
+
+<xs:attributeGroup name="uplimit.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="uplimit.content">
+  <xs:sequence>
+    <xs:group ref="Content-expr.class"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="uplimit.type">
+  <xs:group ref="uplimit.content"  minOccurs="1" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="uplimit.attlist"/>
+</xs:complexType>
+
+<xs:element name="uplimit" type="uplimit.type"/>
+
+<!-- "tendsto" -->
+
+<xs:attributeGroup name="tendsto.attlist">
+  <xs:attribute name="type" type="xs:string"/>
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+
+<xs:complexType name="tendsto.type">
+  <xs:attributeGroup ref="tendsto.attlist"/>
+</xs:complexType>
+
+<xs:element name="tendsto" type="tendsto.type"/>
+
+<!-- And the group of everything -->
+
+<xs:group name="Content-calculus.class">
+  <xs:choice>
+    <xs:element ref="int"/>
+    <xs:element ref="diff"/>
+    <xs:element ref="partialdiff"/>
+    <xs:element ref="limit"/>
+    <xs:element ref="lowlimit"/>
+    <xs:element ref="uplimit"/>
+    <xs:element ref="tendsto"/>
+  </xs:choice>
+</xs:group>
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/common-attrib.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/common-attrib.xsd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is the XML schema module defining common attributes for the
+  content part of MathML.
+  Authors: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<xs:attributeGroup name="Definition.attrib">
+  <xs:attribute name="encoding" type="xs:string"/>
+  <xs:attribute name="definitionURL" type="xs:anyURI"/>
+</xs:attributeGroup>
+
+</xs:schema>
+
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/constants.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/constants.xsd
@@ -1,0 +1,83 @@
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is the XML Schema module for the basic constants of MathML content.
+  Author: St&#233;phane Dalmas.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- a common type for all this -->
+
+<xs:complexType name="Constant.type">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:complexType>
+
+<!-- Basic sets -->
+
+<xs:element name="naturalnumbers" type="Constant.type"/>
+<xs:element name="primes" type="Constant.type"/>
+<xs:element name="integers" type="Constant.type"/>
+<xs:element name="rationals" type="Constant.type"/>
+<xs:element name="reals" type="Constant.type"/>
+<xs:element name="complexes" type="Constant.type"/>
+
+<!-- Empty set -->
+
+<xs:element name="emptyset" type="Constant.type"/>
+
+<!-- Basic constants -->
+
+<xs:element name="exponentiale" type="Constant.type"/>
+<xs:element name="imaginaryi" type="Constant.type"/>
+<xs:element name="pi" type="Constant.type"/>
+<xs:element name="eulergamma" type="Constant.type"/>
+
+<!-- Boolean constants -->
+
+<xs:element name="true" type="Constant.type"/>
+<xs:element name="false" type="Constant.type"/>
+
+<!-- Infinty -->
+
+<xs:element name="infinity" type="Constant.type"/>
+
+<!-- NotANumber -->
+
+<xs:element name="notanumber" type="Constant.type"/>
+
+<!-- And the group of everything -->
+
+<xs:group name="Content-constants.class">
+  <xs:choice>
+    <xs:element ref="naturalnumbers"/>
+    <xs:element ref="primes"/>
+    <xs:element ref="integers"/>
+    <xs:element ref="rationals"/>
+    <xs:element ref="reals"/>
+    <xs:element ref="complexes"/>
+    <xs:element ref="emptyset"/>
+    <xs:element ref="exponentiale"/>
+    <xs:element ref="imaginaryi"/>
+    <xs:element ref="pi"/>
+    <xs:element ref="eulergamma"/>
+    <xs:element ref="true"/>
+    <xs:element ref="false"/>
+    <xs:element ref="infinity"/>
+    <xs:element ref="notanumber"/>
+  </xs:choice>
+</xs:group>
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/constructs.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/constructs.xsd
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+
+<xs:annotation>
+  <xs:documentation>
+  This is an XML Schema module for the basic constructs of content MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- "apply" -->
+
+<xs:attributeGroup name="apply.attlist">
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="apply.content">
+  <xs:sequence>
+     <xs:group ref="Content-expr.class"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="apply.type">
+  <xs:group ref="apply.content"  minOccurs="0" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="apply.attlist"/>
+</xs:complexType>
+
+<xs:element name="apply" type="apply.type"/>
+
+<!-- "interval" -->
+
+<xs:attributeGroup name="interval.attlist">
+  <xs:attribute name="closure" default="closed">
+    <xs:simpleType>
+       <xs:restriction base="xs:string">
+          <xs:enumeration value="closed"/>
+          <xs:enumeration value="open"/>
+          <xs:enumeration value="open-closed"/>
+          <xs:enumeration value="closed-open"/>
+       </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<!--
+<xs:group name="interval.content">
+  <xs:choice>
+    <xs:group ref="Content-expr.class" minOccurs="2" maxOccurs="2"/>
+    <xs:element ref="condition"/>
+  </xs:choice>
+</xs:group>
+-->
+
+<xs:complexType name="interval.type">
+<!--  <xs:group ref="interval.content"/> -->
+  <xs:group ref="Content-expr.class" maxOccurs="2"/>
+  <xs:attributeGroup ref="interval.attlist"/>
+</xs:complexType>
+
+<xs:element name="interval" type="interval.type"/>
+
+<!-- "inverse" -->
+
+<xs:attributeGroup name="inverse.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="inverse.type">
+  <xs:attributeGroup ref="inverse.attlist"/>
+</xs:complexType>
+
+<xs:element name="inverse" type="inverse.type"/>
+
+<!-- "condition" -->
+
+<xs:attributeGroup name="condition.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="condition.content">
+  <xs:sequence>
+    <xs:group ref="Content-expr.class"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="condition.type">
+  <xs:group ref="condition.content"  minOccurs="1" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="condition.attlist"/>
+</xs:complexType>
+
+<xs:element name="condition" type="condition.type"/>
+
+<!-- "declare" -->
+
+<xs:attributeGroup name="declare.attlist">
+  <xs:attribute name="type" type="xs:string"/>
+  <xs:attribute name="scope" type="xs:string"/>
+  <xs:attribute name="nargs" type="xs:nonNegativeInteger"/>
+  <xs:attribute name="occurrence">
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="prefix"/>
+        <xs:enumeration value="infix"/>
+        <xs:enumeration value="function-model"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attributeGroup ref="Definition.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="declare.content">
+  <xs:sequence>
+    <xs:group ref="Content-expr.class"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="declare.type">
+  <xs:group ref="declare.content"  minOccurs="1" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="declare.attlist"/>
+</xs:complexType>
+
+<xs:element name="declare" type="declare.type"/>
+
+<!-- "lambda" -->
+
+<xs:attributeGroup name="lambda.attlist">
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="lambda.content">
+    <xs:sequence>
+      <xs:group ref="Content-expr.class"/>
+    </xs:sequence>
+</xs:group>
+
+<xs:complexType name="lambda.type">
+  <xs:group ref="lambda.content"  minOccurs="1" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="lambda.attlist"/>
+</xs:complexType>
+
+<xs:element name="lambda" type="lambda.type"/>
+
+<!-- "piecewise" and its inner elements -->
+
+<xs:group name="otherwise.content">
+  <xs:sequence>
+    <xs:group ref="Content-expr.class"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="otherwise.type">
+  <xs:group ref="otherwise.content"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:complexType>
+
+<xs:element name="otherwise" type="otherwise.type"/>
+
+<xs:group name="piece.content">
+  <xs:sequence>
+    <xs:group ref="Content-expr.class"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="piece.type">
+  <xs:group ref="piece.content" minOccurs="1" maxOccurs="unbounded"/>
+</xs:complexType>
+
+<xs:element name="piece" type="piece.type"/>
+
+<xs:attributeGroup name="piecewise.attlist">
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="piecewise.content">
+  <xs:sequence>
+    <xs:element ref="piece" minOccurs="0" maxOccurs="unbounded"/>
+    <xs:sequence minOccurs="0">
+      <xs:element ref="otherwise"/>
+      <xs:element ref="piece" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="piecewise.type">
+  <xs:group ref="piecewise.content"/>
+  <xs:attributeGroup ref="piecewise.attlist"/>
+</xs:complexType>
+
+<xs:element name="piecewise" type="piecewise.type"/>
+
+<!-- "bvar" -->
+
+<xs:attributeGroup name="bvar.attlist">
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="bvar.content">
+    <xs:sequence>
+      <xs:group ref="Content-expr.class"/>
+    </xs:sequence>
+</xs:group>
+
+<xs:complexType name="bvar.type">
+  <xs:group ref="bvar.content"  minOccurs="1" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="bvar.attlist"/>
+</xs:complexType>
+
+<xs:element name="bvar" type="bvar.type"/>
+
+<!-- "degree" -->
+
+<xs:attributeGroup name="degree.attlist">
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="degree.content">
+    <xs:sequence>
+      <xs:group ref="Content-expr.class"/>
+    </xs:sequence>
+</xs:group>
+
+<xs:complexType name="degree.type">
+  <xs:group ref="degree.content"  minOccurs="1" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="degree.attlist"/>
+</xs:complexType>
+
+<xs:element name="degree" type="degree.type"/>
+
+<!-- And the group of everything -->
+
+<xs:group name="Content-constructs.class">
+  <xs:choice>
+    <xs:element ref="apply"/>
+    <xs:element ref="interval"/>
+    <xs:element ref="inverse"/>
+    <xs:element ref="condition"/>
+    <xs:element ref="declare"/>
+    <xs:element ref="lambda"/>
+    <xs:element ref="piecewise"/>
+    <xs:element ref="bvar"/>
+    <xs:element ref="degree"/>
+  </xs:choice>
+</xs:group>
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/elementary-functions.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/elementary-functions.xsd
@@ -1,0 +1,117 @@
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+
+<xs:annotation>
+  <xs:documentation>
+  This is an XML Schema module for the elementary functions in content
+  MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- a common type for all this -->
+
+<xs:complexType name="Elementary-functions.type">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:complexType>
+
+<!-- Exp and logs -->
+
+<xs:element name="exp" type="Elementary-functions.type"/>
+<xs:element name="ln" type="Elementary-functions.type"/>
+<xs:element name="log" type="Elementary-functions.type"/>
+
+<!-- special element of the base of logarithms -->
+
+<xs:group name="logbase.content">
+  <xs:sequence>
+    <xs:group ref="Content-expr.class"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="logbase.type">
+  <xs:group ref="logbase.content"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:complexType>
+
+<xs:element name="logbase" type="logbase.type"/>
+
+<!-- Trigonometric functions -->
+
+<xs:element name="sin" type="Elementary-functions.type"/>
+<xs:element name="cos" type="Elementary-functions.type"/>
+<xs:element name="tan" type="Elementary-functions.type"/>
+<xs:element name="sec" type="Elementary-functions.type"/>
+<xs:element name="csc" type="Elementary-functions.type"/>
+<xs:element name="cot" type="Elementary-functions.type"/>
+
+<xs:element name="arcsin" type="Elementary-functions.type"/>
+<xs:element name="arccos" type="Elementary-functions.type"/>
+<xs:element name="arctan" type="Elementary-functions.type"/>
+<xs:element name="arccot" type="Elementary-functions.type"/>
+<xs:element name="arccsc" type="Elementary-functions.type"/>
+<xs:element name="arcsec" type="Elementary-functions.type"/>
+
+<!-- Hyperbolic trigonometric functions -->
+
+<xs:element name="sinh" type="Elementary-functions.type"/>
+<xs:element name="cosh" type="Elementary-functions.type"/>
+<xs:element name="tanh" type="Elementary-functions.type"/>
+<xs:element name="sech" type="Elementary-functions.type"/>
+<xs:element name="csch" type="Elementary-functions.type"/>
+<xs:element name="coth" type="Elementary-functions.type"/>
+<xs:element name="arccosh" type="Elementary-functions.type"/>
+<xs:element name="arccoth" type="Elementary-functions.type"/>
+<xs:element name="arccsch" type="Elementary-functions.type"/>
+<xs:element name="arcsech" type="Elementary-functions.type"/>
+<xs:element name="arcsinh" type="Elementary-functions.type"/>
+<xs:element name="arctanh" type="Elementary-functions.type"/>
+
+<!-- And the group of everything -->
+
+<xs:group name="Content-elementary-functions.class">
+  <xs:choice>
+    <xs:element ref="exp"/>
+    <xs:element ref="ln"/>
+    <xs:element ref="log"/>
+    <xs:element ref="logbase"/>
+    <xs:element ref="sin"/>
+    <xs:element ref="cos"/>
+    <xs:element ref="tan"/>
+    <xs:element ref="sec"/>
+    <xs:element ref="csc"/>
+    <xs:element ref="cot"/>
+    <xs:element ref="arcsin"/>
+    <xs:element ref="arccos"/>
+    <xs:element ref="arctan"/>
+    <xs:element ref="arcsec"/>
+    <xs:element ref="arccsc"/>
+    <xs:element ref="arccot"/>
+    <xs:element ref="sinh"/>
+    <xs:element ref="cosh"/>
+    <xs:element ref="tanh"/>
+    <xs:element ref="sech"/>
+    <xs:element ref="csch"/>
+    <xs:element ref="coth"/>
+    <xs:element ref="arccosh"/>
+    <xs:element ref="arccoth"/>
+    <xs:element ref="arccsch"/>
+    <xs:element ref="arcsech"/>
+    <xs:element ref="arcsinh"/>
+    <xs:element ref="arctanh"/>
+  </xs:choice>
+</xs:group>
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/functions.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/functions.xsd
@@ -1,0 +1,73 @@
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+
+<xs:annotation>
+  <xs:documentation>
+  This is an XML Schema module for operators dealing with functions in content
+  MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- a common type for all this -->
+
+<xs:complexType name="Functions.type">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:complexType>
+
+<!-- "compose" -->
+
+<xs:element name="compose" type="Functions.type"/>
+
+<!-- Domain, codomain and image -->
+
+<xs:element name="domain" type="Functions.type"/>
+<xs:element name="codomain" type="Functions.type"/>
+<xs:element name="image" type="Functions.type"/>
+
+<!-- "domainofapplication" -->
+
+<xs:group name="domainofapplication.content">
+  <xs:sequence>
+     <xs:group ref="Content-expr.class"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="domainofapplication.type">
+  <xs:group ref="domainofapplication.content"/>
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:complexType>
+
+<xs:element name="domainofapplication" type="domainofapplication.type"/>
+
+<!-- identity -->
+
+<xs:element name="ident" type="Functions.type"/>
+
+<!-- And the group of everything -->
+
+<xs:group name="Content-functions.class">
+  <xs:choice>
+    <xs:element ref="compose"/>
+    <xs:element ref="domain"/>
+    <xs:element ref="codomain"/>
+    <xs:element ref="image"/>
+    <xs:element ref="domainofapplication"/>
+    <xs:element ref="ident"/>
+  </xs:choice>
+</xs:group>
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/linear-algebra.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/linear-algebra.xsd
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is an XML Schema module for the linear algebra part of content MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- "vector" -->
+
+<xs:attributeGroup name="vector.attlist">
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="vector.content">
+  <xs:sequence>
+    <xs:group ref="Content-expr.class"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="vector.type">
+  <xs:group ref="vector.content" minOccurs="1" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="vector.attlist"/>
+</xs:complexType>
+
+<xs:element name="vector" type="vector.type"/>
+
+<!-- "matrix" -->
+
+<xs:attributeGroup name="matrix.attlist">
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="matrix.content">
+  <xs:sequence>
+    <xs:element ref="matrixrow"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="matrix.type">
+  <xs:group ref="matrix.content"  minOccurs="1" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="matrix.attlist"/>
+</xs:complexType>
+
+<xs:element name="matrix" type="matrix.type"/>
+
+<!-- "matrixrow" -->
+
+<xs:attributeGroup name="matrixrow.attlist">
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="matrixrow.content">
+  <xs:sequence>
+    <xs:group ref="Content-expr.class"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="matrixrow.type">
+  <xs:group ref="matrixrow.content"  minOccurs="1" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="matrixrow.attlist"/>
+</xs:complexType>
+
+<xs:element name="matrixrow" type="matrixrow.type"/>
+
+<!-- "determinant" -->
+
+<xs:attributeGroup name="determinant.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="determinant.type">
+  <xs:attributeGroup ref="determinant.attlist"/>
+</xs:complexType>
+
+<xs:element name="determinant" type="determinant.type"/>
+
+<!-- "transpose" -->
+
+<xs:attributeGroup name="transpose.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="transpose.type">
+  <xs:attributeGroup ref="transpose.attlist"/>
+</xs:complexType>
+
+<xs:element name="transpose" type="transpose.type"/>
+
+<!-- "selector" -->
+
+<xs:attributeGroup name="selector.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="selector.type">
+  <xs:attributeGroup ref="selector.attlist"/>
+</xs:complexType>
+
+<xs:element name="selector" type="selector.type"/>
+
+<!-- "vectorproduct" -->
+
+<xs:attributeGroup name="vectorproduct.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="vectorproduct.type">
+  <xs:attributeGroup ref="vectorproduct.attlist"/>
+</xs:complexType>
+
+<xs:element name="vectorproduct" type="vectorproduct.type"/>
+
+<!-- "scalarproduct" -->
+
+<xs:attributeGroup name="scalarproduct.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="scalarproduct.type">
+  <xs:attributeGroup ref="scalarproduct.attlist"/>
+</xs:complexType>
+
+<xs:element name="scalarproduct" type="scalarproduct.type"/>
+
+<!-- "outerproduct" -->
+
+<xs:attributeGroup name="outerproduct.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="outerproduct.type">
+  <xs:attributeGroup ref="outerproduct.attlist"/>
+</xs:complexType>
+
+<xs:element name="outerproduct" type="outerproduct.type"/>
+
+<!-- And the group of everything -->
+
+<xs:group name="Content-linear-algebra.class">
+  <xs:choice>
+     <xs:element ref="vector"/>
+     <xs:element ref="matrix"/>
+     <xs:element ref="determinant"/>
+     <xs:element ref="transpose"/>
+     <xs:element ref="selector"/>
+     <xs:element ref="vectorproduct"/>
+     <xs:element ref="scalarproduct"/>
+     <xs:element ref="outerproduct"/>
+  </xs:choice>
+</xs:group>
+</xs:schema>
+
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/logic.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/logic.xsd
@@ -1,0 +1,53 @@
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is an XML Schema module for the logic operators of content MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- a common type for all this -->
+
+<xs:complexType name="Logic.type">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:complexType>
+
+<xs:element name="and" type="Elementary-functions.type"/>
+<xs:element name="or" type="Logic.type"/>
+<xs:element name="xor" type="Logic.type"/>
+
+<xs:element name="not" type="Logic.type"/>
+
+<xs:element name="exists" type="Logic.type"/>
+<xs:element name="forall" type="Logic.type"/>
+
+<xs:element name="implies" type="Logic.type"/>
+
+<!-- And the group of everything -->
+
+<xs:group name="Content-logic.class">
+  <xs:choice>
+    <xs:element ref="and"/>
+    <xs:element ref="or"/>
+    <xs:element ref="xor"/>
+    <xs:element ref="not"/>
+    <xs:element ref="exists"/>
+    <xs:element ref="forall"/>
+    <xs:element ref="implies"/>
+  </xs:choice>
+</xs:group>
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/relations.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/relations.xsd
@@ -1,0 +1,55 @@
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is an XML Schema module for the relational operators of content MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- a common type for all this -->
+<xs:complexType name="Relations.type">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:complexType>
+
+<xs:element name="eq" type="Relations.type"/>
+<xs:element name="neq" type="Relations.type"/>
+<xs:element name="leq" type="Relations.type"/>
+<xs:element name="lt" type="Relations.type"/>
+<xs:element name="geq" type="Relations.type"/>
+<xs:element name="gt" type="Relations.type"/>
+
+<xs:element name="equivalent" type="Relations.type"/>
+
+<xs:element name="approx" type="Relations.type"/>
+
+<xs:element name="factorof" type="Relations.type"/>
+
+<!-- And the group of everything -->
+<xs:group name="Content-relations.class">
+  <xs:choice>
+    <xs:element ref="eq"/>
+    <xs:element ref="neq"/>
+    <xs:element ref="leq"/>
+    <xs:element ref="lt"/>
+    <xs:element ref="geq"/>
+    <xs:element ref="gt"/>
+    <xs:element ref="equivalent"/>
+    <xs:element ref="approx"/>
+    <xs:element ref="factorof"/>
+  </xs:choice>
+</xs:group>
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/semantics.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/semantics.xsd
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is an XML Schema module for the "sematics" element of content MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- "annotation" -->
+
+<xs:attributeGroup name="annotation.attlist">
+   <xs:attribute name="encoding" type="xs:string"/>
+   <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="annotation.type" mixed="true">
+  <xs:attributeGroup ref="annotation.attlist"/>
+</xs:complexType>
+
+<xs:element name="annotation" type="annotation.type"/>
+
+<!-- "annotation-xml" -->
+
+<xs:attributeGroup name="annotation-xml.attlist">
+   <xs:attribute name="encoding" type="xs:string"/>
+   <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="annotation-xml.content">
+   <xs:sequence>
+     <xs:any processContents="lax"/>    
+   </xs:sequence>
+</xs:group>
+
+<xs:complexType name="annotation-xml.type">
+   <xs:group ref="annotation-xml.content"/>
+   <xs:attributeGroup ref="annotation-xml.attlist"/>
+</xs:complexType>
+
+<xs:element name="annotation-xml" type="annotation-xml.type"/>
+
+<!-- "semantics" -->
+
+<xs:attributeGroup name="semantics.attlist">
+   <xs:attribute name="encoding" type="xs:string"/>
+   <xs:attribute name="definitionURL" type="xs:anyURI"/>
+   <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="Annotation.class">
+  <xs:choice>
+    <xs:element ref="annotation"/>
+    <xs:element ref="annotation-xml"/>
+  </xs:choice>
+</xs:group>
+
+<xs:group name="semantics.content">
+  <xs:sequence>
+    <xs:group ref="Content-expr.class"/>
+    <xs:group ref="Annotation.class" minOccurs="1" maxOccurs="unbounded"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="semantics.type">
+  <xs:group ref="semantics.content"  minOccurs="1" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="semantics.attlist"/>
+</xs:complexType>
+
+<xs:element name="semantics" type="semantics.type"/>
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/sets.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/sets.xsd
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is an XML Schema module for the part of content MathML dealing with
+  sets and lists.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- "set" -->
+
+<!-- "type" could be "multiset" or "normal" or anything else -->
+<xs:attributeGroup name="set.attlist">
+  <xs:attribute name="type" type="xs:string"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="set.content">
+  <xs:sequence>
+     <xs:group ref="Content-expr.class"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="set.type">
+  <xs:group ref="set.content"  minOccurs="0" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="set.attlist"/>
+</xs:complexType>
+
+<xs:element name="set" type="set.type"/>
+
+<!-- "list" -->
+
+<xs:attributeGroup name="list.attlist">
+  <xs:attribute name="order">
+    <xs:simpleType>
+       <xs:restriction base="xs:string">
+          <xs:enumeration value="lexicographic"/>
+          <xs:enumeration value="numeric"/>
+       </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="list.content">
+  <xs:sequence>
+     <xs:group ref="Content-expr.class"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="list.type">
+  <xs:group ref="list.content"  minOccurs="0" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="list.attlist"/>
+</xs:complexType>
+
+<xs:element name="list" type="list.type"/>
+
+<!-- "union" -->
+
+<xs:attributeGroup name="union.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="union.type">
+  <xs:attributeGroup ref="union.attlist"/>
+</xs:complexType>
+
+<xs:element name="union" type="union.type"/>
+
+<!-- "intersect" -->
+
+<xs:attributeGroup name="intersect.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="intersect.type">
+  <xs:attributeGroup ref="intersect.attlist"/>
+</xs:complexType>
+
+<xs:element name="intersect" type="intersect.type"/>
+
+<!-- "in" -->
+
+<xs:attributeGroup name="in.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="in.type">
+  <xs:attributeGroup ref="in.attlist"/>
+</xs:complexType>
+
+<xs:element name="in" type="in.type"/>
+
+<!-- "notin" -->
+
+<xs:attributeGroup name="notin.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="notin.type">
+  <xs:attributeGroup ref="notin.attlist"/>
+</xs:complexType>
+
+<xs:element name="notin" type="notin.type"/>
+
+<!-- "subset" -->
+
+<xs:attributeGroup name="subset.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="subset.type">
+  <xs:attributeGroup ref="subset.attlist"/>
+</xs:complexType>
+
+<xs:element name="subset" type="subset.type"/>
+
+<!-- "prsubset" -->
+
+<xs:attributeGroup name="prsubset.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="prsubset.type">
+  <xs:attributeGroup ref="prsubset.attlist"/>
+</xs:complexType>
+
+<xs:element name="prsubset" type="prsubset.type"/>
+
+<!-- "notsubset" -->
+
+<xs:attributeGroup name="notsubset.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="notsubset.type">
+  <xs:attributeGroup ref="notsubset.attlist"/>
+</xs:complexType>
+
+<xs:element name="notsubset" type="notsubset.type"/>
+
+<!-- "notprsubset" -->
+
+<xs:attributeGroup name="notprsubset.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="notprsubset.type">
+  <xs:attributeGroup ref="notprsubset.attlist"/>
+</xs:complexType>
+
+<xs:element name="notprsubset" type="notprsubset.type"/>
+
+<!-- "setdiff" -->
+
+<xs:attributeGroup name="setdiff.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="setdiff.type">
+  <xs:attributeGroup ref="setdiff.attlist"/>
+</xs:complexType>
+
+<xs:element name="setdiff" type="setdiff.type"/>
+
+<!-- "card" -->
+
+<xs:attributeGroup name="card.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="card.type">
+  <xs:attributeGroup ref="card.attlist"/>
+</xs:complexType>
+
+<xs:element name="card" type="card.type"/>
+
+<!-- "cartesianproduct" -->
+
+<xs:attributeGroup name="cartesianproduct.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="cartesianproduct.type">
+  <xs:attributeGroup ref="cartesianproduct.attlist"/>
+</xs:complexType>
+
+<xs:element name="cartesianproduct" type="cartesianproduct.type"/>
+
+<!-- And the group of everything -->
+
+<xs:group name="Content-sets.class">
+  <xs:choice>
+    <xs:element ref="set"/>
+    <xs:element ref="list"/>
+    <xs:element ref="union"/>
+    <xs:element ref="intersect"/>
+    <xs:element ref="in"/>
+    <xs:element ref="notin"/>
+    <xs:element ref="subset"/>
+    <xs:element ref="prsubset"/>
+    <xs:element ref="notsubset"/>
+    <xs:element ref="notprsubset"/>
+    <xs:element ref="setdiff"/>
+    <xs:element ref="card"/>
+    <xs:element ref="cartesianproduct"/>
+  </xs:choice>
+</xs:group>
+
+</xs:schema>
+
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/statistics.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/statistics.xsd
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is an XML Schema module for the statistical operators of content MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- "mean" -->
+
+<xs:attributeGroup name="mean.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="mean.type">
+  <xs:attributeGroup ref="mean.attlist"/>
+</xs:complexType>
+
+<xs:element name="mean" type="mean.type"/>
+
+<!-- "sdev" -->
+
+<xs:attributeGroup name="sdev.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="sdev.type">
+  <xs:attributeGroup ref="sdev.attlist"/>
+</xs:complexType>
+
+<xs:element name="sdev" type="sdev.type"/>
+
+<!-- "variance" -->
+
+<xs:attributeGroup name="variance.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="variance.type">
+  <xs:attributeGroup ref="variance.attlist"/>
+</xs:complexType>
+
+<xs:element name="variance" type="variance.type"/>
+
+<!-- "median" -->
+
+<xs:attributeGroup name="median.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="median.type">
+  <xs:attributeGroup ref="median.attlist"/>
+</xs:complexType>
+
+<xs:element name="median" type="median.type"/>
+
+<!-- "mode" -->
+
+<xs:attributeGroup name="mode.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="mode.type">
+  <xs:attributeGroup ref="mode.attlist"/>
+</xs:complexType>
+
+<xs:element name="mode" type="mode.type"/>
+
+<!-- "moment" -->
+
+<xs:attributeGroup name="moment.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="moment.type">
+  <xs:attributeGroup ref="moment.attlist"/>
+</xs:complexType>
+
+<xs:element name="moment" type="moment.type"/>
+
+<!-- "momentabout" -->
+
+<xs:attributeGroup name="momentabout.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="momentabout.content">
+  <xs:sequence>
+    <xs:group ref="Content-expr.class"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="momentabout.type">
+  <xs:group ref="momentabout.content"  minOccurs="1" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="momentabout.attlist"/>
+</xs:complexType>
+
+<xs:element name="momentabout" type="momentabout.type"/>
+
+<!-- And the group of everything -->
+
+<xs:group name="Content-statistics.class">
+  <xs:choice>
+    <xs:element ref="mean"/>
+    <xs:element ref="sdev"/>
+    <xs:element ref="variance"/>
+    <xs:element ref="median"/>
+    <xs:element ref="mode"/>
+    <xs:element ref="moment"/>
+    <xs:element ref="momentabout"/>
+  </xs:choice>
+</xs:group>
+
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/tokens.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/tokens.xsd
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is the XML schema module for the token elements of the 
+  content part of MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- common content for the token elements -->
+
+<xs:group name="Content-token.content">
+  <xs:sequence>
+    <xs:group ref="Presentation-expr.class"/>
+  </xs:sequence>
+</xs:group>
+
+<!-- "cn" -->
+
+<xs:attributeGroup name="cn.attlist">
+  <xs:attribute name="base">
+    <xs:simpleType>
+      <xs:restriction base="xs:positiveInteger">
+         <xs:minInclusive value="2"/>
+         <xs:maxInclusive value="36"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>  
+  <xs:attribute name="type">
+    <xs:simpleType>
+      <xs:restriction base="xs:NMTOKEN">
+        <xs:enumeration value="e-notation"/>
+        <xs:enumeration value="integer"/>
+        <xs:enumeration value="rational"/>
+        <xs:enumeration value="real"/>
+        <xs:enumeration value="complex-cartesian"/>
+        <xs:enumeration value="complex-polar"/>
+        <xs:enumeration value="constant"/>
+      </xs:restriction>
+     </xs:simpleType>
+  </xs:attribute>
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<!-- the content of "cn" may have <sep> elements in it -->
+
+<xs:complexType name="sep.type">
+</xs:complexType>
+
+<xs:element name="sep" type="sep.type"/>
+
+<xs:group name="cn.content">
+  <xs:choice>
+    <xs:group ref="Presentation-expr.class"/>
+    <xs:element ref="sep"/>
+  </xs:choice>
+</xs:group>
+
+<xs:complexType name="cn.type" mixed="true">
+  <xs:group ref="cn.content" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="cn.attlist"/>
+</xs:complexType>
+
+<xs:element name="cn" type="cn.type"/>
+
+<!-- "ci" -->
+
+<xs:attributeGroup name="ci.attlist">
+  <xs:attribute name="type" type="xs:string"/>
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="ci.type" mixed="true">
+  <xs:group ref="Content-token.content" minOccurs="0"/>
+  <xs:attributeGroup ref="ci.attlist"/>
+</xs:complexType>
+
+<xs:element name="ci" type="ci.type"/>
+
+<!-- "csymbol" -->
+
+<xs:attributeGroup name="csymbol.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="csymbol.type" mixed="true">
+  <xs:group ref="Content-token.content" minOccurs="0"/>
+  <xs:attributeGroup ref="csymbol.attlist"/>
+</xs:complexType>
+
+<xs:element name="csymbol" type="csymbol.type"/>
+
+<!-- And the group of everything -->
+
+<xs:group name="Content-tokens.class">
+  <xs:choice>
+    <xs:element ref="cn"/>
+    <xs:element ref="ci"/>
+    <xs:element ref="csymbol"/>
+  </xs:choice>
+</xs:group>
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/vector-calculus.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/vector-calculus.xsd
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is an XML Schema module for the vector calculs operators of content
+  MathML. 
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- "divergence" -->
+
+<xs:attributeGroup name="divergence.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="divergence.type">
+  <xs:attributeGroup ref="divergence.attlist"/>
+</xs:complexType>
+
+<xs:element name="divergence" type="divergence.type"/>
+
+<!-- "grad" -->
+
+<xs:attributeGroup name="grad.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="grad.type">
+  <xs:attributeGroup ref="grad.attlist"/>
+</xs:complexType>
+
+<xs:element name="grad" type="grad.type"/>
+
+<!-- "curl" -->
+
+<xs:attributeGroup name="curl.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="curl.type">
+  <xs:attributeGroup ref="curl.attlist"/>
+</xs:complexType>
+
+<xs:element name="curl" type="curl.type"/>
+
+<!-- "laplacian" -->
+
+<xs:attributeGroup name="laplacian.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="laplacian.type">
+  <xs:attributeGroup ref="laplacian.attlist"/>
+</xs:complexType>
+
+<xs:element name="laplacian" type="laplacian.type"/>
+
+<!-- And the group of everything -->
+
+<xs:group name="Content-vector-calculus.class">
+  <xs:choice>
+    <xs:element ref="divergence"/>
+    <xs:element ref="grad"/>
+    <xs:element ref="curl"/>
+    <xs:element ref="laplacian"/>
+  </xs:choice>
+</xs:group>
+
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/zzz.tokens.xsd.from.zip
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/content/zzz.tokens.xsd.from.zip
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is the XML schema module for the token elements of the 
+  content part of MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- common content for the token elements -->
+
+<xs:group name="Content-token.content">
+  <xs:sequence>
+    <xs:group ref="Presentation-expr.class"/>
+  </xs:sequence>
+</xs:group>
+
+<!-- "cn" -->
+
+<xs:attributeGroup name="cn.attlist">
+  <xs:attribute name="base">
+    <xs:simpleType>
+      <xs:restriction base="xs:positiveInteger">
+         <xs:minInclusive value="2"/>
+         <xs:maxInclusive value="36"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>  
+  <xs:attribute name="type">
+    <xs:simpleType>
+      <xs:restriction base="xs:NMTOKEN">
+        <xs:enumeration value="e-notation"/>
+        <xs:enumeration value="integer"/>
+        <xs:enumeration value="rational"/>
+        <xs:enumeration value="real"/>
+        <xs:enumeration value="complex-cartesian"/>
+        <xs:enumeration value="complex-polar"/>
+        <xs:enumeration value="constant"/>
+      </xs:restriction>
+     </xs:simpleType>
+  </xs:attribute>
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<!-- the content of "cn" may have <sep> elements in it -->
+
+<xs:complexType name="sep.type">
+</xs:complexType>
+
+<xs:element name="sep" type="sep.type"/>
+
+<xs:group name="cn.content">
+  <xs:choice>
+    <xs:group ref="Presentation-expr.class"/>
+    <xs:element ref="sep"/>
+  </xs:choice>
+</xs:group>
+
+<xs:complexType name="cn.type" mixed="true">
+  <xs:group ref="cn.content" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="cn.attlist"/>
+</xs:complexType>
+
+<xs:element name="cn" type="cn.type"/>
+
+<!-- "ci" -->
+
+<xs:attributeGroup name="ci.attlist">
+  <xs:attribute name="type" type="xs:string"/>
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="ci.type" mixed="true">
+  <xs:group ref="Content-token.content" minOccurs="0"/>
+  <xs:attributeGroup ref="ci.attlist"/>
+</xs:complexType>
+
+<xs:element name="ci" type="ci.type"/>
+
+<!-- "csymbol" -->
+
+<xs:attributeGroup name="csymbol.attlist">
+  <xs:attributeGroup ref="Definition.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="csymbol.type" mixed="true">
+  <xs:group ref="Content-token.content" minOccurs="0"/>
+  <xs:attributeGroup ref="csymbol.attlist"/>
+</xs:complexType>
+
+<xs:element name="csymbol" type="csymbol.type"/>
+
+<!-- And the group of everything -->
+
+<xs:group name="Content-tokens.class">
+  <xs:choice>
+    <xs:element ref="cn"/>
+    <xs:element ref="ci"/>
+    <xs:element ref="csymbol"/>
+  </xs:choice>
+</xs:group>
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/mathml2.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/mathml2.xsd
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+<xs:annotation>
+  <xs:documentation>
+  This is an XML Schema for MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- common stuff -->
+
+<xs:include schemaLocation="common/math.xsd"/>
+<xs:include schemaLocation="common/common-attribs.xsd"/>
+
+<!-- Presentation -->
+<xs:include schemaLocation="presentation/common-types.xsd"/>
+<xs:include schemaLocation="presentation/common-attribs.xsd"/>
+<xs:include schemaLocation="presentation/characters.xsd"/>
+<xs:include schemaLocation="presentation/tokens.xsd"/>
+<xs:include schemaLocation="presentation/scripts.xsd"/>
+<xs:include schemaLocation="presentation/space.xsd"/>
+<xs:include schemaLocation="presentation/layout.xsd"/>
+<xs:include schemaLocation="presentation/table.xsd"/>
+<xs:include schemaLocation="presentation/style.xsd"/>
+<xs:include schemaLocation="presentation/error.xsd"/>
+<xs:include schemaLocation="presentation/action.xsd"/>
+
+<!-- Content -->
+
+<xs:include schemaLocation="content/common-attrib.xsd"/>
+<xs:include schemaLocation="content/tokens.xsd"/>
+<xs:include schemaLocation="content/arith.xsd"/>
+<xs:include schemaLocation="content/functions.xsd"/>
+<xs:include schemaLocation="content/logic.xsd"/>
+<xs:include schemaLocation="content/constructs.xsd"/>
+<xs:include schemaLocation="content/constants.xsd"/>
+<xs:include schemaLocation="content/elementary-functions.xsd"/>
+<xs:include schemaLocation="content/relations.xsd"/>
+<xs:include schemaLocation="content/semantics.xsd"/>
+<xs:include schemaLocation="content/sets.xsd"/>
+<xs:include schemaLocation="content/linear-algebra.xsd"/>
+<xs:include schemaLocation="content/calculus.xsd"/>
+<xs:include schemaLocation="content/vector-calculus.xsd"/>
+<xs:include schemaLocation="content/statistics.xsd"/>
+
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/action.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/action.xsd
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is the XML Schema module for the MathML "maction" element.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<xs:attributeGroup name="maction.attlist">
+  <xs:attribute name="actiontype" type="xs:string" use="required"/>
+  <xs:attribute name="selection"  type="xs:positiveInteger" default="1"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="maction.content">
+  <xs:sequence>
+    <xs:group ref="Presentation-expr.class"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="maction.type">
+  <xs:group ref="maction.content" minOccurs="1" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="maction.attlist"/>
+</xs:complexType>
+
+<xs:element name="maction" type="maction.type"/>
+
+</xs:schema>
+
+
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/characters.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/characters.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is the XML Schema module for the MathML "mglyph" element.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<xs:attributeGroup name="mglyph.attlist">
+  <xs:attribute name="alt" type="xs:string"/>
+  <xs:attribute name="fontfamily" type="xs:string"/>
+  <xs:attribute name="index" type="xs:positiveInteger"/>
+</xs:attributeGroup>
+
+<xs:complexType name="mglyph.type">
+  <xs:attributeGroup ref="mglyph.attlist"/>
+</xs:complexType>
+
+<xs:element name="mglyph" type="mglyph.type"/>
+
+</xs:schema>
+
+
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/common-attribs.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/common-attribs.xsd
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This schema module defines sets of attributes common to several elements
+  of presentation MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- The mathematics style attributes. These attributes are valid on all
+     presentation token elements except "mspace" and "mglyph", and on no
+     other elements except "mstyle". -->
+
+<xs:attributeGroup name="Token-style.attrib">
+   <xs:attribute name="mathvariant">
+     <xs:simpleType>
+       <xs:restriction base="xs:string">
+           <xs:enumeration value="normal"/>
+           <xs:enumeration value="bold"/>
+           <xs:enumeration value="italic"/>
+           <xs:enumeration value="bold-italic"/>
+           <xs:enumeration value="double-struck"/>
+           <xs:enumeration value="bold-fraktur"/>
+           <xs:enumeration value="script"/>
+           <xs:enumeration value="bold-script"/>
+           <xs:enumeration value="fraktur"/>
+           <xs:enumeration value="sans-serif"/>
+           <xs:enumeration value="bold-sans-serif"/>
+           <xs:enumeration value="sans-serif-italic"/>
+           <xs:enumeration value="sans-serif-bold-italic"/>
+           <xs:enumeration value="monospace"/>
+       </xs:restriction>
+     </xs:simpleType>
+   </xs:attribute>
+   <xs:attribute name="mathsize">
+     <xs:simpleType>
+       <xs:union memberTypes="simple-size length-with-unit"/>
+     </xs:simpleType>
+   </xs:attribute>
+   <!-- For both of the following attributes the types should be
+        more restricted -->
+   <xs:attribute name="mathcolor" type="xs:string"/>
+   <xs:attribute name="mathbackground" type="xs:string"/>
+</xs:attributeGroup>
+
+<!-- These operators are all related to operators. They are valid on "mo" 
+     and "mstyle". -->
+
+<xs:attributeGroup name="Operator.attrib">
+   <!-- this attribute value is normally inferred from the position of
+    the operator in its "<mrow"> -->
+   <xs:attribute name="form">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="prefix"/>
+          <xs:enumeration value="infix"/>
+          <xs:enumeration value="postfix"/>
+        </xs:restriction>
+      </xs:simpleType>
+   </xs:attribute>
+   <!-- set by dictionnary, else it is "thickmathspace" -->
+   <xs:attribute name="lspace">
+      <xs:simpleType>
+         <xs:union memberTypes="length-with-unit named-space"/>
+      </xs:simpleType>
+   </xs:attribute>    
+   <!-- set by dictionnary, else it is "thickmathspace" -->
+   <xs:attribute name="rspace">
+      <xs:simpleType>
+         <xs:union memberTypes="length-with-unit named-space"/>
+      </xs:simpleType>
+   </xs:attribute>
+   <!-- set by dictionnary, else it is "false" -->
+   <xs:attribute name="fence" type="xs:boolean"/>
+   <!-- set by dictionnary, else it is "false" -->
+   <xs:attribute name="separator" type="xs:boolean"/>
+   <!-- set by dictionnary, else it is "false" -->
+   <xs:attribute name="stretchy" type="xs:boolean"/>
+   <!-- set by dictionnary, else it is "true" -->
+   <xs:attribute name="symmetric" type="xs:boolean"/>
+   <!-- set by dictionnary, else it is "false" -->
+   <xs:attribute name="movablelimits" type="xs:boolean"/>
+   <!-- set by dictionnary, else it is "false" -->
+   <xs:attribute name="accent" type="xs:boolean"/>
+   <!-- set by dictionnary, else it is "false" -->
+   <xs:attribute name="largeop" type="xs:boolean"/>
+   <xs:attribute name="minsize">
+      <xs:simpleType>
+         <xs:union memberTypes="length-with-unit named-space"/>
+      </xs:simpleType>
+   </xs:attribute>
+   <xs:attribute name="maxsize">
+      <xs:simpleType>
+         <xs:union memberTypes="length-with-unit named-space infinity xs:float"/>
+      </xs:simpleType>
+   </xs:attribute>
+</xs:attributeGroup>
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/common-types.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/common-types.xsd
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is an XML Schema module containing some type definitions for MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- Simple sizes -->
+
+<xs:simpleType name="simple-size">
+  <xs:restriction base="xs:string">
+    <xs:enumeration value="small"/>
+    <xs:enumeration value="normal"/>
+    <xs:enumeration value="big"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<!-- Centering values -->
+
+<xs:simpleType name="centering">
+  <xs:restriction base="xs:string">
+    <xs:enumeration value="left"/>
+    <xs:enumeration value="center"/>
+    <xs:enumeration value="right"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<!-- The named spaces -->
+
+<!-- this is also used in the value of the "width" attribute on the
+     "mpadded" element -->
+<xs:simpleType name="named-space">
+   <xs:restriction base="xs:string">
+     <xs:enumeration value="veryverythinmathspace"/>
+     <xs:enumeration value="verythinmathspace"/>
+     <xs:enumeration value="thinmathspace"/>
+     <xs:enumeration value="mediummathspace"/>
+     <xs:enumeration value="thickmathspace"/>
+     <xs:enumeration value="verythickmathspace"/>
+     <xs:enumeration value="veryverythickmathspace"/>
+   </xs:restriction>
+</xs:simpleType>
+
+<!-- Thickness -->
+
+<xs:simpleType name="thickness">
+  <xs:restriction base="xs:string">
+    <xs:enumeration value="thin"/>
+    <xs:enumeration value="medium"/>
+    <xs:enumeration value="thick"/>
+  </xs:restriction>
+</xs:simpleType>
+
+
+<!-- number with units used to specified lengths -->
+
+<xs:simpleType name="length-with-unit">
+  <xs:restriction base="xs:string">
+    <xs:pattern 
+     value="(-?([0-9]+|[0-9]*\.[0-9]+)*(em|ex|px|in|cm|mm|pt|pc|%))|0"/>
+   </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="length-with-optional-unit">
+  <xs:restriction base="xs:string">
+    <xs:pattern 
+      value="-?([0-9]+|[0-9]*\.[0-9]+)*(em|ex|px|in|cm|mm|pt|pc|%)?"/>
+   </xs:restriction>
+</xs:simpleType>
+
+<!-- This is just "infinity" that can be used as a length -->
+
+<xs:simpleType name="infinity">
+  <xs:restriction base="xs:string">
+    <xs:enumeration value="infinity"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<!-- colors defined as RGB -->
+
+<xs:simpleType name="RGB-color">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="#(([0-9]|[a-f]){3}|([0-9]|[a-f]){6})"/>
+  </xs:restriction>
+</xs:simpleType>
+
+</xs:schema>
+
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/error.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/error.xsd
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is the XML Schema module for the MathML "merror" element.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<xs:attributeGroup name="merror.attlist">
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="merror.content">
+  <xs:sequence>
+    <xs:group ref="Presentation-expr.class"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="merror.type">
+  <xs:group ref="merror.content" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="merror.attlist"/>
+</xs:complexType>
+
+<xs:element name="merror" type="merror.type"/>
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/layout.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/layout.xsd
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+<xs:annotation>
+  <xs:documentation>
+  This is the XML schema module for the layout elements of the 
+  presentation part of MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- "mrow" -->
+
+<xs:attributeGroup name="mrow.attlist">
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="mrow.type">
+  <xs:group ref="Presentation-expr.class" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="mrow.attlist"/>
+</xs:complexType>
+
+<xs:element name="mrow" type="mrow.type"/>
+
+<!-- "mfrac" -->
+
+<xs:attributeGroup name="mfrac.attlist">
+  <xs:attribute name="bevelled" type="xs:boolean"/>
+  <xs:attribute name="denomalign" type="centering" default="center"/>
+  <xs:attribute name="numalign" type="centering" default="center"/>
+  <xs:attribute name="linethickness" default="1">
+    <xs:simpleType>
+      <xs:union memberTypes="length-with-optional-unit thickness"/>
+    </xs:simpleType> 
+  </xs:attribute>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="mfrac.type">
+  <xs:group ref="Presentation-expr.class" minOccurs="2" maxOccurs="2"/>
+  <xs:attributeGroup ref="mfrac.attlist"/>
+</xs:complexType>
+
+<xs:element name="mfrac" type="mfrac.type"/>
+
+<!-- "msqrt" -->
+
+<xs:attributeGroup name="msqrt.attlist">
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<!-- "msqrt" has an "inferred mrow" if more than one argument -->
+<xs:complexType name="msqrt.type">
+  <xs:group ref="Presentation-expr.class" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="msqrt.attlist"/>  
+</xs:complexType>
+
+<xs:element name="msqrt" type="msqrt.type"/>
+
+<!-- "mroot" -->
+
+<xs:attributeGroup name="mroot.attlist">
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="mroot.type">
+  <xs:group ref="Presentation-expr.class" minOccurs="2" maxOccurs="2"/>
+  <xs:attributeGroup ref="mroot.attlist"/>
+</xs:complexType>
+
+<xs:element name="mroot" type="mroot.type"/>
+
+<!-- "mpadded" -->
+
+<xs:simpleType name="mpadded-space">
+  <xs:restriction base="xs:string">
+    <xs:pattern
+value="(\+|-)?([0-9]+|[0-9]*\.[0-9]+)(((%?) *(width|lspace|height|depth))|(em|ex|px|in|cm|mm|pt|pc))"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="mpadded-width-space">
+  <xs:restriction base="xs:string">
+    <!-- MaxF: definition from spec seems wrong, fixing to ([+|-] unsigned-number (%[pseudo-unit]|pseudo-unit|h-unit)) | namedspace | 0 -->
+    <xs:pattern value="((\+|-)?([0-9]+|[0-9]*\.[0-9]+)(((%?) *(width|lspace|height|depth)?)|(width|lspace|height|depth)|(em|ex|px|in|cm|mm|pt|pc)))|((veryverythin|verythin|thin|medium|thick|verythick|veryverythick)mathspace)|0"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:attributeGroup name="mpadded.attlist">
+  <xs:attribute name="width" type="mpadded-width-space"/>
+  <!-- should have default=0 below but '0' is not in value space -->
+  <!-- see bug #425 -->
+  <xs:attribute name="lspace" type="mpadded-space"/>
+  <xs:attribute name="height" type="mpadded-space"/>
+  <xs:attribute name="depth" type="mpadded-space"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="mpadded.type">
+  <xs:group ref="Presentation-expr.class" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="mpadded.attlist"/>
+</xs:complexType>
+
+<xs:element name="mpadded" type="mpadded.type"/>
+
+<!-- "mphantom" -->
+
+<xs:attributeGroup name="mphantom.attlist">
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="mphantom.type">
+  <xs:group ref="Presentation-expr.class" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="mphantom.attlist"/>
+</xs:complexType>
+
+<xs:element name="mphantom" type="mphantom.type"/>
+
+<!-- "mfenced" -->
+
+<xs:attributeGroup name="mfenced.attlist">
+  <xs:attribute name="open" type="xs:string" default="("/>
+  <xs:attribute name="close" type="xs:string" default=")"/>
+  <xs:attribute name="separators" type="xs:string" default=","/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="mfenced.type">
+  <xs:group ref="Presentation-expr.class" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="mfenced.attlist"/>
+</xs:complexType>
+
+<xs:element name="mfenced" type="mfenced.type"/>
+
+<!-- "menclose" -->
+
+<xs:attributeGroup name="menclose.attlist">
+  <xs:attribute name="notation" default="longdiv">
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="actuarial"/>
+        <xs:enumeration value="longdiv"/>
+        <xs:enumeration value="radical"/>
+        <xs:enumeration value="box"/>
+        <xs:enumeration value="roundedbox"/>
+        <xs:enumeration value="circle"/>
+        <xs:enumeration value="left"/>
+        <xs:enumeration value="right"/>
+        <xs:enumeration value="top"/>
+        <xs:enumeration value="bottom"/>
+        <xs:enumeration value="updiagonalstrike"/>
+        <xs:enumeration value="downdiagonalstrike"/>
+        <xs:enumeration value="verticalstrike"/>
+        <xs:enumeration value="horizontalstrike"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="menclose.type">
+  <xs:group ref="Presentation-expr.class" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="menclose.attlist"/>
+</xs:complexType>
+
+<xs:element name="menclose" type="menclose.type"/>
+
+<!-- And the group of everything -->
+
+<xs:group name="Presentation-layout.class">
+  <xs:choice> 
+    <xs:element ref="mrow"/>
+    <xs:element ref="mfrac"/>
+    <xs:element ref="msqrt"/>
+    <xs:element ref="mroot"/>
+    <xs:element ref="mpadded"/>
+    <xs:element ref="mphantom"/>
+    <xs:element ref="mfenced"/>
+    <xs:element ref="menclose"/>
+  </xs:choice>
+</xs:group>
+
+</xs:schema>
+
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/scripts.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/scripts.xsd
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is an XML Schema module for the presentation elements of MathML
+  dealing with subscripts and superscripts.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- "msub" -->
+
+<xs:attributeGroup name="msub.attlist">
+  <xs:attribute name="subscriptshift" type="length-with-unit"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="msub.type">
+  <xs:group ref="Presentation-expr.class" minOccurs="2" maxOccurs="2"/>
+  <xs:attributeGroup ref="msub.attlist"/>
+</xs:complexType>
+
+<xs:element name="msub" type="msub.type"/>
+
+<!-- "msup" -->
+
+<xs:attributeGroup name="msup.attlist">
+  <xs:attribute name="superscriptshift" type="length-with-unit"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="msup.type">
+  <xs:group ref="Presentation-expr.class" minOccurs="2" maxOccurs="2"/>
+  <xs:attributeGroup ref="msup.attlist"/>
+</xs:complexType>
+
+<xs:element name="msup" type="msup.type"/>
+
+<!-- "msubsup" -->
+
+<xs:attributeGroup name="msubsup.attlist">
+  <xs:attribute name="subscriptshift" type="length-with-unit"/>
+  <xs:attribute name="superscriptshift" type="length-with-unit"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="msubsup.type">
+  <xs:group ref="Presentation-expr.class" minOccurs="3" maxOccurs="3"/>
+  <xs:attributeGroup ref="msubsup.attlist"/>
+</xs:complexType>
+
+<xs:element name="msubsup" type="msubsup.type"/>
+
+<!-- "munder" -->
+
+<xs:attributeGroup name="munder.attlist">
+  <xs:attribute name="accentunder" type="xs:boolean"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="munder.type">
+  <xs:group ref="Presentation-expr.class" minOccurs="2" maxOccurs="2"/>
+  <xs:attributeGroup ref="munder.attlist"/>
+</xs:complexType>
+
+<xs:element name="munder" type="munder.type"/>
+
+<!-- "mover" -->
+
+<xs:attributeGroup name="mover.attlist">
+  <xs:attribute name="accent" type="xs:boolean"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="mover.type">
+  <xs:group ref="Presentation-expr.class" minOccurs="2" maxOccurs="2"/>
+  <xs:attributeGroup ref="mover.attlist"/>
+</xs:complexType>
+
+<xs:element name="mover" type="mover.type"/>
+
+<!-- "munderover" -->
+
+<xs:attributeGroup name="munderover.attlist">
+  <xs:attribute name="accent" type="xs:boolean"/>
+  <xs:attribute name="accentunder" type="xs:boolean"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="munderover.type">
+  <xs:group ref="Presentation-expr.class" minOccurs="3" maxOccurs="3"/>
+  <xs:attributeGroup ref="munderover.attlist"/>
+</xs:complexType>
+
+<xs:element name="munderover" type="munderover.type"/>
+
+<!-- "mmultiscripts", "mprescripts" and "none" -->
+
+<xs:attributeGroup name="mmultiscripts.attlist">
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="Presentation-expr-or-none.class">
+  <xs:choice>
+    <xs:group ref="Presentation-expr.class"/>
+    <xs:element ref="none"/>
+  </xs:choice>
+</xs:group>
+
+<!-- not used
+<xs:group name="mprescripts.group">
+  <xs:sequence>
+     <xs:element ref="mprescripts"/>
+     <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:group ref="Presentation-expr.class"/>
+        <xs:element ref="none"/>
+     </xs:choice>
+  </xs:sequence>
+</xs:group>
+-->
+
+<xs:group name="mmultiscripts.content">
+  <xs:sequence>
+    <xs:group ref="Presentation-expr.class"/>
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="Presentation-expr-or-none.class"/>
+      <xs:group ref="Presentation-expr-or-none.class"/>
+    </xs:sequence>
+    <xs:sequence minOccurs="0">
+      <xs:element ref="mprescripts"/>
+      <xs:sequence maxOccurs="unbounded">
+        <xs:group ref="Presentation-expr-or-none.class"/>
+        <xs:group ref="Presentation-expr-or-none.class"/>
+      </xs:sequence>
+    </xs:sequence>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="mmultiscripts.type">
+  <xs:group ref="mmultiscripts.content"/>
+  <xs:attributeGroup ref="mmultiscripts.attlist"/>
+</xs:complexType>
+
+<xs:element name="mmultiscripts" type="mmultiscripts.type"/>
+
+<!-- Nothing... -->
+<xs:complexType name="none.type">
+</xs:complexType>
+
+<xs:element name="none" type="none.type"/>
+
+<!-- also void -->
+<xs:complexType name="mprescripts.type">
+</xs:complexType>
+
+<xs:element name="mprescripts" type="mprescripts.type"/>
+
+<!-- And the group of everything -->
+
+<xs:group name="Presentation-script.class">
+  <xs:choice>
+    <xs:element ref="msub"/>
+    <xs:element ref="msup"/>
+    <xs:element ref="msubsup"/>
+    <xs:element ref="munder"/>
+    <xs:element ref="mover"/>
+    <xs:element ref="munderover"/>
+    <xs:element ref="mmultiscripts"/>
+  </xs:choice>
+</xs:group>
+
+</xs:schema>
+
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/space.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/space.xsd
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is the XML Schema module for the MathML "mspace" element.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<xs:attributeGroup name="mspace.attlist">
+  <xs:attribute name="width" default="0em">
+    <xs:simpleType>
+      <xs:union memberTypes="length-with-unit named-space"/>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="height" type="length-with-unit" default="0ex"/>
+  <xs:attribute name="depth" type="length-with-unit" default="0ex"/>
+  <xs:attribute name="linebreak" default="auto">
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="auto"/>
+        <xs:enumeration value="newline"/>
+        <xs:enumeration value="indentingnewline"/>
+        <xs:enumeration value="nobreak"/>
+        <xs:enumeration value="goodbreak"/>
+        <xs:enumeration value="badbreak"/>
+     </xs:restriction>
+   </xs:simpleType>
+  </xs:attribute>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="mspace.type">
+  <xs:attributeGroup ref="mspace.attlist"/>
+</xs:complexType>
+
+<xs:element name="mspace" type="mspace.type"/>
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/style.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/style.xsd
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is an XML Schema for the "mstyle" element of MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- "mstyle" -->
+
+<xs:attributeGroup name="mstyle.attlist">
+  <xs:attribute name="scriptlevel" type="xs:integer"/>
+  <xs:attribute name="displaystyle" type="xs:boolean"/>
+  <xs:attribute name="scriptsizemultiplier" type="xs:decimal" default="0.71"/>
+  <xs:attribute name="scriptminsize" type="length-with-unit" default="8pt"/>
+  <xs:attribute name="color" type="xs:string"/>
+  <xs:attribute name="background" type="xs:string" default="transparent"/>
+  <xs:attribute name="veryverythinmathspace" type="length-with-unit"
+                default="0.0555556em"/>
+  <xs:attribute name="verythinmathspace" type="length-with-unit"
+                default="0.111111em"/>
+  <xs:attribute name="thinmathspace" type="length-with-unit"
+                default="0.166667em"/>
+  <xs:attribute name="mediummathspace" type="length-with-unit"
+                default="0.222222em"/>
+  <xs:attribute name="thickmathspace" type="length-with-unit"
+                default="0.277778em"/>
+  <xs:attribute name="verythickmathspace" type="length-with-unit"
+                default="0.333333em"/>
+  <xs:attribute name="veryverythickmathspace" type="length-with-unit"
+                default="0.388889em"/>
+  <xs:attribute name="linethickness" default="1">
+    <xs:simpleType>
+      <xs:union memberTypes="length-with-optional-unit thickness"/>
+    </xs:simpleType> 
+  </xs:attribute>
+  <xs:attributeGroup ref="Operator.attrib"/>
+  <xs:attributeGroup ref="Token-style.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="mstyle.content">
+  <xs:sequence>
+    <xs:group ref="Presentation-expr.class"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="mstyle.type">
+  <xs:group ref="mstyle.content" minOccurs="1" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="mstyle.attlist"/>
+</xs:complexType>
+
+<xs:element name="mstyle" type="mstyle.type"/>
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/table.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/table.xsd
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+  >
+
+<xs:annotation>
+  <xs:documentation>
+  This is an XML Schema module for tables in MathML presentation.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- Common attributes -->
+
+<xs:attributeGroup name="Table-alignment.attrib">
+  <xs:attribute name="rowalign" default="baseline">
+    <xs:simpleType> 
+      <xs:restriction base="xs:string">
+        <xs:pattern value="(top|bottom|center|baseline|axis)( top| bottom| center| baseline| axis)*"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="columnalign" default="center">
+    <xs:simpleType> 
+      <xs:restriction base="xs:string">
+        <xs:pattern value="(left|center|right)( left| center| right)*"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="groupalign" type="xs:string"/>
+</xs:attributeGroup>
+
+<!-- "mtr" -->
+
+<xs:attributeGroup name="mtr.attlist">
+  <xs:attributeGroup ref="Table-alignment.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="mtr.content">
+  <xs:sequence>
+    <xs:element ref="mtd"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="mtr.type">
+  <xs:group ref="mtr.content"  minOccurs="1" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="mtr.attlist"/>
+</xs:complexType>
+
+<xs:element name="mtr" type="mtr.type"/>
+
+<!-- "labeledtr" -->
+
+<xs:attributeGroup name="mlabeledtr.attlist">
+  <xs:attributeGroup ref="Table-alignment.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="mlabeledtr.content">
+  <xs:sequence>
+    <xs:element ref="mtd"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="mlabeledtr.type">
+  <xs:group ref="mlabeledtr.content" minOccurs="1" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="mlabeledtr.attlist"/>
+</xs:complexType>
+
+<xs:element name="mlabeledtr" type="mlabeledtr.type"/>
+
+<!-- "mtd" -->
+
+<xs:attributeGroup name="mtd.attlist">
+  <xs:attributeGroup ref="Table-alignment.attrib"/>
+  <xs:attribute name="columnspan" type="xs:positiveInteger" default="1"/>
+  <xs:attribute name="rowspan" type="xs:positiveInteger" default="1"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="mtd.content">
+  <xs:sequence>
+    <xs:group ref="Presentation-expr.class" minOccurs="0" maxOccurs="1"/>
+  </xs:sequence>
+</xs:group>
+
+<xs:complexType name="mtd.type">
+  <xs:group ref="mtd.content"  minOccurs="1" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="mtd.attlist"/>
+</xs:complexType>
+
+<xs:element name="mtd" type="mtd.type"/>
+
+<!-- "mtable" -->
+
+<xs:attributeGroup name="mtable.attlist">
+  <xs:attributeGroup ref="Table-alignment.attrib"/>
+  <xs:attribute name="align" type="xs:string" default="axis"/>
+  <xs:attribute name="alignmentscope" default="true">
+   <xs:simpleType>
+      <xs:restriction base="xs:string">
+         <xs:pattern value="(true|false)( true| false)*"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="columnwidth" type="xs:string" default="auto"/>
+  <xs:attribute name="width" type="xs:string" default="auto"/>
+  <xs:attribute name="rowspacing" type="xs:string" default="1.0ex"/>
+  <xs:attribute name="columnspacing" type="xs:string" default="0.8em"/>
+  <xs:attribute name="rowlines" type="xs:string" default="none"/>
+  <xs:attribute name="columnlines" type="xs:string" default="none"/>
+  <xs:attribute name="frame" default="none">
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="none"/>
+         <xs:enumeration value="solid"/>
+         <xs:enumeration value="dashed"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="framespacing" type="xs:string" default="0.4em 0.5ex"/>
+  <xs:attribute name="equalrows" type="xs:boolean" default="false"/>
+  <xs:attribute name="equalcolumns" type="xs:boolean" default="false"/>
+  <xs:attribute name="displaystyle" type="xs:boolean" default="false"/>
+  <xs:attribute name="side" default="right">
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="left"/>
+         <xs:enumeration value="right"/>
+         <xs:enumeration value="leftoverlap"/>
+         <xs:enumeration value="rightoverlap"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="minlabelspacing" type="length-with-unit" default="0.8em"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:group name="mtable.content">
+  <xs:choice>
+    <xs:element ref="mtr"/>
+    <xs:element ref="mlabeledtr"/>
+  </xs:choice>
+</xs:group>
+
+<xs:complexType name="mtable.type">
+  <xs:group ref="mtable.content"  minOccurs="1" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="mtable.attlist"/>
+</xs:complexType>
+
+<xs:element name="mtable" type="mtable.type"/>
+
+<!-- "maligngroup" -->
+
+<xs:attributeGroup name="maligngroup.attlist">
+  <xs:attribute name="groupalign">
+     <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="left"/>
+          <xs:enumeration value="center"/>
+          <xs:enumeration value="right"/>
+          <xs:enumeration value="decimalpoint"/>
+      </xs:restriction>
+     </xs:simpleType>    
+  </xs:attribute>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="maligngroup.type">
+  <xs:attributeGroup ref="maligngroup.attlist"/>
+</xs:complexType>
+
+<xs:element name="maligngroup" type="maligngroup.type"/>
+
+<!-- "malignmark" -->
+
+<xs:attributeGroup name="malignmark.attlist">
+  <xs:attribute name="edge" default="left">
+     <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="left"/>
+          <xs:enumeration value="right"/>
+        </xs:restriction>
+     </xs:simpleType>
+  </xs:attribute>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="malignmark.type">
+  <xs:attributeGroup ref="malignmark.attlist"/>
+</xs:complexType>
+
+<xs:element name="malignmark" type="malignmark.type"/>
+
+<!-- The group of everything -->
+
+<xs:group name="Presentation-table.class">
+  <xs:choice>
+     <xs:element ref="mtable"/>
+     <xs:element ref="maligngroup"/>
+     <xs:element ref="malignmark"/>
+  </xs:choice>  
+</xs:group>
+
+</xs:schema>
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/tokens.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/mathml2/presentation/tokens.xsd
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/1998/Math/MathML"
+  targetNamespace="http://www.w3.org/1998/Math/MathML"
+  elementFormDefault="qualified"
+ >
+
+<xs:annotation>
+  <xs:documentation>
+  This is the XML schema module for the token elements of the 
+  presentation part of MathML.
+  Author: St&#233;phane Dalmas, INRIA.
+  </xs:documentation>
+</xs:annotation>
+
+<!-- The content of presentation token elements is either normal
+  characters, "mglyph" ones or alignment marks -->
+
+<xs:group name="Glyph-alignmark.class">
+    <xs:choice>
+      <xs:element ref="malignmark"/>
+      <xs:element ref="mglyph"/>
+    </xs:choice>
+</xs:group>
+
+<!-- "mi" -->
+
+<!-- "mi" is supposed to have a default value of its "mathvariant" attribute
+     set to "italic" -->
+<xs:attributeGroup name="mi.attlist">
+   <xs:attributeGroup ref="Token-style.attrib"/>
+   <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="mi.type" mixed="true">
+  <xs:group ref="Glyph-alignmark.class" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="mi.attlist"/> 
+</xs:complexType>
+
+<xs:element name="mi" type="mi.type"/>
+
+<!-- "mo" -->
+
+<xs:attributeGroup name="mo.attlist">
+   <xs:attributeGroup ref="Operator.attrib"/>
+   <xs:attributeGroup ref="Token-style.attrib"/>
+   <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="mo.type" mixed="true">
+  <xs:group ref="Glyph-alignmark.class" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="mo.attlist"/> 
+</xs:complexType>
+
+<xs:element name="mo" type="mo.type"/>
+
+<!-- "mn" -->
+
+<xs:attributeGroup name="mn.attlist">
+  <xs:attributeGroup ref="Token-style.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="mn.type" mixed="true">
+  <xs:group ref="Glyph-alignmark.class" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="mi.attlist"/> 
+</xs:complexType>
+
+<xs:element name="mn" type="mn.type"/>
+
+<!-- "mtext" -->
+
+<xs:attributeGroup name="mtext.attlist">
+  <xs:attributeGroup ref="Token-style.attrib"/>
+  <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="mtext.type" mixed="true">
+  <xs:group ref="Glyph-alignmark.class" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="mtext.attlist"/> 
+</xs:complexType>
+
+<xs:element name="mtext" type="mtext.type"/>
+
+<!-- "ms" -->
+
+<xs:attributeGroup name="ms.attlist">
+   <!-- the values of "lquote" or "rquote" are not restricted to be
+        one character strings... -->
+   <xs:attribute name="lquote" type="xs:string" default="&quot;"/>
+   <xs:attribute name="rquote" type="xs:string" default="&quot;"/>
+   <xs:attributeGroup ref="Token-style.attrib"/>
+   <xs:attributeGroup ref="Common.attrib"/>
+</xs:attributeGroup>
+
+<xs:complexType name="ms.type" mixed="true">
+  <xs:group ref="Glyph-alignmark.class" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="ms.attlist"/> 
+</xs:complexType>
+
+<xs:element name="ms" type="ms.type"/>
+
+<!-- And the group of any token -->
+
+<xs:group name="Presentation-token.class">
+  <xs:choice> 
+    <xs:element ref="mi"/>
+    <xs:element ref="mo"/>
+    <xs:element ref="mn"/>
+    <xs:element ref="mtext"/>
+    <xs:element ref="ms"/>
+  </xs:choice>
+</xs:group>
+
+</xs:schema>
+
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/module-ali.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/module-ali.xsd
@@ -1,0 +1,46 @@
+<?xml-stylesheet href="xsd.xsl" type="text/xsl"?>
+<xsd:schema xmlns:mtl="http://www.mulberrytech.com/taglib"
+            xmlns:c="http://www.w3.org/ns/xproc-step"
+            xmlns:ali="http://www.niso.org/schemas/ali/1.0/"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://www.niso.org/schemas/ali/1.0/"><!--* Allow references to unqualified names *-->
+   <xsd:import/>
+   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+   <!--* Some imports may need to be added manually *-->
+   <xsd:element name="free_to_read">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>Free to Read (Niso Ali)</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="end_date" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="start_date" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="license_ref">
+      <xsd:annotation>
+         <xsd:documentation>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+               <h3>License Reference (Niso Ali)</h3>
+            </div>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:complexType mixed="true">
+         <xsd:group ref="license-ref-model"/>
+         <xsd:attribute name="content-type" use="optional" type="xsd:string"/>
+         <xsd:attribute name="id" use="optional" type="xsd:ID"/>
+         <xsd:attribute name="specific-use" use="optional" type="xsd:string"/>
+         <xsd:attribute name="start_date" use="optional" type="xsd:string"/>
+         <xsd:attribute ref="xml:base" use="optional"/>
+      </xsd:complexType>
+   </xsd:element>
+   <xsd:annotation/>
+</xsd:schema>
+

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/xlink.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/xlink.xsd
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- METS XLink Schema, v. 2, Nov. 15, 2004 -->
+<!--* Downloaded 27 April 2012 from http://www.loc.gov/standards/mets/xlink.xsd 
+    * and modified as noted. *-->
+<!--* Some cosmetic changes to line breaks. *-->
+<!--* Add top-level declaration of xlink:type. *-->
+<schema targetNamespace="http://www.w3.org/1999/xlink" 
+	xmlns="http://www.w3.org/2001/XMLSchema" 
+	xmlns:xlink="http://www.w3.org/1999/xlink" 
+	elementFormDefault="qualified">
+
+  <!--  global attributes  --> 
+  <attribute name="href"  type="anyURI"/>
+  <attribute name="role" type="string"/>
+  <attribute name="arcrole" type="string"/>
+  <attribute name="title" type="string" /> 
+  <attribute name="show">
+    <simpleType>
+      <restriction base="string">
+	<enumeration value="new" /> 
+	<enumeration value="replace" /> 
+	<enumeration value="embed" /> 
+	<enumeration value="other" /> 
+	<enumeration value="none" /> 
+      </restriction>
+    </simpleType>
+  </attribute>
+  <attribute name="actuate">
+    <simpleType>
+      <restriction base="string">
+	<enumeration value="onLoad" /> 
+	<enumeration value="onRequest" /> 
+	<enumeration value="other" /> 
+	<enumeration value="none" /> 
+      </restriction>
+    </simpleType>
+  </attribute>
+  <attribute name="label" type="string" /> 
+  <attribute name="from" type="string" /> 
+  <attribute name="to" type="string" /> 
+
+  <attributeGroup name="simpleLink">
+    <attribute name="type" type="string" fixed="simple" form="qualified" /> 
+    <attribute ref="xlink:href" use="optional" /> 
+    <attribute ref="xlink:role" use="optional" /> 
+    <attribute ref="xlink:arcrole" use="optional" /> 
+    <attribute ref="xlink:title" use="optional" /> 
+    <attribute ref="xlink:show" use="optional" /> 
+    <attribute ref="xlink:actuate" use="optional" /> 
+  </attributeGroup>
+  <attributeGroup name="extendedLink">
+    <attribute name="type" type="string" fixed="extended" form="qualified" /> 
+    <attribute ref="xlink:role" use="optional" /> 
+    <attribute ref="xlink:title" use="optional" /> 
+  </attributeGroup>
+  <attributeGroup name="locatorLink">
+    <attribute name="type" type="string" fixed="locator" form="qualified" /> 
+    <attribute ref="xlink:href" use="required" /> 
+    <attribute ref="xlink:role" use="optional" /> 
+    <attribute ref="xlink:title" use="optional" /> 
+    <attribute ref="xlink:label" use="optional" /> 
+  </attributeGroup>
+  <attributeGroup name="arcLink">
+    <attribute name="type" type="string" fixed="arc" form="qualified" /> 
+    <attribute ref="xlink:arcrole" use="optional" /> 
+    <attribute ref="xlink:title" use="optional" /> 
+    <attribute ref="xlink:show" use="optional" /> 
+    <attribute ref="xlink:actuate" use="optional" /> 
+    <attribute ref="xlink:from" use="optional" /> 
+    <attribute ref="xlink:to" use="optional" /> 
+  </attributeGroup>
+  <attributeGroup name="resourceLink">
+    <attribute name="type" type="string" fixed="resource" form="qualified" /> 
+    <attribute ref="xlink:role" use="optional" /> 
+    <attribute ref="xlink:title" use="optional" /> 
+    <attribute ref="xlink:label" use="optional" /> 
+  </attributeGroup>
+  <attributeGroup name="titleLink">
+    <attribute name="type" type="string" fixed="title" form="qualified" /> 
+  </attributeGroup>
+  <attributeGroup name="emptyLink">
+    <attribute name="type" type="string" fixed="none" form="qualified" /> 
+  </attributeGroup>
+
+  <!--* Addition for IEEE union schema *-->
+  <attribute name="type">
+    <simpleType>
+      <restriction base="string">
+	<enumeration value="simple"/>
+	<enumeration value="extended"/>
+	<enumeration value="locator"/>
+	<enumeration value="arc"/>
+	<enumeration value="resource"/>
+	<enumeration value="title"/>
+	<enumeration value="none"/>
+      </restriction>
+    </simpleType>
+  </attribute>	     
+	     
+</schema>

--- a/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/xml.xsd
+++ b/src/main/resources/dtd/archiving/1.2/xsd/JATS-Archiving-1-2-MathML2-XSD/standard-modules/xml.xsd
@@ -1,0 +1,287 @@
+<?xml version='1.0'?>
+<?xml-stylesheet href="../2008/09/xsd.xsl" type="text/xsl"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns   ="http://www.w3.org/1999/xhtml"
+  xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+    <h1>About the XML namespace</h1>
+
+    <div class="bodytext">
+     <p>
+      This schema document describes the XML namespace, in a form
+      suitable for import by other schema documents.
+     </p>
+     <p>
+      See <a href="http://www.w3.org/XML/1998/namespace.html">
+      http://www.w3.org/XML/1998/namespace.html</a> and
+      <a href="http://www.w3.org/TR/REC-xml">
+      http://www.w3.org/TR/REC-xml</a> for information 
+      about this namespace.
+     </p>
+     <p>
+      Note that local names in this namespace are intended to be
+      defined only by the World Wide Web Consortium or its subgroups.
+      The names currently defined in this namespace are listed below.
+      They should not be used with conflicting semantics by any Working
+      Group, specification, or document instance.
+     </p>
+     <p>   
+      See further below in this document for more information about <a
+      href="#usage">how to refer to this schema document from your own
+      XSD schema documents</a> and about <a href="#nsversioning">the
+      namespace-versioning policy governing this schema document</a>.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>lang (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       is a language code for the natural language of the content of
+       any element; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML specification.</p>
+     
+    </div>
+    <div>
+     <h4>Notes</h4>
+     <p>
+      Attempting to install the relevant ISO 2- and 3-letter
+      codes as the enumerated possible values is probably never
+      going to be a realistic possibility.  
+     </p>
+     <p>
+      See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+       http://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
+      and the IANA language subtag registry at
+      <a href="http://www.iana.org/assignments/language-subtag-registry">
+       http://www.iana.org/assignments/language-subtag-registry</a>
+      for further information.
+     </p>
+     <p>
+      The union allows for the 'un-declaration' of xml:lang with
+      the empty string.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>space (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose
+       value is a keyword indicating what whitespace processing
+       discipline is intended for the content of the element; its
+       value is inherited.  This name is reserved by virtue of its
+       definition in the XML specification.</p>
+     
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+ 
+ <xs:attribute name="base" type="xs:anyURI"> <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>base (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       provides a URI to be used as the base for interpreting any
+       relative URIs in the scope of the element on which it
+       appears; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML Base specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>id (as an attribute name)</h3> 
+      <p>
+       denotes an attribute whose value
+       should be interpreted as if declared to be of type ID.
+       This name is reserved by virtue of its definition in the
+       xml:id specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
+ </xs:attributeGroup>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+   
+    <h3>Father (in any context at all)</h3> 
+
+    <div class="bodytext">
+     <p>
+      denotes Jon Bosak, the chair of 
+      the original XML Working Group.  This name is reserved by 
+      the following decision of the W3C XML Plenary and 
+      XML Coordination groups:
+     </p>
+     <blockquote>
+       <p>
+	In appreciation for his vision, leadership and
+	dedication the W3C XML Plenary on this 10th day of
+	February, 2000, reserves for Jon Bosak in perpetuity
+	the XML name "xml:Father".
+       </p>
+     </blockquote>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div xml:id="usage" id="usage">
+    <h2><a name="usage">About this schema document</a></h2>
+
+    <div class="bodytext">
+     <p>
+      This schema defines attributes and an attribute group suitable
+      for use by schemas wishing to allow <code>xml:base</code>,
+      <code>xml:lang</code>, <code>xml:space</code> or
+      <code>xml:id</code> attributes on elements they define.
+     </p>
+     <p>
+      To enable this, such a schema must import this schema for
+      the XML namespace, e.g. as follows:
+     </p>
+     <pre>
+          &lt;schema . . .>
+           . . .
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+     </pre>
+     <p>
+      or
+     </p>
+     <pre>
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+     </pre>
+     <p>
+      Subsequently, qualified reference to any of the attributes or the
+      group defined below will have the desired effect, e.g.
+     </p>
+     <pre>
+          &lt;type . . .>
+           . . .
+           &lt;attributeGroup ref="xml:specialAttrs"/>
+     </pre>
+     <p>
+      will define a type which will schema-validate an instance element
+      with any of those attributes.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div id="nsversioning" xml:id="nsversioning">
+    <h2><a name="nsversioning">Versioning policy for this schema document</a></h2>
+    <div class="bodytext">
+     <p>
+      In keeping with the XML Schema WG's standard versioning
+      policy, this schema document will persist at
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd</a>.
+     </p>
+     <p>
+      At the date of issue it can also be found at
+      <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd</a>.
+     </p>
+     <p>
+      The schema document at that URI may however change in the future,
+      in order to remain compatible with the latest version of XML
+      Schema itself, or with the XML namespace itself.  In other words,
+      if the XML Schema or XML namespaces change, the version of this
+      document at <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd 
+      </a> 
+      will change accordingly; the version at 
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd 
+      </a> 
+      will not change.
+     </p>
+     <p>
+      Previous dated (and unchanging) versions of this schema 
+      document are at:
+     </p>
+     <ul>
+      <li><a href="http://www.w3.org/2009/01/xml.xsd">
+	http://www.w3.org/2009/01/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2007/08/xml.xsd">
+	http://www.w3.org/2007/08/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2004/10/xml.xsd">
+	http://www.w3.org/2004/10/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2001/03/xml.xsd">
+	http://www.w3.org/2001/03/xml.xsd</a></li>
+     </ul>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+</xs:schema>
+


### PR DESCRIPTION
Legger til tag settet på samme måte for "Journal Archiving and Interchange Tag Set" som vi har gjort for "Journal Article Tag Suite Journal Publishing" etter vi har fått feil i forsøk på å parse jats filer i nytt format.

Hvis det blir hyppige endringer av hvilke versjoner som brukes etc. i XML filene kan det være hensiktsmessig med en annen løsning. Men det er i alle fall ikke blitt gjort noe i dette repoet på 3 år og ting har fungert, så det er lov å håpe.